### PR TITLE
GOVSI-747: add configurable 'your account' url to account management

### DIFF
--- a/ci/tasks/generate-account-management-deployment-variables.yml
+++ b/ci/tasks/generate-account-management-deployment-variables.yml
@@ -8,6 +8,7 @@ image_resource:
     password: ((docker-hub-password))
 inputs:
   - name: domain-terraform-outputs
+  - name: terraform-outputs
 outputs:
   - name: di-account-management-deploy-variables
 params:
@@ -24,6 +25,7 @@ run:
       API_URL="https://$(jq -r .${ENVIRONMENT_NAME}_api_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"
       AM_URL="$(jq -r .${ENVIRONMENT_NAME}_account_management_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"
       AM_API_URL="https://$(jq -r .${ENVIRONMENT_NAME}_account_management_api_url.value < domain-terraform-outputs/domain-terraform-outputs.json)"
+      AM_YOUR_ACCOUNT_URL="$(jq -r .account_management_your_account_url.value < terraform-outputs/${ENVIRONMENT_NAME}-terraform-outputs.json)"
 
       cat <<EOF > di-account-management-deploy-variables/vars.yml
       api_base_url: ${API_URL}
@@ -32,4 +34,5 @@ run:
       session_secret: ${SESSION_SECRET}
       route_name: ${AM_URL}
       environment_name: ${ENVIRONMENT_NAME}
+      am_your_account_url: ${AM_YOUR_ACCOUNT_URL}
       EOF

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,3 +1,4 @@
 redis_service_plan = "tiny-ha-5.x"
 environment      = "build"
 cf_domain          = "build.auth.ida.digital.cabinet-office.gov.uk"
+your_account_url  = ""

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,3 +1,4 @@
 redis_service_plan = "tiny-ha-5.x"
 environment      = "integration"
 cf_domain          = "integration.auth.ida.digital.cabinet-office.gov.uk"
+your_account_url  = "https://www.integration.publishing.service.gov.uk/account/home"

--- a/ci/terraform/outputs.tf
+++ b/ci/terraform/outputs.tf
@@ -6,3 +6,7 @@ output "account_management_client_details" {
   }
   sensitive = true
 }
+
+output "account_management_your_account_url" {
+  value = "${var.your_account_url}"
+}

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,0 +1,4 @@
+redis_service_plan = ""
+environment      = "production"
+cf_domain          = ""
+your_account_url  = "https://www.gov.uk/account/home"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,3 +1,4 @@
 cf_org_name = "gds-digital-identity-authentication"
 cf_domain = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
 environment = "sandpit"
+your_account_url  = "https://www.gov.uk/account/home"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -31,3 +31,7 @@ variable "redis_service_plan" {
   description = "The PaaS service plan (instance size) to use for Redis. For a full list of options, run 'cf marketplace -e redis'"
 }
 
+variable "your_account_url" {
+  type = string
+  description = "the url to the GOV.UK Account - Your Account homepage"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - SESSION_EXPIRY=1800000
       - SESSION_SECRET=secret
       - OIDC_CLIENT_ID=
+      - AM_YOUR_ACCOUNT_URL=
       - AM_API_BASE_URL=
       - OIDC_CLIENT_SCOPES=
     restart: on-failure

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,8 @@ applications:
       API_BASE_URL: ((api_base_url))
       AM_API_BASE_URL: ((am_api_base_url))
       SESSION_EXPIRY: ((session_expiry))
-      SESSION_SECRET: ((session_secret))      
+      SESSION_SECRET: ((session_secret))
+      AM_YOUR_ACCOUNT_URL: ((am_your_account_url))
     routes:
       - route: ((route_name))
     services:

--- a/src/components/common/layout/base-menu.njk
+++ b/src/components/common/layout/base-menu.njk
@@ -6,14 +6,14 @@
             <nav aria-label="Account management">
                 <ul class="accounts-menu">
                     <li class="accounts-menu__item ">
-                        <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="https://www.integration.publishing.service.gov.uk/sign-in">
-                            Your account
+                        <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="{{yourAccountUrl}}">
+                            {{ 'pages.manageYourAccount.menuItemList.yourAccount' | translate }}
                         </a>
                     </li>
                     {% block menuItem %}{% endblock %}
                     <li class="accounts-menu__item ">
                         <a class="accounts-menu__link govuk-link govuk-link--no-visited-state" href="/#">
-                            Security and privacy
+                            {{ 'pages.manageYourAccount.menuItemList.securityAndPrivacy' | translate }}
                         </a>
                     </li>
                 </ul>
@@ -24,3 +24,4 @@
         </div>
     </div>
 {% endblock %}
+

--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -15,7 +15,7 @@
 
 {% block mainContent %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.manageYourAccount.header' | translate }}</h1>
-    <h2 class="govuk-heading-m">Account details</h2>
+    <h2 class="govuk-heading-m">{{ 'pages.manageYourAccount.accountDetails' | translate }}</h2>
     {{ govukSummaryList({
         classes:"accounts-summary-list",
         rows: [

--- a/src/components/manage-your-account/manage-your-account-controller.ts
+++ b/src/components/manage-your-account/manage-your-account-controller.ts
@@ -1,10 +1,12 @@
 import { Request, Response } from "express";
+import { getYourAccountUrl } from "../../config";
 import { redactPhoneNumber } from "../../utils/strings";
 
 export function manageYourAccountGet(req: Request, res: Response): void {
   const data = {
     email: req.session.user.email,
     phoneNumber: redactPhoneNumber(req.session.user.phoneNumber),
+    yourAccountUrl: getYourAccountUrl(),
   };
 
   res.render("manage-your-account/index.njk", data);

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,3 +33,7 @@ export function getSessionExpiry(): number {
 export function getSessionSecret(): string {
   return process.env.SESSION_SECRET;
 }
+
+export function getYourAccountUrl(): string {
+  return process.env.AM_YOUR_ACCOUNT_URL;
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -105,6 +105,7 @@
     "manageYourAccount": {
       "title": "Sign in to or create your GOV.UK Account",
       "header": "Manage your account",
+      "accountDetails": "Account details",
       "menuItemList": {
         "manageYourAccount": "Manage your account",
         "securityAndPrivacy": "Security and privacy",


### PR DESCRIPTION

## What?

Add configurable 'your account' url to account management.

Configurable per environment.
Applied from a terraform variable in the pipeline.

## Why?

As the url varies per environment it need to be configured via an environment variable.

