### PR TITLE
GOVSI-630: add email updated confirmation page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -31,6 +31,7 @@ import { getSessionCookieOptions, getSessionStore } from "./config/session";
 import { getOIDCConfig } from "./config/oidc";
 import { enterPasswordRouter } from "./components/enter-password/enter-password-routes";
 import { enterNewEmailRouter } from "./components/enter-new-email/enter-new-email-routes";
+import { updateConfirmationRouter } from "./components/update-confirmation/update-confirmation-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -44,6 +45,7 @@ function registerRoutes(app: express.Application) {
   app.use(logoutRouter);
   app.use(enterPasswordRouter);
   app.use(enterNewEmailRouter);
+  app.use(updateConfirmationRouter);
 }
 
 function createApp(): express.Application {

--- a/src/components/update-confirmation/index.njk
+++ b/src/components/update-confirmation/index.njk
@@ -1,0 +1,18 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% set pageTitleName = pageTitle %}
+{% block content %}
+
+{{ govukPanel({
+    titleText: panelText
+}) }}
+
+<p class="govuk-body">{{summaryText}}</p>
+
+{{ govukButton({
+    "text": button_text|default('general.backToAccountButtonText' | translate, true),
+    "href": "/manage-your-account"
+}) }}
+
+{% endblock %}

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from "express";
+
+export function updateConfirmationEmailGet(req: Request, res: Response): void {
+  res.render("update-confirmation/index.njk", 
+  { pageTitle: req.t('pages.updateEmailConfirmation.title'),
+    panelText: req.t('pages.updateEmailConfirmation.panelText'),
+    summaryText: req.t('pages.updateEmailConfirmation.summaryText') + req.session.user.email
+  });
+}

--- a/src/components/update-confirmation/update-confirmation-routes.ts
+++ b/src/components/update-confirmation/update-confirmation-routes.ts
@@ -1,0 +1,13 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import * as express from "express";
+import { updateConfirmationEmailGet } from "./update-confirmation-controller";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.EMAIL_UPDATED_CONFIRMATION,
+  updateConfirmationEmailGet
+);
+
+export { router as updateConfirmationRouter };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,6 +14,7 @@
     },
     "yes": "Yes",
     "no": "No",
+    "backToAccountButtonText": "Back to your account",
     "cookie": {
       "cookieBanner": {
         "title": "Cookies on GOV.UK Account",
@@ -152,6 +153,11 @@
       "dontWantTo": {
         "changeEmailLinkText": "I don't want to change my email address"
       }
+    },
+    "updateEmailConfirmation": {
+      "title": "You have changed your email address",
+      "panelText": "You have changed your email address",
+      "summaryText": "Your email address has been changed to: "
     }
   }
 }


### PR DESCRIPTION
## What?

Add email updated confirmation page.

## Why?

Need a confirmation page once the user has updated their email.
