### PR TITLE
BAU: Grant policy directly user

### DIFF
--- a/ci/terraform/account-management-kms.tf
+++ b/ci/terraform/account-management-kms.tf
@@ -37,6 +37,11 @@ resource "aws_iam_user" "account_management_app" {
   name = "${var.environment}-account-management-application"
 }
 
+resource "aws_iam_user_policy_attachment" "account_management_app_kms_policy" {
+  policy_arn = aws_iam_policy.account_management_jwt_lambda_kms_policy.arn
+  user       = aws_iam_user.account_management_app.arn
+}
+
 resource "aws_iam_access_key" "account_management_app_access_keys" {
   user = aws_iam_user.account_management_app.name
 }


### PR DESCRIPTION
## What?

- To avoid having to use STS to get temporary tokens to access STS, lets give the user direct permissions for the timebeing.

## Why?

The KMS client does not provide a convenient way to assume a role when calling the API. Lets give the user direct permissions for the meantime.