### PR TITLE
GOVSI-185: integrate enter-password with authenticate API

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -10,7 +10,7 @@ export const PATH_NAMES = {
 };
 
 export const API_ENDPOINTS = {
-  CHECK_USER_PASSWORD: "/check-user-password",
+  AUTHENTICATE: "/authenticate",
   UPDATE_EMAIL: "/update-email",
 };
 

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -20,16 +20,14 @@ export function enterPasswordPost(
   service: EnterPasswordServiceInterface = enterPasswordService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const email = "";
-    const id = "";
-    const userPassword = await service.checkUserPassword(
-      id,
+    const email = req.session.user.email;
+    const accessToken = req.session.user.accessToken;
+    const authenticated = await service.authenticated(
+      accessToken,
       email,
       req.body["password"]
     );
-
-    if (userPassword.isValidPassword) {
-      // TODO: this page does not exist
+    if (authenticated) {
       return res.redirect(PATH_NAMES.ENTER_NEW_EMAIL);
     }
     renderValidationError(

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -1,29 +1,34 @@
 import { getBaseRequestConfig, Http, http } from "../../utils/http";
-import { EnterPasswordServiceInterface, UserPassword } from "./types";
-import { API_ENDPOINTS } from "../../app.constants";
+import { EnterPasswordServiceInterface } from "./types";
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 
 export function enterPasswordService(
   axios: Http = http
 ): EnterPasswordServiceInterface {
-  const checkUserPassword = async function (
+  const authenticated = async function (
     token: string,
     emailAddress: string,
     password: string
-  ): Promise<UserPassword> {
+  ): Promise<boolean> {
     const config = getBaseRequestConfig(token);
-
-    // TODO: this API does not exist
-    const { data } = await axios.client.post<UserPassword>(
-      API_ENDPOINTS.CHECK_USER_PASSWORD,
+    config.validateStatus = function (status: any) {
+      return (
+        status === HTTP_STATUS_CODES.OK ||
+        status === HTTP_STATUS_CODES.FORBIDDEN ||
+        status === HTTP_STATUS_CODES.UNAUTHORIZED
+      );
+    };
+    const { status } = await axios.client.post<void>(
+      API_ENDPOINTS.AUTHENTICATE,
       {
         email: emailAddress,
         password: password,
       },
       config
     );
-    return data;
+    return status === HTTP_STATUS_CODES.OK;
   };
   return {
-    checkUserPassword,
+    authenticated,
   };
 }

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -1,12 +1,7 @@
-export interface UserPassword {
-  isValidPassword: boolean;
-  sessionState: string;
-}
-
 export interface EnterPasswordServiceInterface {
-  checkUserPassword: (
+  authenticated: (
     token: string,
     email: string,
     password: string
-  ) => Promise<UserPassword>;
+  ) => Promise<boolean>;
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -12,7 +12,7 @@ const headers: Readonly<Record<string, string | boolean>> = {
 export function getBaseRequestConfig(token: string): AxiosRequestConfig {
   return {
     headers: {
-      Token: token,
+      'Authorization': 'Bearer ' + token
     },
     proxy: false,
   };


### PR DESCRIPTION
## What?

Integrate enter-password with authenticate API

## Why?

Page needs to call the backend service to check the password.
Currently tested against the service with the authorizer switched off.

## Related PRs

#48 