### PR TITLE
OLH-1294 Add error handling for undefined session or queryParameters

### DIFF
--- a/src/components/track-and-redirect/track-and-redirect-route.ts
+++ b/src/components/track-and-redirect/track-and-redirect-route.ts
@@ -3,9 +3,14 @@ import { EVENT_NAME, PATH_DATA } from "../../app.constants";
 
 import { eventService } from "../../services/event-service";
 import { buildContactEmailServiceUrl } from "./track-and-redirect-controller";
+import { logger } from "../../utils/logger";
 
 const router = express.Router();
 router.get(PATH_DATA.TRACK_AND_REDIRECT.url, (req, res) => {
+  if (!req.session || !req.session.queryParameters) {
+    logger.error("Request session or queryParameters are undefined.");
+    return res.redirect(PATH_DATA.CONTACT.url);
+  }
   const emailServiceUrl = buildContactEmailServiceUrl(req);
   const service = eventService();
   const audit_event = service.buildAuditEvent(

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,3 +1,15 @@
+import { Session } from "express-session";
+import { NextFunction, Request, Response } from "express";
+import { Middleware } from "express-validator/src/base";
+
 export function testComponent(componentId: string): string {
   return `[data-test-id='${componentId}']`;
+}
+export function mockSessionMiddleware(
+  sessionData: Partial<Session>
+): Middleware {
+  return function (req: Request, res: Response, next: NextFunction) {
+    req.session = sessionData as Session;
+    next();
+  };
 }


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Updates to track-and-redirect-controller to include error checking for undefined session or queryParameters. Corresponding tests have also been updated to check this new error handling behaviour. The changes help prevent potential crashes due to undefined values and will redirect users if page is trying to be accessed directly.

### Why did it change

Dynatrace has picked up some 500 status codes on the frontend for the /track-and-redirect route. 

## Testing

Tested locally

## How to review

When user navigates to /track-and-redirect page directly it will be redirected to /contact-gov-uk-one-login
