### PR TITLE
Make header link active

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -49,7 +49,8 @@
            navigation: [
                {
                  href: govAccountsUrl,
-                 text: 'general.header.accountLink' | translate
+                 text: 'general.header.accountLink' | translate,
+                 active: true
                },
                {
                    href: "/sign-out",


### PR DESCRIPTION
## What?

Make link active in header for account link.

## Why?

To follow the design guidelines. 