### PR TITLE
BAU: add build context to docker-compose file to allow app to start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@ services:
       - 6379:6379
 
   di-auth-account-management-frontend:
-    build:
-      dockerfile: Dockerfile
+    build: .
     ports:
     - 6001:6001
     volumes:


### PR DESCRIPTION
## What?

Add build context to docker-compose file to allow app to start.

## Why?

Resolves error where app would not start due to not having a build context.
