### PR TITLE
OLH-1304: Ensure chat icon scales better on zoom

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -351,3 +351,25 @@ $nav-active-border-thickness: 5px;
     visibility: hidden;
   }
 }
+
+.sa-chat-tab { 
+  // limit size of webchat button when zoom is applied 
+  max-width: 25vw !important; 
+  max-height: 25vw !important;
+  bottom: 2vh !important;
+  right: 2vw !important;
+  left: auto !important;
+  @include govuk-media-query($from: tablet) {
+    max-width: 20vw !important; 
+    max-height: 20vw !important;
+  }
+}
+
+.sa-message-count {
+  // ensure webchat notification icon number is visible when zoom is applied
+  // the notification counter has fixed width and height which is no longer readable when text zoom is applied
+  min-height: 1.1em;
+  min-width: 1.1em;
+  --sa-message-count-x-position: -17%;
+  --sa-message-count-y-position: -20%;
+}


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
When browser zoom is applied, the chat button takes up a very large proportion of the viewport, obfuscating content and making the page difficult to navigate. 

There is also a separate issue when text zoom is applied where the text inside the notification counter becomes hard to read. 

This is an attempt to fix both those issues and making the button scale better by using relative units to set max and min dimensions on the relevant elements.

Ideally this type of issue should be addressed on the vendor's side. It's a brittle solution as these fixes could stop working or break the chat button (worst case scenario)  if class names of the elements are updated, or the approach to CSS changes on the vendor's side of things which we have zero control over. This is an interim attempt to address this on our side ahead of the accessibility audit in January but ideally in the long term it will be managed by the vendor. 

Note: some of the screenshots below are quite extreme examples: hopefully very few people out there are navigating OL at 500% zoom level.

| Browser zoom before  | Browser zoom after |
| ------------- | ------------- |
| <img width="875" alt="Screenshot 2023-12-21 at 09 51 28" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/0e0cdf04-a430-41ae-a5fc-f7c842d6f494">  | <img width="875" alt="Screenshot 2023-12-21 at 09 53 53" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/4f94cac6-cb98-4979-a7ba-5c559b6ab77f">  |

| Text only zoom before  | Text only zoom after |
| ------------- | ------------- |
|  ![Screenshot 2023-12-21 at 09 52 30](https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/508458f6-e46b-4bef-987d-a62cdef3408b)  |  ![Screenshot 2023-12-21 at 09 56 13](https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/1f8633ec-008d-4d66-a04f-4b703daf6d37) |



<!-- Describe the changes in detail - the "what"-->

### Why did it change
For accessibility reasons. 

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done -->

Please test this at different zoom levels on as many devices as you can. Ideally testing on a mobile device. The WCAG 2.1 AA requirement is content should scale up to 200%, but service manual recommendations are that we should try to support up to 4x magnification. I've used Browserstack to check this on different devices.
Verify that the button still looks as expected when it's not zoomed in/out as well.