### PR TITLE
GOVSI-962: Point the GOV.UK logo to the gov.uk site

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -39,15 +39,13 @@
 {% block header %}
  {% if hideSignOutLink %}
     {{ govukHeader({
-           homepageUrl: "#",
-           serviceUrl: "#",
+           homepageUrl: 'general.header.homepageHref' | translate,
            serviceName: 'general.serviceNameTitle' | translate
        }) }}
 
   {% else %}
        {{ govukHeader({
-           homepageUrl: "#",
-           serviceUrl: "#",
+           homepageUrl: 'general.header.homepageHref' | translate,
            serviceName: 'general.serviceNameTitle' | translate,
            navigation: [
                {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -47,6 +47,9 @@
     "continue": {
       "label": "Continue"
     },
+    "header": {
+      "homepageHref": "https://www.gov.uk/"
+    },
     "footer": {
       "accessibilityStatement": {
         "pageTitle": "Accessibility statement",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -47,6 +47,9 @@
     "continue": {
       "label": "Continue"
     },
+    "header": {
+      "homepageHref": "https://www.gov.uk/"
+    },
     "footer": {
       "accessibilityStatement": {
         "pageTitle": "Accessibility statement",


### PR DESCRIPTION
## What?
GOVSI-962: Fix banner logo to point to the gov.uk site.

## Why?

Fixing contents and bugs as a result of the GOVSI-961 manual testing.

