### PR TITLE
OLH-1336 Use a singleton for the SQS client.

### DIFF
--- a/src/utils/sqs.ts
+++ b/src/utils/sqs.ts
@@ -3,12 +3,11 @@ import {
   SendMessageCommand,
   SendMessageCommandOutput,
   SendMessageRequest,
-  SQSClient,
 } from "@aws-sdk/client-sqs";
 import { logger } from "./logger";
-import { getSQSConfig, SqsConfig } from "../config/aws";
+import { sqsClient } from "../config/aws";
 
-export function sqsService(config: SqsConfig = getSQSConfig()): SqsService {
+export function sqsService(): SqsService {
   const send = async function (
     messageBody: string,
     trace: string
@@ -23,17 +22,15 @@ export function sqsService(config: SqsConfig = getSQSConfig()): SqsService {
       return;
     }
 
-    const client = new SQSClient(config.sqsClientConfig);
-
     const message: SendMessageRequest = {
       QueueUrl: AUDIT_QUEUE_URL,
       MessageBody: messageBody,
     };
 
     try {
-      const result: SendMessageCommandOutput = await client.send(
-        new SendMessageCommand(message)
-      );
+      const result: SendMessageCommandOutput = await sqsClient
+        .getClient()
+        .send(new SendMessageCommand(message));
       logger.info(
         { trace: trace },
         `Event sent with message id ${result.MessageId}`


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
Change the frontend so that it doesn't create a new SQS client every time it needs to publish an event.

### What changed

<!-- Describe the changes in detail - the "what"-->
Introduced a new singleton SQS client object.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
In prod we are seeing CredentialsProviderError which we think is due to the existing pattern of creating a new SQS client every time an event is published.  

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

<!-- Provide a summary of any manual testing you've done -->
It is deployed in dev.  I have visited the triage page several times and seen audit events published each time.  I visited the page over a period greater than an hour to check that the temporary creds that the client obtains are refreshed.

The error was seen in the build environment when running a performance test against the triage page.  To gain confidence this fixes the issue we could run the perf test over a longer period than previously run.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
