### PR TITLE
OLH-1375: Emergency messaging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,5 +25,6 @@ WEBCHAT_STYLES_SOURCE_PATH=https://dev-chat-loader.smartagent.app/css/
 SUPPORT_WEBCHAT_CONTACT=1
 SUPPORT_PHONE_CONTACT=1
 SHOW_CONTACT_GUIDANCE=1
+SHOW_CONTACT_EMERGENCY_MESSAGE=0
 CONTACT_EMAIL_SERVICE_URL=https://signin.staging.account.gov.uk/contact-us-from-triage-page
 AUDIT_QUEUE_URL=

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -159,6 +159,7 @@ Mappings:
       SUPPORTWEBCHATCONTACT: "0"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"
+      SHOWCONTACTEMERGENCYMESSAGE: "1"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     build:
@@ -181,6 +182,7 @@ Mappings:
       SUPPORTWEBCHATCONTACT: "0"
       SUPPORTPHONECONTACT: "0"
       SHOWCONTACTGUIDANCE: "1"
+      SHOWCONTACTEMERGENCYMESSAGE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     staging:
@@ -203,6 +205,7 @@ Mappings:
       SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"
+      SHOWCONTACTEMERGENCYMESSAGE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     integration:
@@ -225,6 +228,7 @@ Mappings:
       SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"
+      SHOWCONTACTEMERGENCYMESSAGE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.integration.account.gov.uk/contact-us-from-triage-page"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     production:
@@ -247,6 +251,7 @@ Mappings:
       SUPPORTWEBCHATCONTACT: "0"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"
+      SHOWCONTACTEMERGENCYMESSAGE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.account.gov.uk/contact-us-from-triage-page"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
 
@@ -701,6 +706,13 @@ Resources:
                   EnvironmentVariables,
                   !Ref Environment,
                   SHOWCONTACTGUIDANCE,
+                ]
+            - Name: "SHOW_CONTACT_EMERGENCY_MESSAGE"
+              Value:
+                !FindInMap [
+                  EnvironmentVariables,
+                  !Ref Environment,
+                  SHOWCONTACTEMERGENCYMESSAGE,
                 ]
             - Name: "CONTACT_EMAIL_SERVICE_URL"
               Value:

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -22,6 +22,7 @@ $govuk-new-link-styles: true;
 @import "components/phase-banner/phase-banner";
 @import "components/skip-link/skip-link";
 @import "components/summary-list/summary-list";
+@import "components/warning-text/warning-text";
 // end Design System component imports
 
 .information-box {

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -6,6 +6,7 @@ import {
   getWebchatUrl,
   getWebchatStylesSource,
   showContactGuidance,
+  showContactEmergencyMessage,
   supportPhoneContact,
   supportWebchatContact,
 } from "../../config";
@@ -55,6 +56,7 @@ const render = (req: Request, res: Response): void => {
     contactWebchatEnabled: supportWebchatContact(),
     contactPhoneEnabled: supportPhoneContact(),
     showContactGuidance: showContactGuidance(),
+    showContactEmergencyMessage: showContactEmergencyMessage(),
     showSignOut: isAuthenticated && !isLoggedOut,
     referenceCode,
     contactEmailServiceUrl: PATH_DATA.TRACK_AND_REDIRECT.url,

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -1,5 +1,6 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% set pageTitleName = 'pages.contact.title' | translate %}
 {% set hideAccountNavigation = true %}
 {% set languageToggle = true %}
@@ -58,6 +59,11 @@
         <p class="govuk-body">{{ paragraph }}</p>
       {% endfor %}
     {% endif %}
+
+    {{ govukWarningText({
+      html: 'pages.contact.section3.phone.waitingTimeWarning' | translate | replace('[contactEmailServiceUrl]', contactEmailServiceUrl),
+      iconFallbackText: "Warning"
+    }) if showContactEmergencyMessage }}
 
     {{ govukInsetText({
       html: insetTextHtml

--- a/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
+++ b/src/components/contact-govuk-one-login/tests/contact-govuk-one-login-controller.test.ts
@@ -63,6 +63,7 @@ describe("Contact GOV.UK One Login controller", () => {
     process.env.SUPPORT_TRIAGE_PAGE = "1";
     process.env.SUPPORT_PHONE_CONTACT = "1";
     process.env.SHOW_CONTACT_GUIDANCE = "1";
+    process.env.SHOW_CONTACT_EMERGENCY_MESSAGE = "1";
     process.env.SUPPORT_WEBCHAT_CONTACT = "1";
     process.env.CONTACT_EMAIL_SERVICE_URL =
       "https://signin.account.gov.uk/contact-us";
@@ -77,6 +78,7 @@ describe("Contact GOV.UK One Login controller", () => {
     delete process.env.SUPPORT_TRIAGE_PAGE;
     delete process.env.SUPPORT_PHONE_CONTACT;
     delete process.env.SHOW_CONTACT_GUIDANCE;
+    delete process.env.SHOW_CONTACT_EMERGENCY_MESSAGE;
     delete process.env.SUPPORT_WEBCHAT_CONTACT;
     delete process.env.CONTACT_EMAIL_SERVICE_URL;
     delete process.env.WEBCHAT_SOURCE_URL;
@@ -97,6 +99,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
         contactEmailServiceUrl: "/track-and-redirect",
@@ -129,6 +132,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: false,
         referenceCode: MOCK_REFERENCE_CODE,
         contactEmailServiceUrl: "/track-and-redirect",
@@ -165,6 +169,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
         webchatSource: "https://example.com",
@@ -205,6 +210,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
         webchatSource: "https://example.com",
@@ -237,6 +243,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
         webchatSource: "https://example.com",
@@ -274,6 +281,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: true,
         referenceCode: MOCK_REFERENCE_CODE,
         webchatSource: "https://example.com",
@@ -297,6 +305,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: true,
         referenceCode: "654321",
         contactEmailServiceUrl: "/track-and-redirect",
@@ -322,6 +331,7 @@ describe("Contact GOV.UK One Login controller", () => {
         contactWebchatEnabled: true,
         contactPhoneEnabled: true,
         showContactGuidance: true,
+        showContactEmergencyMessage: true,
         showSignOut: false,
         referenceCode: "654321",
         contactEmailServiceUrl: "/track-and-redirect",

--- a/src/config.ts
+++ b/src/config.ts
@@ -193,6 +193,10 @@ export function showContactGuidance(): boolean {
   return process.env.SHOW_CONTACT_GUIDANCE === "1";
 }
 
+export function showContactEmergencyMessage(): boolean {
+  return process.env.SHOW_CONTACT_EMERGENCY_MESSAGE === "1";
+}
+
 export function getContactEmailServiceUrl(): string {
   return process.env.CONTACT_EMAIL_SERVICE_URL;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -556,7 +556,8 @@
             "Oriau agor:<br>Dydd Llun i ddydd Gwener, 8am i 8pm <br>Penwythnosau a gwyliau cyhoeddus, 9am i 5:30pm",
             "<a class=\"govuk-link\" href=\"[callChargesLinkHref]\">Darganfyddwch fwy am gostau galwadau</a>"
           ],
-          "callChargesLinkHref": "https://www.gov.uk/call-charges"
+          "callChargesLinkHref": "https://www.gov.uk/call-charges",
+          "waitingTimeWarning": "Mae amseroedd aros hir ar y ffôn ar hyn o bryd. Os nad yw'ch galwad yn un brys, rhowch gynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\">cwblhewch y ffurflen gyswllt</a>."
         },
         "email": {
           "heading": "E-bost",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -557,7 +557,8 @@
             "Opening times:<br>Monday to Friday, 8am to 8pm <br>Weekends and public holidays, 9am to 5.30pm",
             "<a class=\"govuk-link\" href=\"[callChargesLinkHref]\">Find out about call charges</a>"
           ],
-          "callChargesLinkHref": "https://www.gov.uk/call-charges"
+          "callChargesLinkHref": "https://www.gov.uk/call-charges",
+          "waitingTimeWarning": "There are currently long waiting times on the phone. If your call is not urgent, try again later or <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\">fill in the contact form</a>."
         },
         "email": {
           "heading": "Email",


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed & why
We have been asked to publish "emergency messaging" on the contact
triage page in the event that the contact centre is overwhelmed by
calls.
This is a preemptive measure ahead of the Veterans ID card service, a
high profile service, onboarding with OL soon.
Welsh language version still TBD. This adds the English language version
of the content in the Design System "warning text" style.


![image](https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/4fb8b197-783e-40b0-ae37-0fc522a62de8)


The warning is behind a flag which is currently switched off in all envs except dev. 


### Related links
https://govukverify.atlassian.net/browse/OLH-1375
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing
Done manual testing locally checking the content and visual appearance against the mockup provided. 
<!-- Provide a summary of any manual testing you've done -->

## How to review
Please sense check the feature flag and confirm that the content is correct.
<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
