### PR TITLE
OLH-1456: Add HMRC card to the service dashboard

### DIFF
--- a/localstack/provision.sh
+++ b/localstack/provision.sh
@@ -31,7 +31,7 @@ aws --endpoint-url=http://localhost:4566 dynamodb put-item \
                 "N": "4"
               },
               "client_id": {
-                "S": "gov.uk"
+                "S": "gov-uk"
               },
               "last_accessed": {
                 "N": "1666169856"
@@ -47,10 +47,42 @@ aws --endpoint-url=http://localhost:4566 dynamodb put-item \
                 "N": "4"
               },
               "client_id": {
-                "S": "cqGoT1LYLsjn-iwGcDTzamckhZU"
+                "S": "connectFamilies"
               },
               "last_accessed": {
                 "N": "1666169856"
+              },
+              "last_accessed_pretty": {
+                "S": "20 January 1970"
+              }
+            }
+          },
+          {
+            "M": {
+              "count_successful_logins": {
+                "N": "4"
+              },
+              "client_id": {
+                "S": "hmrc"
+              },
+              "last_accessed": {
+                "N": "1696969856"
+              },
+              "last_accessed_pretty": {
+                "S": "20 January 1970"
+              }
+            }
+          },
+          {
+            "M": {
+              "count_successful_logins": {
+                "N": "4"
+              },
+              "client_id": {
+                "S": "veteransCard"
+              },
+              "last_accessed": {
+                "N": "1699969996"
               },
               "last_accessed_pretty": {
                 "S": "20 January 1970"

--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -55,10 +55,23 @@
           {% set locale = ['clientRegistry.', env, '.', service.client_id, '.'] | join %}
           <li class="your-services__card">
             <div class="your-services__card__content">
-            <{{serviceHeadingLevel}} class="govuk-heading-s govuk-!-font-weight-regular" data-test-id="service-card-heading">
-              <a class="govuk-link" href="{{ [locale, 'link_href'] | join | translate }}">{{ [locale, 'link_text'] | join | translate }}</a>
-            </{{serviceHeadingLevel}}>
-            <p class="govuk-body your-services__card__last-used">{{ 'pages.yourServices.lastUsed' | translate }}: {{ service.last_accessed_readable_format }}</p>
+            {% if service.isHMRC %}
+            {# The HMRC service card contains more information than the regular ones #}
+              <{{serviceHeadingLevel}} class="govuk-heading-s" data-test-id="service-card-heading">
+                {{ [locale, 'header'] | join | translate }}
+              </{{serviceHeadingLevel}}>
+              <p class="govuk-hint">{{ [locale, 'hint_text'] | join | translate }}</p>
+              <hr class="govuk-section-break govuk-section-break--m  govuk-section-break--visible">
+              <p class="govuk-body">{{ [locale, 'paragraph1'] | join | translate }}</p>
+              <p class="govuk-body">{{ [locale, 'paragraph2'] | join | translate }}</p>
+              <p class="govuk-body"><a class="govuk-link" href="{{ [locale, 'link_href'] | join | translate }}">{{ [locale, 'link_text'] | join | translate }}</a></p>
+              <p class="govuk-body your-services__card__last-used">{{ 'pages.yourServices.lastUsed' | translate }}: {{ service.last_accessed_readable_format }}</p>
+            {% else %}
+              <{{serviceHeadingLevel}} class="govuk-heading-s govuk-!-font-weight-regular" data-test-id="service-card-heading">
+                <a class="govuk-link" href="{{ [locale, 'link_href'] | join | translate }}">{{ [locale, 'link_text'] | join | translate }}</a>
+              </{{serviceHeadingLevel}}>
+              <p class="govuk-body your-services__card__last-used">{{ 'pages.yourServices.lastUsed' | translate }}: {{ service.last_accessed_readable_format }}</p>
+            {% endif %}
             </div>
           </li>
         {% endfor %}

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,11 @@ export const getAllowedAccountListClientIDs: string[] = [
   "childDevelopmentTraining",
 ];
 
+export const hmrcClientIds: string[] = [
+  "mQDXGO7gWdK7V28v82nVcEGuacY",
+  "hmrc",
+]
+
 export const getAllowedServiceListClientIDs: string[] = [
   "RqFZ83csmS4Mi4Y7s7ohD9-ekwU",
   "XwwVDyl5oJKtK0DVsuw3sICWkPU",
@@ -157,6 +162,7 @@ export const getAllowedServiceListClientIDs: string[] = [
   "mortgageDeed",
   "zFeCxrwpLCUHFm-C4_CztwWtLfQ",
   "veteransCard",
+  ...hmrcClientIds
 ];
 
 function getProtocol(): string {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -693,6 +693,14 @@
         "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
         "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "mQDXGO7gWdK7V28v82nVcEGuacY": {
+        "header": "Gwasanaeth a weithredir gan Gyllid a Thollau EF (CThEF)",
+        "hint_text": "Er enghraifft gwasanaethau am dreth, gofal plant, neu bensiynau'r wladwriaeth.",
+        "paragraph1": "Ar hyn o bryd, ni all GOV.UK One Login ddangos i chi pa wasanaeth CThEF rydych wedi'i ddefnyddio.",
+        "paragraph2": "Rydym yn gweithio i wneud hyn yn bosibl.",
+        "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       }
     },
     "integration": {
@@ -798,6 +806,14 @@
         "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
         "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "mQDXGO7gWdK7V28v82nVcEGuacY": {
+        "header": "Gwasanaeth a weithredir gan Gyllid a Thollau EF (CThEF)",
+        "hint_text": "Er enghraifft gwasanaethau am dreth, gofal plant, neu bensiynau'r wladwriaeth.",
+        "paragraph1": "Ar hyn o bryd, ni all GOV.UK One Login ddangos i chi pa wasanaeth CThEF rydych wedi'i ddefnyddio.",
+        "paragraph2": "Rydym yn gweithio i wneud hyn yn bosibl.",
+        "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       }
     },
     "staging": {
@@ -903,6 +919,14 @@
         "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
         "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "Gwasanaeth a weithredir gan Gyllid a Thollau EF (CThEF)",
+        "hint_text": "Er enghraifft gwasanaethau am dreth, gofal plant, neu bensiynau'r wladwriaeth.",
+        "paragraph1": "Ar hyn o bryd, ni all GOV.UK One Login ddangos i chi pa wasanaeth CThEF rydych wedi'i ddefnyddio.",
+        "paragraph2": "Rydym yn gweithio i wneud hyn yn bosibl.",
+        "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       }
     },
     "build": {
@@ -1008,8 +1032,15 @@
         "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
         "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "Gwasanaeth a weithredir gan Gyllid a Thollau EF (CThEF)",
+        "hint_text": "Er enghraifft gwasanaethau am dreth, gofal plant, neu bensiynau'r wladwriaeth.",
+        "paragraph1": "Ar hyn o bryd, ni all GOV.UK One Login ddangos i chi pa wasanaeth CThEF rydych wedi'i ddefnyddio.",
+        "paragraph2": "Rydym yn gweithio i wneud hyn yn bosibl.",
+        "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       }
-
     },
     "dev": {
       "gov-uk": {
@@ -1114,6 +1145,14 @@
         "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
         "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "Gwasanaeth a weithredir gan Gyllid a Thollau EF (CThEF)",
+        "hint_text": "Er enghraifft gwasanaethau am dreth, gofal plant, neu bensiynau'r wladwriaeth.",
+        "paragraph1": "Ar hyn o bryd, ni all GOV.UK One Login ddangos i chi pa wasanaeth CThEF rydych wedi'i ddefnyddio.",
+        "paragraph2": "Rydym yn gweithio i wneud hyn yn bosibl.",
+        "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       }
     },
     "local": {
@@ -1219,6 +1258,14 @@
         "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
         "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "Gwasanaeth a weithredir gan Gyllid a Thollau EF (CThEF)",
+        "hint_text": "Er enghraifft gwasanaethau am dreth, gofal plant, neu bensiynau'r wladwriaeth.",
+        "paragraph1": "Ar hyn o bryd, ni all GOV.UK One Login ddangos i chi pa wasanaeth CThEF rydych wedi'i ddefnyddio.",
+        "paragraph2": "Rydym yn gweithio i wneud hyn yn bosibl.",
+        "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -695,6 +695,14 @@
         "description": "Training on child development, including advice on supporting child development in your early years setting.",
         "link_text": "Go to your early years child development training account",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "mQDXGO7gWdK7V28v82nVcEGuacY": {
+        "header": "A service run by HM Revenue and Customs (HMRC)",
+        "hint_text": "For example services about tax, childcare, or state pensions.",
+        "paragraph1": "At the moment, GOV.UK One Login cannot show you which HMRC service you’ve used.",
+        "paragraph2": "We’re working to make this possible.",
+        "link_text": "Find the HMRC service you need",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
     },
     "integration": {
@@ -800,6 +808,14 @@
         "description": "Training on child development, including advice on supporting child development in your early years setting.",
         "link_text": "Go to your early years child development training account",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "mQDXGO7gWdK7V28v82nVcEGuacY": {
+        "header": "A service run by HM Revenue and Customs (HMRC)",
+        "hint_text": "For example services about tax, childcare, or state pensions.",
+        "paragraph1": "At the moment, GOV.UK One Login cannot show you which HMRC service you’ve used.",
+        "paragraph2": "We’re working to make this possible.",
+        "link_text": "Find the HMRC service you need",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
     },
     "staging": {
@@ -905,6 +921,14 @@
         "description": "Training on child development, including advice on supporting child development in your early years setting.",
         "link_text": "Go to your early years child development training account",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "A service run by HM Revenue and Customs (HMRC)",
+        "hint_text": "For example services about tax, childcare, or state pensions.",
+        "paragraph1": "At the moment, GOV.UK One Login cannot show you which HMRC service you’ve used.",
+        "paragraph2": "We’re working to make this possible.",
+        "link_text": "Find the HMRC service you need",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
     },
     "build": {
@@ -1010,6 +1034,14 @@
         "description": "Training on child development, including advice on supporting child development in your early years setting.",
         "link_text": "Go to your early years child development training account",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "A service run by HM Revenue and Customs (HMRC)",
+        "hint_text": "For example services about tax, childcare, or state pensions.",
+        "paragraph1": "At the moment, GOV.UK One Login cannot show you which HMRC service you’ve used.",
+        "paragraph2": "We’re working to make this possible.",
+        "link_text": "Find the HMRC service you need",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
     },
     "dev": {
@@ -1115,6 +1147,14 @@
         "description": "Training on child development, including advice on supporting child development in your early years setting.",
         "link_text": "Go to your early years child development training account",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "A service run by HM Revenue and Customs (HMRC)",
+        "hint_text": "For example services about tax, childcare, or state pensions.",
+        "paragraph1": "At the moment, GOV.UK One Login cannot show you which HMRC service you’ve used.",
+        "paragraph2": "We’re working to make this possible.",
+        "link_text": "Find the HMRC service you need",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
     },
     "local": {
@@ -1220,6 +1260,14 @@
         "description": "Training on child development, including advice on supporting child development in your early years setting.",
         "link_text": "Go to your early years child development training account",
         "link_href": "https://child-development-training.education.gov.uk/my-modules"
+      },
+      "hmrc": {
+        "header": "A service run by HM Revenue and Customs (HMRC)",
+        "hint_text": "For example services about tax, childcare, or state pensions.",
+        "paragraph1": "At the moment, GOV.UK One Login cannot show you which HMRC service you’ve used.",
+        "paragraph2": "We’re working to make this possible.",
+        "link_text": "Find the HMRC service you need",
+        "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
     }
   }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,6 +13,7 @@ export interface Service {
   count_successful_logins: number;
   last_accessed: number;
   last_accessed_readable_format: string;
+  isHMRC?: boolean;
 }
 
 export interface YourServices {

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -4,6 +4,7 @@ import {
   getDynamoServiceStoreTableName,
   getAllowedAccountListClientIDs,
   getAllowedServiceListClientIDs,
+  hmrcClientIds,
 } from "../config";
 import { prettifyDate } from "./prettifyDate";
 import type { YourServices, Service } from "./types";
@@ -81,11 +82,13 @@ export const getAllowedListServices = async (
 
 export const formatService = (service: Service): Service => {
   const readable_format_date = prettifyDate(service.last_accessed);
+  const isHMRC = hmrcClientIds.includes(service.client_id);
   return {
     client_id: service.client_id,
     count_successful_logins: service.count_successful_logins,
     last_accessed: service.last_accessed,
     last_accessed_readable_format: readable_format_date,
+    isHMRC: isHMRC,
   };
 };
 


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Add content for the HMRC service card on the service dashboard. The card will live under "Other services you've used" as opposed to "Your accounts".

![Screenshot 2024-02-27 at 13 35 20](https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/ff89ca10-3418-4a49-82fa-c2e81ea69ddb)
![Screenshot 2024-02-27 at 13 35 53](https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/39024e9a-16eb-46ae-b736-109e02d65195)


It has a different design from the other services on the service dashboard due to the requirement to have more content to explain to users what the card is about. For the time being I handled this by adding an "isHMRC" flag which is true if the id of a service matches one of the HMRC client IDs.

For now we should not add this service to the "Services you can use" list as they'll be in private beta initially.

### Why did it change
HMRC is onboarding with OL at the end of Feb (initially as private beta) so they need a service card. 
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Tested locally and in dev, in isolation and with other service cards, in English and Welsh
<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
