### PR TITLE
GOVSI-982: Update password error to match figma diagram

### DIFF
--- a/src/components/change-password/change-password-validation.ts
+++ b/src/components/change-password/change-password-validation.ts
@@ -41,7 +41,9 @@ export function validateChangePasswordRequest(): ValidationChainFunc {
       .custom((value, { req }) => {
         if (value !== req.body["confirm-password"]) {
           throw new Error(
-            req.t("pages.changePassword.password.validationError.required")
+            req.t(
+              "pages.changePassword.confirmPassword.validationError.matches"
+            )
           );
         }
         return true;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,3 +18,8 @@ export interface ClientAssertionServiceInterface {
     tokenEndpointUri: string
   ) => Promise<string>;
 }
+
+export interface Error {
+  text: string;
+  href: string;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,6 @@
 import { Response, Request } from "express";
 import { HTTP_STATUS_CODES } from "../app.constants";
+import { Error } from "./types";
 
 export const isObjectEmpty = (obj: Record<string, unknown>): boolean => {
   return Object.keys(obj).length === 0;
@@ -8,8 +9,8 @@ export const isObjectEmpty = (obj: Record<string, unknown>): boolean => {
 export function formatValidationError(
   key: string,
   validationMessage: string
-): { [k: string]: any } {
-  const error: { [k: string]: any } = {};
+): { [k: string]: Error } {
+  const error: { [k: string]: Error } = {};
   error[key] = {
     text: validationMessage,
     href: `#${key}`,
@@ -21,13 +22,17 @@ export function renderBadRequest(
   res: Response,
   req: Request,
   template: string,
-  errors: any
+  errors: { [k: string]: Error }
 ): void {
   res.status(HTTP_STATUS_CODES.BAD_REQUEST);
 
+  const errorValues = Object.values(errors);
+  const uniqueErrorList = [
+    ...new Map(errorValues.map((error) => [error.text, error])).values(),
+  ];
   res.render(template, {
     errors,
-    errorList: Object.values(errors),
+    errorList: uniqueErrorList,
     ...req.body,
     language: req.i18n.language,
   });


### PR DESCRIPTION
## What?

Update the create password error messages to match the figma designs, and de-duplicate the errorList to only render 1 instance of a duplicated error message.

## Why?

Updated the error content to match with the figma designs.

