### PR TITLE
Update page titles to match figma

### DIFF
--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -3,7 +3,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% set pageTitleName = 'pages.enterPassword.title' | translate %}
+{% if requestType == 'changePassword' %}
+    {% set pageTitleName = 'pages.enterPassword.changePassword.title' | translate %}
+{%  else %}
+    {% set pageTitleName = 'pages.enterPassword.title' | translate %}
+{% endif %}
+
 {% set backLink = "/manage-your-account" %}
 
 {% block pageContent %}

--- a/src/components/manage-your-account/index.njk
+++ b/src/components/manage-your-account/index.njk
@@ -20,54 +20,54 @@
         rows: [
             {
                 key: {
-                text: 'pages.manageYourAccount.summaryList.email' | translate
-            },
+                    text: 'pages.manageYourAccount.summaryList.email' | translate
+                },
                 value: {
-                text: email
-            },
+                    text: email
+                },
                 actions: {
-                items: [
-                    {
-                        href: "/enter-password?type=changeEmail",
-                        text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                        visuallyHiddenText: 'pages.manageYourAccount.summaryList.email' | translate
-                    }
-                ]
-            }
+                    items: [
+                        {
+                            href: "/enter-password?type=changeEmail",
+                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
+                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.email' | translate
+                        }
+                    ]
+                }
             },
             {
                 key: {
-                text: 'pages.manageYourAccount.summaryList.password' | translate
-            },
+                    text: 'pages.manageYourAccount.summaryList.password' | translate
+                },
                 value: {
-                text: "••••••••••••••••"
-            },
+                    text: "••••••••••••••••"
+                },
                 actions: {
-                items: [
-                    {
-                        href: "/enter-password?type=changePassword",
-                        text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                        visuallyHiddenText: 'pages.manageYourAccount.summaryList.password' | translate
-                    }
-                ]
-            }
+                    items: [
+                        {
+                            href: "/enter-password?type=changePassword",
+                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
+                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.password' | translate
+                        }
+                    ]
+                }
             },
             {
                 key: {
-                text: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
-            },
+                    text: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
+                },
                 value: {
-                text: phoneNumber
-            },
+                    text: phoneNumber
+                },
                 actions: {
-                items: [
-                    {
-                        href: "/enter-password?type=changePhoneNumber",
-                        text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
-                        visuallyHiddenText: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
-                    }
-                ]
-            }
+                    items: [
+                        {
+                            href: "/enter-password?type=changePhoneNumber",
+                            text: 'pages.manageYourAccount.summaryList.changeAction' | translate,
+                            visuallyHiddenText: 'pages.manageYourAccount.summaryList.phoneNumber' | translate
+                        }
+                    ]
+                }
             }
         ]
     }) }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -98,7 +98,7 @@
   },
   "pages": {
     "manageYourAccount": {
-      "title": "Sign in to or create your GOV.UK account",
+      "title": "Manage your account",
       "header": "Manage your account",
       "accountDetails": "Account details",
       "menuItemList": {
@@ -131,6 +131,7 @@
         "backLink": "I do not want to change my email address"
       },
       "changePassword": {
+        "title": "Enter your current password",
         "header": "Enter your current password",
         "paragraph": "We need to make sure it’s you before you can change your password.",
         "backLink": "I do not want to change my password"
@@ -262,7 +263,7 @@
       }
     },
     "deleteAccount": {
-      "title": "Remove account",
+      "title": "Are you sure you want to delete your account?",
       "header": "Are you sure you want to delete your account?",
       "warningText": "Your account will be permanently deleted. You won’t be able to get it back.",
       "paragraph": "Deleting your GOV.UK account won’t delete any other government accounts you have, such as Government Gateway or your Universal Credit account.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -98,7 +98,7 @@
   },
   "pages": {
     "manageYourAccount": {
-      "title": "Sign in to or create your GOV.UK account",
+      "title": "Manage your account",
       "header": "Manage your account",
       "accountDetails": "Account details",
       "menuItemList": {
@@ -131,6 +131,7 @@
         "backLink": "I do not want to change my email address"
       },
       "changePassword": {
+        "title": "Enter your current password",
         "header": "Enter your current password",
         "paragraph": "We need to make sure it’s you before you can change your password.",
         "backLink": "I do not want to change my password"
@@ -262,7 +263,7 @@
       }
     },
     "deleteAccount": {
-      "title": "Remove account",
+      "title": "Are you sure you want to delete your account?",
       "header": "Are you sure you want to delete your account?",
       "warningText": "Your account will be permanently deleted. You won’t be able to get it back.",
       "paragraph": "Deleting your GOV.UK account won’t delete any other government accounts you have, such as Government Gateway or your Universal Credit account.",


### PR DESCRIPTION
## What?

Update page titles to match latest figma diagrams and h1 of page.

## Why?

The page titles should match the main header of the page.

