### PR TITLE
BAU: remove github actions coverage task

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -43,8 +43,6 @@ jobs:
         run: yarn test:unit
       - name: Run integration tests
         run: yarn test:integration
-      - name: Run test coverage
-        run: yarn test:coverage
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -48,8 +48,6 @@ jobs:
         run: yarn test:integration
       - name: Run lint
         run: yarn lint
-      - name: Run test coverage
-        run: yarn test:coverage
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
## What?

remove github actions coverage task

## Why?

The unit test and integration test tasks already produce coverage reports so this is duplication.
As these tasks also clear coverage before running the output only represents integration test coverage and not combined coverage.
