### PR TITLE
BAU: Provision account managment client with `ServiceType`

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -55,5 +55,8 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     PublicKey = {
       S = "paste me manually until Terraform provider bug is fixed"
     }
+    ServiceType = {
+      S = "MANDATORY"
+    }
   })
 }


### PR DESCRIPTION
## What?

- Set account management `ServiceType` to `MANDATORY`

## Why?

Clients now need this field set to ensure correct journey type
