### PR TITLE
BAU: Remove workaround code now Terraform provider is fixed

### DIFF
--- a/ci/tasks/generate-account-management-deployment-variables.yml
+++ b/ci/tasks/generate-account-management-deployment-variables.yml
@@ -8,43 +8,18 @@ image_resource:
     password: ((docker-hub-password))
 inputs:
   - name: domain-terraform-outputs
-  - name: environment-terraform-outputs
 outputs:
   - name: di-account-management-deploy-variables
 params:
   SESSION_EXPIRY: ((build-session-expiry))
   SESSION_SECRET: ((build-session-secret))
   ENVIRONMENT_NAME: build
-  DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
 run:
   path: /bin/sh
   args:
     - -c
     - |
       set -eu
-      export AWS_REGION=eu-west-2
-      STS_TOKEN=$(aws sts assume-role --role-arn="${DEPLOYER_ROLE_ARN}" --role-session-name="concourse-get-keys")
-
-      export AWS_ACCESS_KEY_ID="$(echo ${STS_TOKEN} | jq -r .Credentials.AccessKeyId)"
-      export AWS_SECRET_ACCESS_KEY="$(echo ${STS_TOKEN} | jq -r .Credentials.SecretAccessKey)"
-      export AWS_SESSION_TOKEN="$(echo ${STS_TOKEN} | jq -r .Credentials.SessionToken)"
-
-      KEY_ID=$(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.KMS_KEY_ID')
-
-      echo "Getting public key for KMS key ${KEY_ID}"
-      PUBLIC_KEY=$(aws kms get-public-key --key-id "${KEY_ID}" --region eu-west-2 | jq -r .PublicKey)
-
-      echo "Public Key:"
-      echo "${PUBLIC_KEY}"
-
-      CLIENT_ID=$(cat environment-terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json | jq -r '.account_management_client_details.value.client_id')
-      echo "Updating Client Registry for client = ${CLIENT_ID}"
-
-      aws dynamodb update-item --table-name "${ENVIRONMENT_NAME}-client-registry" --key "$(jq -nc '{ ClientID: { S: $client_id }}' --arg client_id "${CLIENT_ID}")" \
-        --update-expression "SET PublicKey = :pk" \
-        --expression-attribute-values "$(jq -nc '{ ":pk": { S: $public_key }}' --arg public_key "${PUBLIC_KEY}")"\
-        --return-values NONE  --region eu-west-2
-
       echo "Generating vars file..."
       API_URL="https://$(jq -r .${ENVIRONMENT_NAME}_api_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"
       AM_URL="$(jq -r .${ENVIRONMENT_NAME}_account_management_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"

--- a/ci/terraform/.terraform.lock.hcl
+++ b/ci/terraform/.terraform.lock.hcl
@@ -25,21 +25,21 @@ provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.54.0"
-  constraints = ">= 3.54.0"
+  version     = "3.57.0"
+  constraints = ">= 3.56.0"
   hashes = [
-    "h1:0iQztV76msVUPkkqncoH/FvO26tNVRV7uVuY1ERNWbY=",
-    "zh:06c2dfbbf8ca2bea50444c26c5159763fe9cbe92553c13a208b4df1035368f35",
-    "zh:2ea54ab59a3a4cf455a1f1589778ca0721ed5d6ad681d64cfa7f2036dcc6df61",
-    "zh:30719cb435dac60fa69564e2ce221d589be3a974daed966f88fae88782db3a67",
-    "zh:8b13e240955bd9181dd5d0081bbc7c03200b4493e2e9f52a783c5e1582e16311",
-    "zh:99b344ab400300309e27dea4195671d1b021dee44758d0a97236f171b8395cbf",
-    "zh:bc0d72a343b161c3b47ce78760b9deae0d9339e279c3be35a2e9f148c09c4688",
-    "zh:d905eaa3c074131d8e7e5207a3c9ddab73c32a792dcd97a1c9d52a2a9753c1b7",
-    "zh:dddc2752b9d6846eaef3b2e2486f8789df91d16794e7aae03c9d5d6cb1bc10eb",
-    "zh:ed1bee76d38117594f336bd2656135c7f85b4a1af3ff65d2a3e59a8107b9219a",
-    "zh:f1f1a0bebd03e479b072dde9831f573070f6deada2972f5b966dd4858b99a8c2",
-    "zh:f91a6dfbc46d523d5f90ae84ac6ee6bf0aa2b1ced9a55f6142669849d3608998",
+    "h1:H6JCnoa3swF3rgHL0ys9KNArffU+IEGPvhQ6JnfQY/c=",
+    "zh:241a4203078ea35f63202b613f0e4b428a842734ded62d9f487cdf7c2a66d639",
+    "zh:2c1cbf3cd03a2a7ff267be09cedf1698738c372b1411ca74cfcb3bf4b0846f27",
+    "zh:318ad2331f60e03d284f90f728486b9df7ac9570af641c43b56216357e624b52",
+    "zh:43ff96b34b4829a34693281492786b9ca6dd06870dd45b0ae82ea352c33353d7",
+    "zh:6c36b874622603793fc637272742d84ecbf68dfe4c8d8148bb6e9b733cd0e216",
+    "zh:7a1aaac01c82d06f9ebc997ae2094a7d96e7a467aaaeaa1cda64ee952f3144d8",
+    "zh:9b917b03b8771f87a021fe7aa9fd00ae06cc455a1eaa1fb748930182617b2772",
+    "zh:bd90550e6d9311092170f4935e42e91e6d8bed5241e41eca39fa4aeca28d9c6f",
+    "zh:be5076ea705c174581fd616b118e0c17d15bd8ab0da1b3eee4f3fb6b11e78f2c",
+    "zh:f4f0d13414c932ecf65ba92daab6e755c244dcb77b4be59a3ac18ba2f56cdc00",
+    "zh:fa3575a23fd20ce00658977374491022c4c0c36a00260ebeebb0c3f3af4824aa",
   ]
 }
 

--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -55,7 +55,7 @@ resource "aws_dynamodb_table_item" "account_management_client" {
       ]
     }
     PublicKey = {
-      S = "paste me manually until Terraform provider bug is fixed"
+      S = data.aws_kms_public_key.account_management_jwt_key.public_key
     }
     ServiceType = {
       S = "MANDATORY"

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">= 3.54.0"
+      version = ">= 3.56.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## What?

- Use the `aws_kms_public_key` provider now, as originally planned, and remove the workaround that was added to the pipeline.

## Why?

The Terraform AWS provider bug (https://github.com/hashicorp/terraform-provider-aws/issues/20595) has been fixed and release as of 3.56.0
