### PR TITLE
[OLH-1317] Reduce number of logging messages by excluding the healthcheck

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -54,6 +54,7 @@ const loggerMiddleware = PinoHttp({
       "/assets/fonts/bold-b542beb274-v2.woff2",
       "/assets/images/favicon.ico",
       "/assets/fonts/light-94a07e06a1-v2.woff2",
+      "/healthcheck",
     ],
   },
   customErrorMessage: function (error, res) {


### PR DESCRIPTION
## Proposed changes

This adds the /healthcheck route to the list of paths for the logger to ignore.

### Why did it change

The log message does not add any real value and clutters up the logs.

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I have run this locally; and verified that without the change, a log item appears when the endpoint is hit. And with the change, the log item does not appear.