### PR TITLE
BAU: add am scope

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -3,6 +3,7 @@ locals {
     "openid",
     "phone",
     "email",
+    "am"
   ]
 }
 


### PR DESCRIPTION
## What?

Add 'am' scope to account management.

Adds the scope to the am client in the client registry.
Passes the scopes to be used to the client.

Means that only this test client can be used to access account management.

## Why?

Ability to restrict account management usage to specific clients that can only be configured through the database.

## Related

https://github.com/alphagov/di-authentication-api/pull/479


