### PR TITLE
ATB-128 Enable deployment of multiple AMF stacks in our Dev environment

### DIFF
--- a/.github/workflows/dev-instance.yml
+++ b/.github/workflows/dev-instance.yml
@@ -4,6 +4,14 @@ name: "Verify & Publish to Dev (1-3) Instance"
 on:
   workflow_dispatch:
     inputs:
+      refType:
+        type: choice
+        description: "Find branch name, commit SHA, or tag?"
+        options:
+          - Branch name
+          - Commit SHA
+          - Tag
+        default: Branch name
       gitRef:
         description: "Commit SHA, branch name or tag"
         required: true
@@ -29,7 +37,7 @@ jobs:
 
   validate_deployment:
     name: Deployment Template Checks
-    uses: ./.github/workflows/validate-sam-template.yml
+    uses: ./.github/workflows/validate-sam-template-dev.yml
     secrets: inherit
     with:
       gitRef: ${{ inputs.gitRef }}
@@ -45,6 +53,21 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.gitRef }}
+          
+      - name: Fetch Commit SHA
+        id: gitRefSHA
+        if: ${{ github.event.inputs.choice }} == "Commit SHA"
+        run: echo GIT_REF_SHA=${{ inputs.gitRef }} >> $GITHUB_ENV
+
+      - name: Fetch Commit SHA by Branch name
+        id: gitRefBranch
+        if: ${{ github.event.inputs.choice }} == "Branch name"
+        run: echo GIT_REF_SHA=$(git log -1 ${{ inputs.gitRef }} --pretty=format:%H) >> $GITHUB_ENV
+
+      - name: Fetch Commit SHA by Tag
+        id: gitRefTag
+        if: ${{ github.event.inputs.choice }} == "Tag"
+        run : echo GIT_REF_SHA=$(git rev-list -n 1 ${{ inputs.gitRef }}) >> $GITHUB_ENV
 
       - name: Set tag
         id: vars
@@ -68,25 +91,30 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
+          ECR_REPOSITORY: ${{ secrets.DEV_INSTANCE_ECR_REPOSITORY }}
+          DEV_ENVIRONMENT_NUMBER: ${{ inputs.environmentNumber }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_REF_SHA-$DEV_ENVIRONMENT_NUMBER .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_REF_SHA-$DEV_ENVIRONMENT_NUMBER
       - name: Upload SAM Template to Bucket
         id: publish-template
         env:
           ARTIFACT_BUCKET_NAME: ${{ secrets.DEV_INSTANCE_ARTIFACT_SOURCE_BUCKET_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
+          ECR_REPOSITORY: ${{ secrets.DEV_INSTANCE_ECR_REPOSITORY }}
+          DEV_ENVIRONMENT_NUMBER: ${{ inputs.environmentNumber }}
         run: |
           echo "Running sam build on template file"
           sam build --template-file=./deploy/template.yaml
           mv .aws-sam/build/template.yaml cf-template.yaml
           echo "Replacing 'CONTAINER-IMAGE-PLACEHOLDER' with new ECR image ref"
-          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA|" cf-template.yaml
+          sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPOSITORY:$GIT_REF_SHA-$DEV_ENVIRONMENT_NUMBER|" cf-template.yaml
           echo "Updating the Environment Number to ${{ inputs.environmentNumber }}"
           sed -i "s|ENVIRONMENT_NUMBER_PLACEHOLDER|${{ inputs.environmentNumber }}|" cf-template.yaml
-          zip template.zip cf-template.yaml
-          aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+          echo "Create config.properties file to provide the environment number"
+          touch config.properties
+          echo "environmentNumber:${{ inputs.environmentNumber }}" > config.properties
+          zip template.zip cf-template.yaml config.properties
+          aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GIT_REF_SHA"
       - name: "Delegated Deployment via AWS CodeDeploy"
         run: echo "Deployment has been delegated to AWS CodeDeploy"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -53,6 +53,15 @@ Parameters:
       - "integration"
       - "production"
     Default: dev
+  EnvironmentNumber:
+    Type: String
+    Default: "ENVIRONMENT_NUMBER_PLACEHOLDER"
+    AllowedPattern: "(^[1-3]{1}$)|(.*?PLACEHOLDER)"
+    Description: "Must be an environment number between 1 and 3 or leave as default"
+  FrontendStackName:
+    Description: The name of the authentication account management front-end application stack name
+    Type: String
+    Default: account-mgmt-frontend
   VpcStackName:
     Description: The name of the stack that defines the VPC in which this container will run.
     Type: String
@@ -108,6 +117,12 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  IsDevInstance: !And
+    - Fn::Equals: [ !Ref Environment, dev ]
+    - Fn::Or:
+      - !Equals [ !Ref EnvironmentNumber, 1 ]
+      - !Equals [ !Ref EnvironmentNumber, 2 ]
+      - !Equals [ !Ref EnvironmentNumber, 3 ]
 
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
@@ -333,7 +348,7 @@ Resources:
                 Resource: !Join
                   - ""
                   - - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/"
-                    - !Sub "{{resolve:ssm:/${AWS::StackName}/KMS/JwtSigningKey/Id}}"
+                    - !Sub "{{resolve:ssm:/${FrontendStackName}/KMS/JwtSigningKey/Id}}"
               - Effect: Allow
                 Action:
                   - "kms:GenerateDataKey*"
@@ -342,7 +357,6 @@ Resources:
                   - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/{{resolve:ssm:/${BackendStackName}/KMS/SnsKmsKey/ID}}"
                   - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/{{resolve:ssm:/${BackendStackName}/KMS/DatabaseKmsKey/ID}}"
                   - !GetAtt DynamoDBKmsKey.Arn
-
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
@@ -458,117 +472,59 @@ Resources:
               awslogs-stream-prefix: "ecs"
           Environment:
             - Name: "NODE_ENV"
-              Value:
-                !FindInMap [EnvironmentVariables, !Ref Environment, NODEENV]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, NODEENV]
             - Name: "APP_ENV"
               Value: !Sub "${Environment}"
             - Name: "API_BASE_URL"
-              Value:
-                !FindInMap [EnvironmentVariables, !Ref Environment, APIBASEURL]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, APIBASEURL]
             - Name: "AM_API_BASE_URL"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  AMAPIBASEURL,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, AMAPIBASEURL]
             - Name: "BASE_URL"
-              Value:
-                !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+              Value: !If
+                - IsDevInstance
+                - !Join
+                  - "."
+                  - - !Sub "${Environment}-${EnvironmentNumber}"
+                    - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+                - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
             - Name: "OIDC_CLIENT_ID"
-              Value: !Sub "{{resolve:ssm:/${AWS::StackName}/Config/OIDC/Client/Id}}"
+              Value: !Sub "{{resolve:ssm:/${FrontendStackName}/Config/OIDC/Client/Id}}"
             - Name: "OIDC_CLIENT_SCOPES"
               Value: "openid phone email am offline_access govuk-account"
             - Name: "SESSION_EXPIRY"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SESSIONEXPIRY,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SESSIONEXPIRY]
             - Name: "SESSION_SECRET"
               Value: !Sub "{{resolve:secretsmanager:${SessionSecret}}}"
             - Name: "AM_YOUR_ACCOUNT_URL"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  AMYOURACCOUNTURL,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, AMYOURACCOUNTURL]
             - Name: "GTM_ID"
-              Value: !Sub "{{resolve:ssm:/${AWS::StackName}/Config/GTM/Id}}"
+              Value: !Sub "{{resolve:ssm:/${FrontendStackName}/Config/GTM/Id}}"
             - Name: "GOV_ACCOUNTS_PUBLISHING_API_URL"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  GOVACCOUNTSPUBLISHINGAPIURL,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, GOVACCOUNTSPUBLISHINGAPIURL]
             - Name: "GOV_ACCOUNTS_PUBLISHING_API_TOKEN"
-              Value: !Sub "{{resolve:secretsmanager:/${AWS::StackName}/Config/Publishing/API/Key}}"
+              Value: !Sub '{{resolve:secretsmanager:/${FrontendStackName}/Config/Publishing/API/Key}}'
             - Name: "SUPPORT_INTERNATIONAL_NUMBERS"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SUPPORTINTERNATIONALNUMBERS,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SUPPORTINTERNATIONALNUMBERS]
             - Name: "SUPPORT_LANGUAGE_CY"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SUPPORTLANGUAGECY,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SUPPORTLANGUAGECY]
             - Name: "SUPPORT_NEW_ACCOUNT_HEADER"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SUPPORTNEWACCOUNTHEADER,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SUPPORTNEWACCOUNTHEADER]
             - Name: "SUPPORT_DELETE_SERVICE_STORE"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SUPPORTDELETESERVICESTORE,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SUPPORTDELETESERVICESTORE]
             - Name: "SUPPORT_SERVICE_CARDS"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SUPPORTSERVICECARDS,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SUPPORTSERVICECARDS]
             - Name: "AUTH_FRONTEND_URL"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  AUTHFRONTENDURL,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, AUTHFRONTENDURL]
             - Name: "ANALYTICS_COOKIE_DOMAIN"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  ANALYTICSCOOKIEDOMAIN,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, ANALYTICSCOOKIEDOMAIN]
             - Name: "SESSION_STORE_TABLE_NAME"
               Value: !Ref SessionsDynamoDB
             - Name: "KMS_KEY_ID"
-              Value: !Sub "{{resolve:ssm:/${AWS::StackName}/KMS/JwtSigningKey/Id}}"
+              Value: !Sub "{{resolve:ssm:/${FrontendStackName}/KMS/JwtSigningKey/Id}}"
             - Name: "SERVICE_DOMAIN"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SERVICEDOMAIN,
-                ]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, SERVICEDOMAIN]
             - Name: "LOGS_LEVEL"
-              Value:
-                !FindInMap [EnvironmentVariables, !Ref Environment, LOGSLEVEL]
+              Value: !FindInMap [EnvironmentVariables, !Ref Environment, LOGSLEVEL]
             - Name: "DELETE_TOPIC_ARN"
               Value: !Sub "{{resolve:ssm:/${BackendStackName}/SNS/DeleteTopic/ARN}}"
             - Name: "SERVICE_STORE_TABLE_NAME"
@@ -716,9 +672,13 @@ Resources:
       PayloadFormatVersion: 1.0
       Description: !Sub "API GW to ECS Container integration for ${AWS::StackName}"
       TlsConfig:
-        ServerNameToVerify:
-          !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
-
+        ServerNameToVerify: !If
+          - IsDevInstance
+          - !Join
+            - "."
+            - - !Sub "${Environment}-${EnvironmentNumber}"
+              - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+          - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
   ApiRoute:
     Type: AWS::ApiGatewayV2::Route
     Properties:
@@ -767,7 +727,13 @@ Resources:
   AppFrontCustomDomain:
     Type: AWS::ApiGatewayV2::DomainName
     Properties:
-      DomainName: !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+      DomainName: !If
+        - IsDevInstance
+        - !Join
+          - "."
+          - - !Sub "${Environment}-${EnvironmentNumber}"
+            - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+        - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
       DomainNameConfigurations:
         - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/HostedZone/Certificate/Home/ARN}}"
           EndpointType: REGIONAL
@@ -782,7 +748,13 @@ Resources:
   AppFrontApiRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      Name: !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+      Name: !If
+        - IsDevInstance
+        - !Join
+          - "."
+          - - !Sub "${Environment}-${EnvironmentNumber}"
+            - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+        - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/HostedZone/Home}}"
       AliasTarget:
@@ -794,7 +766,13 @@ Resources:
   AppFrontApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
     Properties:
-      DomainName: !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+      DomainName: !If
+        - IsDevInstance
+        - !Join
+          - "."
+          - - !Sub "${Environment}-${EnvironmentNumber}"
+            - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+        - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
       ApiId: !Ref ApiGateway
       Stage: !Ref ApiDefaultStage
     DependsOn:
@@ -1284,10 +1262,20 @@ Resources:
     DependsOn: CloudFrontLogsBucket
     Properties:
       DistributionConfig:
-        Aliases:
-          - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
-        CNAMEs:
-          - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+        Aliases: !If
+          - IsDevInstance
+          - - !Join
+              - "."
+              - - !Sub "${Environment}-${EnvironmentNumber}"
+                - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+          - - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
+        CNAMEs: !If
+          - IsDevInstance
+          - - !Join
+              - "."
+              - - !Sub "${Environment}-${EnvironmentNumber}"
+                - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+          - - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
         Comment: !Sub "CloudFront Distribution resource for the ${AWS::StackName} application"
         DefaultCacheBehavior:
           AllowedMethods:
@@ -1304,8 +1292,13 @@ Resources:
           OriginRequestPolicyId: !GetAtt CloudFrontOriginRequestPolicy.Id
           Compress: false
           MinTTL: 0
-          TargetOriginId:
-            !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+          TargetOriginId: !If
+            - IsDevInstance
+            - !Join
+              - "."
+              - - !Sub "${Environment}-${EnvironmentNumber}"
+                - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+            - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
           ViewerProtocolPolicy: redirect-to-https
         Enabled: true
         HttpVersion: "http2"
@@ -1315,7 +1308,13 @@ Resources:
           - ConnectionAttempts: 3
             ConnectionTimeout: 10
             DomainName: !Sub "${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com"
-            Id: !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+            Id: !If
+              - IsDevInstance
+              - !Join
+                - "."
+                - - !Sub "${Environment}-${EnvironmentNumber}"
+                  - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+              - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]
             CustomOriginConfig:
               HTTPSPort: 443
               OriginKeepaliveTimeout: 5
@@ -1948,4 +1947,10 @@ Outputs:
     Value: !GetAtt ApiGateway.ApiEndpoint
   CloudFrontDistributionEndpoint:
     Description: The Application URL.
-    Value: !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
+    Value: !If
+      - IsDevInstance
+      - !Join
+        - "."
+        - - !Sub "${Environment}-${EnvironmentNumber}"
+          - !FindInMap [ EnvironmentVariables, !Ref Environment, BASEURL ]
+      - !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL ]


### PR DESCRIPTION
## Proposed changes

### What changed

- Created a new GitHub workflow to facilitate the deployment of parallel AMF stacks in the dev environment.
- Refactored the AMF template to enable instance deployments of the AMF stack with dev prefixed e.g. dev-1-account-management-frontend. Supported environments are `dev-1`, `dev-2` and `dev-3`.

### Why did it change

We have a single instance of the AMF stack in the dev environment meaning GOV.UK Account developers must coordinate to test changes to not override front-end and infrastructure changes deployed off feature branches. Developers will now have three new instances of the AMF stack (four in total) to deploy and test their changes against.

### Additional considerations
It's worth noting that this is the first iteration of the parallel stack deployment pipeline work and future enhancements will include a single pipeline that deploys both standard dev and prefixed dev stacks.

The `FrontendStackName` parameter has been defined to reference existing SSM parameter values that will be shared across the dev stack instances.

### Issue tracking
- [ATB-128](https://govukverify.atlassian.net/browse/ATB-128)

### Related PRs
- [ATB-128 Dev AMF Parallel Pipeline template & Allow dev instance of ECS Task Role to sign JWT Signing Key](https://github.com/alphagov/di-accounts-infra/pull/26)

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
GitHub secrets created as part of the pipeline work:
- DEV_INSTANCE_ARTIFACT_SOURCE_BUCKET_NAME
- DEV_INSTANCE_ECR_REPOSITORY
- DEV_INSTANCE_GH_ACTIONS_ROLE_ARN


[ATB-128]: https://govukverify.atlassian.net/browse/ATB-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ