### PR TITLE
Add splunk binding to manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,3 +26,4 @@ applications:
       - ((environment_name))-account-management-kms-provider
       - ((environment_name))-account-management-idp-provider
       - ((environment_name))-redis
+      - ((environment_name))-splunk


### PR DESCRIPTION
## What?

Add splunk binding to manifest.

## Why?

To send logs to splunk.

