### PR TITLE
Add check to see if token is expiring soon

### DIFF
--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -28,7 +28,11 @@ const cached = pMemoize(getOIDCClient, { maxAge: 43200000 });
 
 function isTokenExpired(token: string): boolean {
   const decodedToken: any = JWT.decode(token);
-  return (decodedToken.exp as number) < Date.now() / 1000;
+
+  const next60Seconds = new Date();
+  next60Seconds.setSeconds(60)
+
+  return (decodedToken.exp as number) < next60Seconds.getTime() / 1000;
 }
 
 function clientAssertionGenerator(

--- a/test/unit/utils/oidc.ts
+++ b/test/unit/utils/oidc.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { isTokenExpired } from "../../../src/utils/oidc";
+import { JWT } from "jose";
+
+
+describe("oidc", () => {
+  describe("isTokenExpired", () => {
+    it("should return false when token doesn't expire in next 60 seconds", () => {
+      const accessToken =  JWT.sign(
+        { sub: "12345", exp: "1758477938" },
+        "secret"
+      );
+
+      const value = isTokenExpired(accessToken);
+      expect(value).to.equal(false);
+    });
+
+    it("should return true when token expires in next 60 seconds", () => {
+      const next30Seconds = new Date();
+      next30Seconds.setSeconds(30);
+
+      const accessToken =  JWT.sign(
+        { sub: "12345", exp: Math.round(next30Seconds.getTime() / 1000) },
+        "secret"
+      );
+      const value = isTokenExpired(accessToken);
+      expect(value).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
## What?

Add check to see if access token expires in next 60 seconds.

## Why?

To prevent the chance that the token will expire before  hitting the API.
