### PR TITLE
AUT-212: Set AM desired count to 2 by default

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -73,7 +73,7 @@ variable "account_management_image_digest" {
 
 variable "account_management_ecs_desired_count" {
   type    = number
-  default = 3
+  default = 2
 }
 
 variable "account_management_app_port" {


### PR DESCRIPTION
## What?

Set AM desired count to 2 by default

## Why?

Align with frontend.
2 is an even number so easier to do the math when min % is 50%.
