### PR TITLE
OLH-1368 - Onboard Veterans Card.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -151,6 +151,8 @@ export const getAllowedServiceListClientIDs: string[] = [
   "dbs",
   "vehicleOperatorLicense",
   "mortgageDeed",
+  "zFeCxrwpLCUHFm-C4_CztwWtLfQ",
+  "veteransCard",
 ];
 
 function getProtocol(): string {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -210,7 +210,12 @@
           "listItems": [
             {
               "text": "Gwasanaeth asesu prentisiaeth (AAS)",
-              "href":  "https://assessors.apprenticeships.education.gov.uk/"},
+              "href":  "https://assessors.apprenticeships.education.gov.uk/"
+            },
+            {
+              "text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+              "href": "https://www.gov.uk/veteran-card"
+            },
             {
               "text": "Cofrestrfa datganiad caethwasiaeth modern",
               "href": "https://www.gov.uk/guidance/add-your-modern-slavery-statement-to-the-statement-registry"
@@ -663,6 +668,11 @@
         "description": "Anfonwch eich mesurau effeithlonrwydd ynni cwsmeriaid wedi'u cwblhau i Ofgem i'w hadolygu.",
         "link_text": "Ewch i'ch dangosfwrdd GBIS",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "zFeCxrwpLCUHFm-C4_CztwWtLfQ": {
+        "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "integration": {
@@ -751,6 +761,11 @@
         "description": "Anfonwch eich mesurau effeithlonrwydd ynni cwsmeriaid wedi'u cwblhau i Ofgem i'w hadolygu.",
         "link_text": "Ewch i'ch dangosfwrdd GBIS",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "zFeCxrwpLCUHFm-C4_CztwWtLfQ": {
+        "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "staging": {
@@ -839,6 +854,11 @@
         "description": "Anfonwch eich mesurau effeithlonrwydd ynni cwsmeriaid wedi'u cwblhau i Ofgem i'w hadolygu.",
         "link_text": "Ewch i'ch dangosfwrdd GBIS",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "build": {
@@ -927,7 +947,13 @@
         "description": "Anfonwch eich mesurau effeithlonrwydd ynni cwsmeriaid wedi'u cwblhau i Ofgem i'w hadolygu.",
         "link_text": "Ewch i'ch dangosfwrdd GBIS",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
+
     },
     "dev": {
       "gov-uk": {
@@ -1015,6 +1041,11 @@
         "description": "Anfonwch eich mesurau effeithlonrwydd ynni cwsmeriaid wedi'u cwblhau i Ofgem i'w hadolygu.",
         "link_text": "Ewch i'ch dangosfwrdd GBIS",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "local": {
@@ -1103,6 +1134,11 @@
         "description": "Anfonwch eich mesurau effeithlonrwydd ynni cwsmeriaid wedi'u cwblhau i Ofgem i'w hadolygu.",
         "link_text": "Ewch i'ch dangosfwrdd GBIS",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -213,6 +213,10 @@
               "href": "https://www.gov.uk/apply-vehicle-operator-licence"
             },
             {
+              "text": "Apply for an HM Armed Forces Veteran Card",
+              "href": "https://www.gov.uk/veteran-card"
+            },
+            {
               "text": "Apply to become a registered social worker in England",
               "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
             },
@@ -665,6 +669,11 @@
         "description": "Send your completed customer energy efficiency measures to Ofgem for review.",
         "link_text": "Go to your GBIS dashboard",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "zFeCxrwpLCUHFm-C4_CztwWtLfQ": {
+        "header": "Apply for an HM Armed Forces Veteran Card",
+        "link_text": "Apply for an HM Armed Forces Veteran Card",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "integration": {
@@ -753,6 +762,11 @@
         "description": "Send your completed customer energy efficiency measures to Ofgem for review.",
         "link_text": "Go to your GBIS dashboard",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "zFeCxrwpLCUHFm-C4_CztwWtLfQ": {
+        "header": "Apply for an HM Armed Forces Veteran Card",
+        "link_text": "Apply for an HM Armed Forces Veteran Card",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "staging": {
@@ -841,6 +855,11 @@
         "description": "Send your completed customer energy efficiency measures to Ofgem for review.",
         "link_text": "Go to your GBIS dashboard",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Apply for an HM Armed Forces Veteran Card",
+        "link_text": "Apply for an HM Armed Forces Veteran Card",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "build": {
@@ -929,6 +948,11 @@
         "description": "Send your completed customer energy efficiency measures to Ofgem for review.",
         "link_text": "Go to your GBIS dashboard",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Apply for an HM Armed Forces Veteran Card",
+        "link_text": "Apply for an HM Armed Forces Veteran Card",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "dev": {
@@ -1017,6 +1041,11 @@
         "description": "Send your completed customer energy efficiency measures to Ofgem for review.",
         "link_text": "Go to your GBIS dashboard",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Apply for an HM Armed Forces Veteran Card",
+        "link_text": "Apply for an HM Armed Forces Veteran Card",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     },
     "local": {
@@ -1105,6 +1134,11 @@
         "description": "Send your completed customer energy efficiency measures to Ofgem for review.",
         "link_text": "Go to your GBIS dashboard",
         "link_href": "https://gbinsulationscheme.ofgem.gov.uk/"
+      },
+      "veteransCard": {
+        "header": "Apply for an HM Armed Forces Veteran Card",
+        "link_text": "Apply for an HM Armed Forces Veteran Card",
+        "link_href": "https://www.gov.uk/veteran-card"
       }
     }
   }


### PR DESCRIPTION
## Proposed changes

[OLD-1368] Add support for HM Armed Forces Veteran Card

### What changed

- Add `veteransCard` as an allowed clientID
- Show a link to the veterans card page when the user has that in their recent activity
- Display veterans card link in the "Services you can use with GOV.UK One Login" List
- Add Welsh translation

### Why did it change

The Veterans Card service is going live soon, and we need to support it

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

## Testing

Verified that the link shows when the activity is present, and that the links work