### PR TITLE
OLH-1224 Sign out link as POST request

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -67,7 +67,7 @@ $govuk-new-link-styles: true;
 
 .govuk-summary-list--activity-log {
   .govuk-summary-list__key {
-    @include govuk-font($size: 24, $weight: bold)
+    @include govuk-font($size: 24, $weight: bold);
   }
 
   @include govuk-media-query($from: "tablet") {
@@ -201,16 +201,89 @@ $govuk-new-link-styles: true;
 $nav-link-padding: govuk-spacing(3);
 $nav-link-outline-thickness: 2px;
 $nav-active-border-thickness: 5px;
+$nav-link-padding-left: $nav-link-padding - 2;
+$nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
 
+/* Combined styles for buttons */
+.account-header-navigation__button, .account-navigation__button {
+  border: 0 none;
+  cursor: pointer;
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+
+  &:focus {
+    outline: none;
+    span {
+      @include govuk-focused-text;
+    }
+  }
+}
+
+/* Specific styles for .account-header-navigation__button */
+.account-header-navigation__button-content {
+  @include govuk-font($size: 16);
+  color: govuk-colour("white");
+  @include govuk-link-style-inverse;
+
+  &:not(:hover) {
+    text-decoration: none;
+  }
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-thickness: 3px;
+
+    @if $govuk-link-underline-offset {
+      text-underline-offset: $govuk-link-underline-offset;
+    }
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+}
+
+// /* Positioning for the navigation form */
+
+.account-header-navigation__form {
+  position: absolute;
+  padding: 5px;
+  right: 0;
+  bottom: 7px;
+  @include govuk-media-query($until: mobile) {
+    position: relative;
+    float: left;
+    padding-left: 0;
+  }
+}
+
+// /* Specific styles for .account-navigation__button */
+.account-navigation__button {
+  color: $govuk-link-colour;
+  font-size: inherit;
+
+  &:focus {
+    span {
+      padding: $nav-link-padding-left 0 16px;
+    }
+  }
+}
+
+.account-navigation__button-content,
 .account-navigation__link {
   @extend .govuk-link;
   display: inline-block;
   font-weight: bold;
-  padding: $nav-link-padding - $nav-link-outline-thickness 0 $nav-link-padding;
+  padding: $nav-link-padding-left 0 govuk-spacing(2);
   margin-top: $nav-link-outline-thickness;
 
   &:not(:hover) {
     text-decoration: none;
+  }
+
+  &:focus {
+    padding: $nav-link-padding-left 0 $nav-link-padding;
   }
 
   &:visited {
@@ -226,18 +299,22 @@ $nav-active-border-thickness: 5px;
   }
 
   .account-navigation__list-item--active & {
-    padding: $nav-link-padding - $nav-link-outline-thickness 0 $nav-link-padding - $nav-active-border-thickness;
     border-bottom: $nav-active-border-thickness solid $govuk-link-colour;
 
     &:focus {
       border-bottom: none;
-      padding: $nav-link-padding - $nav-link-outline-thickness 0 $nav-link-padding;
+      padding: $nav-link-padding-left 0 $nav-link-padding;
+      margin-top: $nav-link-outline-thickness;
     }
 
     &:hover {
       border-color: $govuk-link-hover-colour;
     }
   }
+}
+
+.account-navigation__button-content {
+  padding: $nav-link-padding-left 0 $nav-link-padding-left;
 }
 
 .your-services__heading {
@@ -353,15 +430,15 @@ $nav-active-border-thickness: 5px;
   }
 }
 
-.sa-chat-tab { 
-  // limit size of webchat button when zoom is applied 
-  max-width: 25vw !important; 
+.sa-chat-tab {
+  // limit size of webchat button when zoom is applied
+  max-width: 25vw !important;
   max-height: 25vw !important;
   bottom: 2vh !important;
   right: 2vw !important;
   left: auto !important;
   @include govuk-media-query($from: tablet) {
-    max-width: 20vw !important; 
+    max-width: 20vw !important;
     max-height: 20vw !important;
   }
 }

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -36,15 +36,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({
-      homepageUrl: accountHome,
-      productName: 'general.header.productName' | translate,
-      classes: headerClasses,
-      navigation: [{
-        href: accountSignOut,
-        text: 'general.header.signOutLink' | translate
-      }] if showSignOut
-    }) }}
+    {% include 'common/layout/header.njk' %}
     {% if not hideAccountNavigation %}
       {% include 'common/layout/navigation.njk' %}
     {% endif %}

--- a/src/components/common/layout/header.njk
+++ b/src/components/common/layout/header.njk
@@ -1,0 +1,29 @@
+<header class="govuk-header {{ headerClasses }}" role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+            <a href="{{ accountHome }}" class="govuk-header__link govuk-header__link--homepage" style="margin-right: 20px;">
+                <span class="govuk-header__logotype">
+                  <!--[if gt IE 8]><!-->
+                  <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                    <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                  </svg>
+                    <!--<![endif]-->
+                    <span class="govuk-header__logotype-text">
+                    GOV.UK
+                  </span>
+                </span>
+                <span class="govuk-header__product-name">{{ 'general.header.productName' | translate }}</span>
+            </a>
+        </div>
+        {% if showSignOut %}
+            <div class="govuk-header__content">
+                <nav class="account-header-navigation" aria-label="{{ 'general.header.signOutLink' | translate }}">
+                    <form class="account-header-navigation__form" action="{{ accountSignOut }}" method="post">
+                        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                        <button class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
+                    </form>
+                </nav>
+            </div>
+        {% endif %}
+    </div>
+</header>

--- a/src/components/common/layout/navigation.njk
+++ b/src/components/common/layout/navigation.njk
@@ -8,18 +8,21 @@
     active: true if (active == "security") else false,
     href: accountSecurity,
     text: 'general.header.accountNavSecurityLink' | translate
-  },{
-    active: true if (active == "sign-out") else false,
-    href: accountSignOut,
-    text: 'general.header.signOutLink' | translate
   }]
 %}
 <nav aria-label="Account navigation" class="account-navigation">
-  <div class="govuk-width-container">
-    <ul class="account-navigation__list">
-      {% for item in navigationItems %}
-        <li class="account-navigation__list-item {{ 'account-navigation__list-item--active' if item.active else '' }}"><a class="account-navigation__link" href="{{item.href}}">{{item.text}}</a></li>
-      {% endfor %}
-    </ul>
-  </div>
+    <div class="govuk-width-container">
+        <ul class="account-navigation__list">
+            {% for item in navigationItems %}
+                <li class="account-navigation__list-item {{ 'account-navigation__list-item--active' if item.active else '' }}">
+                    <a class="account-navigation__link" href="{{ item.href }}">{{ item.text }}</a></li>
+            {% endfor %}
+            <li class="account-navigation__list-item">
+                <form action="{{ accountSignOut }}" method="post">
+                    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+                    <button class="account-navigation__button" type="submit"><span class="account-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
+                </form>
+            </li>
+        </ul>
+    </div>
 </nav>

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -3,7 +3,7 @@ import { logger } from "../../utils/logger";
 import { LOG_MESSAGES } from "../../app.constants";
 import { ERROR_MESSAGES } from "../../app.constants";
 
-export async function logoutGet(req: Request, res: Response): Promise<void> {
+export async function logoutPost(req: Request, res: Response): Promise<void> {
   const idToken = req.session.user.tokens.idToken;
   logger.info(
     { trace: res.locals.trace },

--- a/src/components/logout/logout-routes.ts
+++ b/src/components/logout/logout-routes.ts
@@ -1,10 +1,10 @@
 import * as express from "express";
-import { logoutGet } from "./logout-controller";
+import { logoutPost } from "./logout-controller";
 import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 
 const router = express.Router();
 
-router.get(PATH_DATA.SIGN_OUT.url, requiresAuthMiddleware, logoutGet);
+router.post(PATH_DATA.SIGN_OUT.url, requiresAuthMiddleware, logoutPost);
 
 export { router as logoutRouter };

--- a/src/components/logout/tests/logout-controller.test.ts
+++ b/src/components/logout/tests/logout-controller.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { describe } from "mocha";
 
 import { sinon } from "../../../../test/utils/test-utils";
-import { logoutGet } from "../logout-controller";
+import { logoutPost } from "../logout-controller";
 import { logger } from "../../../utils/logger";
 import { ERROR_MESSAGES, LOG_MESSAGES } from "../../../app.constants";
 
@@ -51,7 +51,7 @@ describe("logout controller", () => {
 
     req.session.destroy = sandbox.fake();
 
-    logoutGet(req, res);
+      logoutPost(req, res);
 
     expect(req.session.destroy).to.have.been.calledOnce;
     expect(res.mockCookies.lo).to.equal("true");
@@ -65,7 +65,7 @@ describe("logout controller", () => {
 
   it("should log error when session destroy fails and continue with logout process", () => {
     const ERROR_MESSAGE = "error";
-    const mockSession = {
+    req.session = {
       user: {
         tokens: {
           idToken: "id-token",
@@ -76,9 +76,7 @@ describe("logout controller", () => {
       },
     };
 
-    req.session = mockSession;
-
-    logoutGet(req, res);
+    logoutPost(req, res);
 
     expect(errorLoggerSpy).to.have.been.calledWith(
       { trace: TEST_TRACE_ID },


### PR DESCRIPTION
## Proposed changes
Change sign-out link from GET to POST request

### What changed

There were two sign-out links, one inside the header and another one on the navigation. Both links were changed to buttons

### Why did it change

The use of POST for a logout feature is strongly recommended to enhance security, adhere to web standards and HTTP specifications, and ensure a better user experience. It mitigates the risk of CSRF attacks, keeps user actions intentional, and aligns with the principles of safe web navigation.

## Testing

Tested locally for both signed in and not signed in users to make sure the link only appears on logged in users only.
/sign-out path does not work any more unless it's a valid POST request

## How to review

Replicate the testing above in different environments
