### PR TITLE
Add cookie consent support to UI

### DIFF
--- a/ci/terraform/account-management-client.tf
+++ b/ci/terraform/account-management-client.tf
@@ -72,6 +72,9 @@ resource "aws_dynamodb_table_item" "account_management_client" {
     }
     IsInternalService = {
       N = "1"
+    },
+    CookieConsentShared = {
+      N = "1"
     }
   })
 }

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -3,6 +3,8 @@
   function appInit(trackingId) {
     var cookies = window.GOVSignIn.Cookies(trackingId);
 
+    cookies.processCookieConsentFlag();
+
     if (cookies.hasConsentForAnalytics()) {
       cookies.initAnalytics();
     }

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -46,6 +46,26 @@ var cookies = function (trackingId) {
     }
   }
 
+  function getQueryParameterByName(name) {
+    var match = RegExp("[?&]" + name + "=([^&]*)").exec(window.location.search);
+    return match && decodeURIComponent(match[1].replace(/\+/g, " "));
+  }
+
+  function processCookieConsentFlag() {
+    var cookieConsent = getQueryParameterByName("cookie_consent");
+
+    if (
+      (cookieConsent && cookieConsent === "accept") ||
+      cookieConsent === "reject"
+    ) {
+      setCookie(COOKIES_PREFERENCES_SET, {
+        analytics: cookieConsent === "accept",
+      });
+    } else {
+      setCookie(COOKIES_PREFERENCES_SET, "", { days: -1 });
+    }
+  }
+
   function setBannerCookieConsent(analyticsConsent) {
     setCookie(
       COOKIES_PREFERENCES_SET,
@@ -179,7 +199,10 @@ var cookies = function (trackingId) {
       var date = new Date();
       date.setTime(date.getTime() + options.days * 24 * 60 * 60 * 1000);
       cookieString =
-        cookieString + "; expires=" + date.toGMTString() + "; path=/";
+        cookieString +
+        "; expires=" +
+        date.toGMTString() +
+        "; path=/;";
     }
 
     if (document.location.protocol === "https:") {
@@ -207,6 +230,7 @@ var cookies = function (trackingId) {
     cookiesPageInit,
     hasConsentForAnalytics,
     initAnalytics,
+    processCookieConsentFlag,
   };
 };
 

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -47,6 +47,20 @@ export function oidcAuthCallbackGet(
       state: {},
     };
 
-    return res.redirect(PATH_DATA.MANAGE_YOUR_ACCOUNT.url);
+    return res.redirect(
+      appendQueryParam(
+        "cookie_consent",
+        req.query.cookie_consent as string,
+        PATH_DATA.MANAGE_YOUR_ACCOUNT.url
+      )
+    );
   };
+}
+
+function appendQueryParam(param: string, value: string, url: string) {
+  if (!param || !value) {
+    return url;
+  }
+
+  return `${url}?${param}=${value}`;
 }

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -17,6 +17,7 @@ describe("callback controller", () => {
 
     req = {
       body: {},
+      query:{},
       session: { user: {}, destroy: sandbox.fake() },
       t: sandbox.fake(),
       oidc: {
@@ -52,6 +53,20 @@ describe("callback controller", () => {
 
       expect(res.redirect).to.have.calledWith(
         PATH_DATA.MANAGE_YOUR_ACCOUNT.url
+      );
+    });
+
+    it("should redirect to /manage-your-account with cookie consent query param", async () => {
+      req.query.cookie_consent = "accept";
+
+      const fakeService: ClientAssertionServiceInterface = {
+        generateAssertionJwt: sandbox.fake.returns("testassert"),
+      };
+
+      await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_DATA.MANAGE_YOUR_ACCOUNT.url + "?cookie_consent=accept"
       );
     });
   });


### PR DESCRIPTION
## What?

Add cookie consent support to UI.

## Why?

To allow cookie banner to be toggled where needed.