### PR TITLE
OLH-1521 Make activity log and RSA available only if the user has certain service cards

### DIFF
--- a/src/components/activity-history/activity-history-routes.ts
+++ b/src/components/activity-history/activity-history-routes.ts
@@ -2,12 +2,14 @@ import * as express from "express";
 import { activityHistoryGet } from "./activity-history-controller";
 import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
+import { checkAllowedServicesList } from "../../middleware/check-allowed-services-list";
 
 const router = express.Router();
 
 router.get(
   PATH_DATA.SIGN_IN_HISTORY.url,
   requiresAuthMiddleware,
+  checkAllowedServicesList,
   activityHistoryGet
 );
 

--- a/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
@@ -8,12 +8,14 @@ import { PATH_DATA } from "../../app.constants";
 import { asyncHandler } from "../../utils/async";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
+import { checkAllowedServicesList } from "../../middleware/check-allowed-services-list";
 
 const router = express.Router();
 
 router.get(
   PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url,
   requiresAuthMiddleware,
+  checkAllowedServicesList,
   reportSuspiciousActivityGet
 );
 
@@ -21,6 +23,7 @@ router.post(
   PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done",
   requiresAuthMiddleware,
   refreshTokenMiddleware(),
+  checkAllowedServicesList,
   asyncHandler(reportSuspiciousActivityPost)
 );
 

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -1,15 +1,23 @@
 import { Request, Response } from "express";
 import { supportActivityLog } from "../../config";
 import { PATH_DATA } from "../../app.constants";
+import { hasHmrcService } from "../../middleware/check-allowed-services-list";
 
-export function securityGet(req: Request, res: Response): void {
+export async function securityGet(req: Request, res: Response): Promise<void> {
+  const { email, phoneNumber, isPhoneNumberVerified } = req.session.user;
+  const phoneNumberLastFourDigits = phoneNumber ? phoneNumber.slice(-4) : null;
+
+  const supportActivityLogFlag = supportActivityLog();
+  const hasHmrc = await hasHmrcService(req, res);
+
+  const activityLogUrl = PATH_DATA.SIGN_IN_HISTORY.url;
+
   const data = {
-    email: req.session.user.email,
-    phoneNumber:
-      req.session.user.phoneNumber && req.session.user.phoneNumber.slice(-4),
-    isPhoneNumberVerified: req.session.user.isPhoneNumberVerified,
-    supportActivityLog: supportActivityLog(),
-    activityLogUrl: PATH_DATA.SIGN_IN_HISTORY.url
+    email,
+    phoneNumber: phoneNumberLastFourDigits,
+    isPhoneNumberVerified,
+    supportActivityLog: supportActivityLogFlag && hasHmrc,
+    activityLogUrl,
   };
 
   res.render("security/index.njk", data);

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -21,23 +21,47 @@ describe("security controller", () => {
   });
 
   describe("securityGet", () => {
-    it("should render security view", () => {
+    it("should render security view", async () => {
       const configFuncs = require("../../../config");
       sandbox.stub(configFuncs, "supportActivityLog").callsFake(() => {
         return true;
       });
+      const hasHmrcServiceStub = require("../../../middleware/check-allowed-services-list");
+      sandbox.stub(hasHmrcServiceStub, "hasHmrcService").resolves(true);
       req.session.user = {
         email: "test@test.com",
         phoneNumber: "xxxxxxx7898",
         isPhoneNumberVerified: true,
       } as any;
-      securityGet(req as Request, res as Response);
+      await securityGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("security/index.njk", {
         email: "test@test.com",
         phoneNumber: "7898",
         isPhoneNumberVerified: true,
         supportActivityLog: true,
+        activityLogUrl: "/activity-history",
+      });
+    });
+    it("should render security view without activity log", async () => {
+      const configFuncs = require("../../../config");
+      sandbox.stub(configFuncs, "supportActivityLog").callsFake(() => {
+        return false;
+      });
+      const hasHmrcServiceStub = require("../../../middleware/check-allowed-services-list");
+      sandbox.stub(hasHmrcServiceStub, "hasHmrcService").resolves(true);
+      req.session.user = {
+        email: "test@test.com",
+        phoneNumber: "xxxxxxx7898",
+        isPhoneNumberVerified: true,
+      } as any;
+      await securityGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("security/index.njk", {
+        email: "test@test.com",
+        phoneNumber: "7898",
+        isPhoneNumberVerified: true,
+        supportActivityLog: false,
         activityLogUrl: "/activity-history",
       });
     });

--- a/src/components/your-services/your-services-controller.ts
+++ b/src/components/your-services/your-services-controller.ts
@@ -8,18 +8,23 @@ export async function yourServicesGet(
 ): Promise<void> {
   const { user } = req.session;
   const env = getAppEnv();
+  let data;
+
   if (user && user.subjectId) {
     const trace = res.locals.sessionId;
-    const serviceData = await presentYourServices(user.subjectId, trace, req.i18n.language);
-    const data = {
+    const serviceData = await presentYourServices(
+      user.subjectId,
+      trace,
+      req.i18n.language
+    );
+    data = {
       email: req.session.user.email,
       accountsList: serviceData.accountsList,
       servicesList: serviceData.servicesList,
       env: env,
     };
-
-    res.render("your-services/index.njk", data);
   } else {
-    res.render("your-services/index.njk", { email: user.email, env: env });
+    data = { email: user.email, env: env };
   }
+  res.render("your-services/index.njk", data);
 }

--- a/src/middleware/check-allowed-services-list.ts
+++ b/src/middleware/check-allowed-services-list.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from "express";
+import { hmrcClientIds } from "../config";
+import { getServices } from "../utils/yourServices";
+import { PATH_DATA } from "../app.constants";
+import type { Service } from "../utils/types";
+
+const findClientInServices = (
+  clientIds: string[],
+  services: Service[]
+): boolean => {
+  return clientIds.some((clientId) => {
+    return services.some(({ client_id }) => client_id === clientId);
+  });
+};
+export const hasHmrcService = async (
+  req: Request,
+  res: Response
+): Promise<boolean> => {
+  const { user } = req.session;
+  const { trace } = res.locals;
+
+  const userServices = await getServices(user.subjectId, trace);
+  return userServices && findClientInServices(hmrcClientIds, userServices);
+};
+
+export async function checkAllowedServicesList(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  if (await hasHmrcService(req, res)) {
+    next();
+  } else {
+    res.redirect(PATH_DATA.SECURITY.url);
+  }
+}

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -22,7 +22,7 @@ const serviceStoreDynamoDBRequest = (
 const unmarshallDynamoData = (dynamoDBResponse: DynamoDB.Types.AttributeMap) =>
   DynamoDB.Converter.unmarshall(dynamoDBResponse);
 
-const getServices = async (
+export const getServices = async (
   subjectId: string,
   trace: string
 ): Promise<Service[]> => {
@@ -49,11 +49,13 @@ export const presentYourServices = async (
       formatService(service, currentLanguage)
     );
     return {
-      accountsList: userServicesWithPresentableDates.filter((service) =>
-        getAllowedAccountListClientIDs.includes(service.client_id)
+      accountsList: filterServicesBasedOnClientIDs(
+        userServicesWithPresentableDates,
+        getAllowedAccountListClientIDs
       ),
-      servicesList: userServicesWithPresentableDates.filter((service) =>
-        getAllowedServiceListClientIDs.includes(service.client_id)
+      servicesList: filterServicesBasedOnClientIDs(
+        userServicesWithPresentableDates,
+        getAllowedServiceListClientIDs
       ),
     };
   } else {
@@ -62,6 +64,13 @@ export const presentYourServices = async (
       servicesList: [],
     };
   }
+};
+
+const filterServicesBasedOnClientIDs = (
+  services: Service[],
+  clientIDs: string[]
+): Service[] => {
+  return services.filter(({ client_id }) => clientIDs.includes(client_id));
 };
 
 export const getAllowedListServices = async (
@@ -81,9 +90,12 @@ export const getAllowedListServices = async (
   }
 };
 
-export const formatService = (service: Service, currentLanguage?: string): Service => {
+export const formatService = (
+  service: Service,
+  currentLanguage?: string
+): Service => {
   const readable_format_date = prettifyDate({
-    dateEpoch: service.last_accessed, 
+    dateEpoch: service.last_accessed,
     locale: currentLanguage,
   });
   const isHMRC = hmrcClientIds.includes(service.client_id);


### PR DESCRIPTION
[OLH-1521] Make activity log and RSA available only if the user has certain service cards

## Proposed changes

Only users with HMRC service in their list would be able to access the activity history page and report suspicious activity page

### What changed

Added checks to verify if the user has HMRC services in their list

### Why did it change

To reduce the risk of overwhelming TICF.


### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing

Unit, integration and local testing



[OLH-1521]: https://govukverify.atlassian.net/browse/OLH-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ