### PR TITLE
GOVSI-717: Move KMS generation to Account Management Terraform

### DIFF
--- a/ci/tasks/generate-account-management-deployment-variables.yml
+++ b/ci/tasks/generate-account-management-deployment-variables.yml
@@ -54,10 +54,5 @@ run:
       session_expiry: ${SESSION_EXPIRY}
       session_secret: ${SESSION_SECRET}
       route_name: ${AM_URL}
-      AWS_ACCESS_KEY_ID: $(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.AWS_ACCESS_KEY_ID')
-      AWS_SECRET_ACCESS_KEY: $(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.AWS_SECRET_ACCESS_KEY')
-      KMS_KEY_ID: ${KEY_ID}
-      AWS_REGION: $(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.AWS_REGION')
-      client_id: $(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.client_id')
-      client_name: $(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.client_name')
+      environment_name: ${ENVIRONMENT_NAME}
       EOF

--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -1,0 +1,59 @@
+resource "random_string" "account_management_client_id" {
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length = 32
+}
+
+data "aws_kms_public_key" "account_management_jwt_key" {
+  depends_on = [aws_kms_key.account_management_jwt_key]
+  key_id = aws_kms_key.account_management_jwt_key.arn
+}
+
+data "aws_dynamodb_table" "client_registry_table" {
+  name = "${var.environment}-client-registry"
+}
+
+resource "aws_dynamodb_table_item" "account_management_client" {
+  table_name = data.aws_dynamodb_table.client_registry_table.name
+  hash_key   = data.aws_dynamodb_table.client_registry_table.hash_key
+
+  item     = jsonencode({
+    ClientID = {
+      S = random_string.account_management_client_id.result
+    }
+    ClientName = {
+      S = "${var.environment}-account-management"
+    }
+    Contacts = {
+      L = []
+    }
+    PostLogoutRedirectUrls = {
+      L = []
+    }
+    RedirectUrls = {
+      L = [
+        {
+          S = "https://account-management.${var.cf_domain}/auth/callback"
+        }
+      ]
+    }
+    Scopes = {
+      L = [
+        {
+          S = "openid"
+        },
+        {
+          S = "phone"
+        },
+        {
+          S = "email"
+        },
+      ]
+    }
+    PublicKey = {
+      S = "paste me manually until Terraform provider bug is fixed"
+    }
+  })
+}

--- a/ci/terraform/account-management-kms.tf
+++ b/ci/terraform/account-management-kms.tf
@@ -1,0 +1,69 @@
+resource "aws_kms_key" "account_management_jwt_key" {
+  description              = "KMS key for Account Management JWT Authentication (${var.environment})"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "RSA_2048"
+}
+
+resource "aws_kms_alias" "account_management_jwt_alias" {
+  name          = "alias/${var.environment}-account-management-jwt-key"
+  target_key_id = aws_kms_key.account_management_jwt_key.key_id
+}
+
+data "aws_iam_policy_document" "account_management_jwt_kms_policy_document" {
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      aws_kms_key.account_management_jwt_key.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "account_management_jwt_lambda_kms_policy" {
+  name        = "${var.environment}-account-management-jwt-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS connection for account management application"
+
+  policy = data.aws_iam_policy_document.account_management_jwt_kms_policy_document.json
+}
+
+resource "aws_iam_user" "account_management_app" {
+  name = "${var.environment}-account-management-application"
+}
+
+resource "aws_iam_access_key" "account_management_app_access_keys" {
+  user = aws_iam_user.account_management_app.name
+}
+
+data "aws_iam_policy_document" "account_management_app_role_assume_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [
+        aws_iam_user.account_management_app.arn
+      ]
+      type = "AWS"
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+resource "aws_iam_role" "account_management_app_role" {
+  assume_role_policy = data.aws_iam_policy_document.account_management_app_role_assume_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "account_management_app_kms" {
+  role       = aws_iam_role.account_management_app_role.name
+  policy_arn = aws_iam_policy.account_management_jwt_lambda_kms_policy.arn
+}

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,3 +1,3 @@
 redis_service_plan = "tiny-ha-5.x"
-cf_space_name      = "build"
+environment      = "build"
 cf_domain          = "build.auth.ida.digital.cabinet-office.gov.uk"

--- a/ci/terraform/cf-data.tf
+++ b/ci/terraform/cf-data.tf
@@ -3,7 +3,7 @@ data "cloudfoundry_org" "org" {
 }
 
 data "cloudfoundry_space" "space" {
-  name = var.cf_space_name
+  name = var.environment
   org  = data.cloudfoundry_org.org.id
 }
 

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,3 +1,3 @@
 redis_service_plan = "tiny-ha-5.x"
-cf_space_name      = "integration"
+environment      = "integration"
 cf_domain          = "integration.auth.ida.digital.cabinet-office.gov.uk"

--- a/ci/terraform/outputs.tf
+++ b/ci/terraform/outputs.tf
@@ -1,0 +1,8 @@
+output "account_management_client_details" {
+  value = {
+    client_id             = random_string.account_management_client_id.result
+    client_name           = "${var.environment}-account-managment"
+    KMS_KEY_ID            = aws_kms_key.account_management_jwt_key.id
+  }
+  sensitive = true
+}

--- a/ci/terraform/redis.tf
+++ b/ci/terraform/redis.tf
@@ -3,7 +3,7 @@ data "cloudfoundry_service" "redis" {
 }
 
 resource "cloudfoundry_service_instance" "redis" {
-  name         = "${var.cf_space_name}-redis"
+  name         = "${var.environment}-redis"
   space        = data.cloudfoundry_space.space.id
   service_plan = data.cloudfoundry_service.redis.service_plans["tiny-5_x"]
 }

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,3 +1,3 @@
 cf_org_name = "gds-digital-identity-authentication"
 cf_domain = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
-cf_space_name = "sandpit"
+environment = "sandpit"

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -26,6 +26,13 @@ provider "aws" {
   assume_role {
     role_arn = var.deployer_role_arn
   }
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Application = "account-management"
+    }
+  }
 }
 
 provider "cloudfoundry" {

--- a/ci/terraform/user-provided-services.tf
+++ b/ci/terraform/user-provided-services.tf
@@ -1,0 +1,23 @@
+resource "cloudfoundry_user_provided_service" "kms" {
+  name  = "${var.environment}-account-management-kms-provider"
+  space = data.cloudfoundry_space.space.id
+
+  credentials = {
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.account_management_app_access_keys.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.account_management_app_access_keys.id
+    AWS_REGION            = var.aws_region
+    KMS_KEY_ID            = aws_kms_key.account_management_jwt_key.id
+    KMS_KEY_ALIAS         = aws_kms_alias.account_management_jwt_alias.name
+  }
+}
+
+resource "cloudfoundry_user_provided_service" "idp" {
+  name  = "${var.environment}-account-management-idp-provider"
+  space = data.cloudfoundry_space.space.id
+
+  credentials = {
+    client_id   = random_string.account_management_client_id.result
+    client_name = "${var.environment}-account-managment"
+    idp_url     = "https://api.${var.cf_domain}"
+  }
+}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -18,8 +18,8 @@ variable "cf_org_name" {
   description = "target org"
 }
 
-variable "cf_space_name" {
-  description = "target space"
+variable "environment" {
+  description = "the name of the environment being deployed (e.g. sandpit, build), this also matches the PaaS space name"
 }
 
 variable "cf_domain" {

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,3 +13,6 @@ applications:
       SESSION_SECRET: ((session_secret))      
     routes:
       - route: ((route_name))
+    services:
+      - ((environment_name))-account-management-kms-provider
+      - ((environment_name))-account-management-idp-provider


### PR DESCRIPTION
## What?

- Move the generation of KMS keys from API Terraform to Account Management Terraform
- Move registering of the account management client ID
- Rename the `cf_space_name` variable to `environment` as equally applicable to AWS as PaaS
- Create user-provided-service in PaaS to hold the creds and bind the app to those services in the manifest

## Why?

Performing these steps in a separate Terraform stack and passing the outputs around is a tad cumbersome and insecure. Creating these resources from account management Terraform and publishing them to the app via a user provided service keeps things isolated.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/324