### PR TITLE
OLH-1378: Add Early Years Child Development card

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -138,6 +138,8 @@ export const getAllowedAccountListClientIDs: string[] = [
   "aas",
   "FakIq5aYsHQ02dBOc6XwyA1wRRs",
   "gbis",
+  "txsGLvMYYCPaWPZRq2L7XxEnyro",
+  "childDevelopmentTraining",
 ];
 
 export const getAllowedServiceListClientIDs: string[] = [

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -253,6 +253,10 @@
               "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
             },
             {
+              "text": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+              "href": "https://child-development-training.education.gov.uk/"
+            },
+            {
               "text": "Llofnodwch eich gweithred morgais",
               "href": "https://sign-your-mortgage-deed.landregistry.gov.uk"
             },
@@ -674,6 +678,12 @@
         "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "txsGLvMYYCPaWPZRq2L7XxEnyro": {
+        "header": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
+        "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "integration": {
@@ -767,6 +777,12 @@
         "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "txsGLvMYYCPaWPZRq2L7XxEnyro": {
+        "header": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
+        "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "staging": {
@@ -860,6 +876,12 @@
         "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
+        "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "build": {
@@ -953,6 +975,12 @@
         "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
+        "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
 
     },
@@ -1047,6 +1075,12 @@
         "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
+        "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "local": {
@@ -1140,6 +1174,12 @@
         "header": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
+        "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -233,6 +233,10 @@
               "href": "https://www.gov.uk/claim-compensation-criminal-injury/make-claim"
             },
             {
+              "text": "Early years child development training",
+              "href": "https://child-development-training.education.gov.uk/"
+            },
+            {
               "text": "Find and apply for a grant",
               "href": "https://www.gov.uk/guidance/find-government-grants"
             },
@@ -675,6 +679,12 @@
         "header": "Apply for an HM Armed Forces Veteran Card",
         "link_text": "Apply for an HM Armed Forces Veteran Card",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "txsGLvMYYCPaWPZRq2L7XxEnyro": {
+        "header": "Early years child development training",
+        "description": "Training on child development, including advice on supporting child development in your early years setting.",
+        "link_text": "Go to your early years child development training account",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "integration": {
@@ -768,6 +778,12 @@
         "header": "Apply for an HM Armed Forces Veteran Card",
         "link_text": "Apply for an HM Armed Forces Veteran Card",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "txsGLvMYYCPaWPZRq2L7XxEnyro": {
+        "header": "Early years child development training",
+        "description": "Training on child development, including advice on supporting child development in your early years setting.",
+        "link_text": "Go to your early years child development training account",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "staging": {
@@ -861,6 +877,12 @@
         "header": "Apply for an HM Armed Forces Veteran Card",
         "link_text": "Apply for an HM Armed Forces Veteran Card",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Early years child development training",
+        "description": "Training on child development, including advice on supporting child development in your early years setting.",
+        "link_text": "Go to your early years child development training account",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "build": {
@@ -954,6 +976,12 @@
         "header": "Apply for an HM Armed Forces Veteran Card",
         "link_text": "Apply for an HM Armed Forces Veteran Card",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Early years child development training",
+        "description": "Training on child development, including advice on supporting child development in your early years setting.",
+        "link_text": "Go to your early years child development training account",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "dev": {
@@ -1047,6 +1075,12 @@
         "header": "Apply for an HM Armed Forces Veteran Card",
         "link_text": "Apply for an HM Armed Forces Veteran Card",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Early years child development training",
+        "description": "Training on child development, including advice on supporting child development in your early years setting.",
+        "link_text": "Go to your early years child development training account",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     },
     "local": {
@@ -1140,6 +1174,12 @@
         "header": "Apply for an HM Armed Forces Veteran Card",
         "link_text": "Apply for an HM Armed Forces Veteran Card",
         "link_href": "https://www.gov.uk/veteran-card"
+      },
+      "childDevelopmentTraining": {
+        "header": "Early years child development training",
+        "description": "Training on child development, including advice on supporting child development in your early years setting.",
+        "link_text": "Go to your early years child development training account",
+        "link_href": "https://child-development-training.education.gov.uk/my-modules"
       }
     }
   }


### PR DESCRIPTION
**DO NOT MERGE (YET)**: The Early Years Child Development Training has a target go-live date of ~31st January 2024~ February 5th 2024.

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
This adds the Early Years Child Development Training service card to the account dashboard, and to the list of services that can be used with OL. 


<!-- Describe the changes in detail - the "what"-->

### Why did it change
This service is onboarding on the ~31st~ 5th of February. 

<!-- Describe the reason these changes were made - the "why" -->

### Related links
https://govukverify.atlassian.net/browse/OLH-1378
https://govukverify.atlassian.net/browse/DOT-478 
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Check the content being added against the information in the JIRA ticket.