### PR TITLE
OLH-1505: Refactor date formatting function

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -132,6 +132,15 @@ export enum LOCALE {
   CY = "cy",
 }
 
+export interface LanguageCodes {
+  en: 'en-GB',
+  cy: 'cy-CY'
+}
+export const LANGUAGE_CODES: LanguageCodes = {
+  en: "en-GB",
+  cy: "cy-CY",
+}
+
 export const LOG_MESSAGES = {
   ATTEMPTING_TO_DESTROY_SESSION: "Attempting to destroy session",
   GS_COOKIE_NOT_IN_REQUEST: "gs cookie not in request.",

--- a/src/components/sign-in-history/sign-in-history-controller.ts
+++ b/src/components/sign-in-history/sign-in-history-controller.ts
@@ -38,7 +38,8 @@ export async function signInHistoryGet(
             : { currentPage: 1 };
         FormattedActivityLog = await formatData(
           validActivityData,
-          pagination?.currentPage
+          pagination?.currentPage,
+          req.i18n.language
         );
         showExplanation = hasExplanationParagraph(FormattedActivityLog);
       }

--- a/src/components/sign-in-history/tests/sign-in-history-controller.test.ts
+++ b/src/components/sign-in-history/tests/sign-in-history-controller.test.ts
@@ -47,6 +47,7 @@ describe("Sign in history controller", () => {
           destroy: sandbox.fake(),
         },
         log: { error: sandbox.fake() },
+        i18n: { language: "en"}
       };
       await signInHistoryGet(req as Request, res as Response).then(() => {
         expect(res.render).to.have.been.calledWith(

--- a/src/components/your-services/tests/your-services-controller.test.ts
+++ b/src/components/your-services/tests/your-services-controller.test.ts
@@ -30,6 +30,7 @@ describe("your services controller", () => {
         destroy: sandbox.fake(),
       },
       log: { error: sandbox.fake() },
+      i18n: { language: "en"},
     };
   }
 

--- a/src/components/your-services/your-services-controller.ts
+++ b/src/components/your-services/your-services-controller.ts
@@ -10,7 +10,7 @@ export async function yourServicesGet(
   const env = getAppEnv();
   if (user && user.subjectId) {
     const trace = res.locals.sessionId;
-    const serviceData = await presentYourServices(user.subjectId, trace);
+    const serviceData = await presentYourServices(user.subjectId, trace, req.i18n.language);
     const data = {
       email: req.session.user.email,
       accountsList: serviceData.accountsList,

--- a/src/utils/prettifyDate.ts
+++ b/src/utils/prettifyDate.ts
@@ -1,5 +1,15 @@
-export const prettifyDate = (dateEpoch: number, options?: Record<string, unknown>): string => {
-  const params = options || { dateStyle: "long" }
+import { LANGUAGE_CODES } from "../app.constants";
+
+export const prettifyDate = ({ 
+    dateEpoch, 
+    locale, 
+    options = { dateStyle: "long" }
+  }: {
+    dateEpoch: number,
+    locale?: string,
+    options?: Intl.DateTimeFormatOptions
+  }): string => {
+  const languageCode = LANGUAGE_CODES[locale as keyof typeof LANGUAGE_CODES] || "en-GB";
   let dateEpochInMilliSeconds: number;
   if (dateEpoch.toString().length === 10) {
     // Epoch is in seconds
@@ -9,7 +19,7 @@ export const prettifyDate = (dateEpoch: number, options?: Record<string, unknown
     dateEpochInMilliSeconds = dateEpoch;
   }
 
-  return new Intl.DateTimeFormat("en-GB", params).format(
+  return new Intl.DateTimeFormat(languageCode, options).format(
     new Date(dateEpochInMilliSeconds)
   );
 };

--- a/src/utils/signInHistory.ts
+++ b/src/utils/signInHistory.ts
@@ -104,7 +104,8 @@ export const generatePagination = (dataLength: number, page: any): [] => {
 
 export const formatData = async (
   data: ActivityLogEntry[],
-  currentPage: number = 1
+  currentPage: number = 1,
+  currentLanguage?: string
 ): Promise<FormattedActivityLog[]> => {
   const indexStart = (currentPage - 1) * activityLogItemsPerPage;
   const indexEnd = indexStart + activityLogItemsPerPage;
@@ -122,15 +123,19 @@ export const formatData = async (
       session_id,
     } = entry;
 
-    const timeFormatted = prettifyDate(Number(timestamp), {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "numeric",
-      hourCycle: "h12",
-      timeZone: "GB",
-    });
+    const timeFormatted = prettifyDate({
+      dateEpoch: Number(timestamp), 
+      options: {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hourCycle: "h12",
+        timeZone: "GB",
+    },
+    locale: currentLanguage
+  });
 
     FormattedActivityLog.push({
       userId: user_id,

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -40,12 +40,13 @@ const getServices = async (
 
 export const presentYourServices = async (
   subjectId: string,
-  trace: string
+  trace: string,
+  currentLanguage?: string
 ): Promise<YourServices> => {
   const userServices = await getServices(subjectId, trace);
   if (userServices) {
     const userServicesWithPresentableDates = userServices.map((service) =>
-      formatService(service)
+      formatService(service, currentLanguage)
     );
     return {
       accountsList: userServicesWithPresentableDates.filter((service) =>
@@ -80,8 +81,11 @@ export const getAllowedListServices = async (
   }
 };
 
-export const formatService = (service: Service): Service => {
-  const readable_format_date = prettifyDate(service.last_accessed);
+export const formatService = (service: Service, currentLanguage?: string): Service => {
+  const readable_format_date = prettifyDate({
+    dateEpoch: service.last_accessed, 
+    locale: currentLanguage,
+  });
   const isHMRC = hmrcClientIds.includes(service.client_id);
   return {
     client_id: service.client_id,

--- a/test/unit/utils/prettifyDate.test.ts
+++ b/test/unit/utils/prettifyDate.test.ts
@@ -3,13 +3,36 @@ import { describe } from "mocha";
 import { prettifyDate } from "../../../src/utils/prettifyDate";
 
 describe("PrettifyDate util", () => {
-    it("It takes a date epoch in seconds and returns a pretty formatted date", async () => {
-        const dateEpochInSeconds = 1673358736;
-        expect(prettifyDate(dateEpochInSeconds)).equal("10 January 2023");
-    });
+  it("takes a date epoch in seconds and returns a pretty formatted date", async () => {
+    const dateEpochInSeconds = 1673358736;
+    expect(prettifyDate({dateEpoch: dateEpochInSeconds})).equal("10 January 2023");
+  });
     
-    it("It takes a date epoch in milliseconds and returns a pretty formatted date", async () => {
+  it("takes a date epoch in milliseconds and returns a pretty formatted date", async () => {
     const dateEpochInSeconds = 2382450028987;
-    expect(prettifyDate(dateEpochInSeconds)).equal("30 June 2045");
-    });
+    expect(prettifyDate({dateEpoch: dateEpochInSeconds })).equal("30 June 2045");
+  });
+
+  it("allows passing formatting options", async () => {
+    const dateEpochInSeconds = 1673358736;
+    expect(prettifyDate({dateEpoch: dateEpochInSeconds, options: {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      hourCycle: "h12",
+      timeZone: "GB",
+    }})).equal("10 January 2023 at 1:52 pm");
+  });
+
+  it("returns Welsh version when locale parameter is 'cy'", async () => {
+    const dateEpochInSeconds = 2382450028987;
+    expect(prettifyDate({dateEpoch: dateEpochInSeconds, locale: "cy" })).equal("30 Mehefin 2045");
+  });
+
+  it("returns date in English if locale parameter is invalid", async () => {
+    const dateEpochInSeconds = 2382450028987;
+    expect(prettifyDate({dateEpoch: dateEpochInSeconds, locale: "asdf" })).equal("30 June 2045");
+  });
 }) 

--- a/test/unit/utils/signInHistory.test.ts
+++ b/test/unit/utils/signInHistory.test.ts
@@ -62,7 +62,7 @@ describe("Sign in History Util", () => {
         .fill(0)
         .map(createLogEntry);
 
-      const FormattedActivityLog = await formatData(longData, 2);
+      const FormattedActivityLog = await formatData(longData, 2, "cy");
 
       expect(FormattedActivityLog.length).equal(3);
     });
@@ -80,7 +80,7 @@ describe("Sign in History Util", () => {
         },
       ];
 
-      const FormattedActivityLog = await formatData(data, 1);
+      const FormattedActivityLog = await formatData(data, 1, "en-GB");
 
       expect(FormattedActivityLog[0].eventType).equal("signedIn");
       expect(FormattedActivityLog[0].clientId).equal(

--- a/test/unit/utils/yourServices.test.ts
+++ b/test/unit/utils/yourServices.test.ts
@@ -17,7 +17,7 @@ describe("YourService Util", () => {
         last_accessed_readable_format: undefined,
       };
 
-      const formattedService: Service = formatService(serviceFromDb);
+      const formattedService: Service = formatService(serviceFromDb, "en");
 
       expect(formattedService.client_id).equal("a_client_id");
       expect(formattedService.count_successful_logins).equal(1);


### PR DESCRIPTION
## Proposed changes
The `prettifyDate` util was hard coded to return dates in `en-GB`. There is a need to display dates in Welsh when the user is viewing their OL home in Welsh.
This refactors the formatter to allow an additional locale parameter to be passed in, to display dates in Welsh when the language has been set to Welsh.
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Extend `prettifyDate` to accept a language parameter which should be one of 'en' or 'cy'. 
If language is not specified, or the parameter has a value other than 'en' or 'cy', default to returning dates in English. 
Refactor the parts of the code which rely on `prettifyDate`, ensuring a language parameter is passed.
`prettifyDate` now accepts named parameters.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Welsh language support is a requirement.

<!-- Describe the reason these changes were made - the "why" -->

### Related links
https://govukverify.atlassian.net/browse/OLH-1505
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing
Automated testing and manual testing of `prettifyDate` passing different options
<!-- Provide a summary of any manual testing you've done -->

## How to review
Code review and reviewing the different pages that rely on the `prettifyDate` function, in English and Welsh

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
