### PR TITLE
Update the gtm blocklist tags

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -137,13 +137,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     window.dataLayer = [
       {
         "gtm.allowlist": ["google"],
-        "gtm.blocklist": [
-          "nonGoogleScripts",
-          "nonGoogleIframes",
-          "nonGooglePixels",
-          "customScripts",
-          "customPixels",
-        ],
+        "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
       },
       {
         'department': {

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -43,7 +43,7 @@ describe("callback controller", () => {
       render: sandbox.fake(),
       redirect: sandbox.fake(),
       cookie: sandbox.fake(),
-      locals:{}
+      locals: {},
     };
   });
 

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -3,7 +3,8 @@ import {
   getAnalyticsCookieDomain,
   getAuthFrontEndUrl,
   getCookiesAndFeedbackLink,
-  getGtmId, getYourAccountUrl,
+  getGtmId,
+  getYourAccountUrl,
 } from "../config";
 import { generateNonce } from "../utils/strings";
 


### PR DESCRIPTION
## What?

Updated the google tag manager blocklist options.

## Why?

Ensures all other tags are blocked apart from google analytics tags.