### PR TITLE
OLH-1363: Remove old env var from the template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -672,13 +672,6 @@ Resources:
                   !Ref Environment,
                   WEBCHATSOURCEURL,
                 ]
-            - Name: "WEBCHAT_STYLES_SOURCE_PATH"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  WEBCHATSTYLESSOURCEPATH,
-                ]
             - Name: "SUPPORT_WEBCHAT_CONTACT"
               Value:
                 !FindInMap [


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Remove old env var from the template

### Why did it change

I missed this in #1163, and it's causing the build to fail

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
