### PR TITLE
OLH-1565 Redirect the user after submitting a suspicious activity report.

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -154,8 +154,12 @@ export async function reportSuspiciousActivityPost(
     return next(err);
   }
 
+  res.redirect(PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done?page=" + page); 
+}
+
+export async function reportSuspiciousActivityConfirmation(req: Request, res: Response): Promise<void> {
   res.render("report-suspicious-activity/success.njk", {
-    backLink: `${PATH_DATA.SIGN_IN_HISTORY.url}?page=${page}`,
+    backLink: `${PATH_DATA.SIGN_IN_HISTORY.url}?page=${req.query.page || 1}`,
     email: req.session.user.email,
     contactLink: PATH_DATA.CONTACT.url,
     changePasswordLink: PATH_DATA.SECURITY.url,

--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -132,8 +132,6 @@ export async function reportSuspiciousActivityPost(
   res: Response,
   next: NextFunction
 ): Promise<void> {
-  const page = req.body.page;
-
   try {
     assert(req.session.user_id, "user_id not found in session");
     assert(req.session.user.email, "email not found in session");
@@ -154,7 +152,9 @@ export async function reportSuspiciousActivityPost(
     return next(err);
   }
 
-  res.redirect(PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done?page=" + page); 
+  const pageUrlParam = req.body.page ? `?page=${req.body.page}` : "";
+
+  res.redirect(PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done" + pageUrlParam); 
 }
 
 export async function reportSuspiciousActivityConfirmation(req: Request, res: Response): Promise<void> {

--- a/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
@@ -2,6 +2,7 @@ import * as express from "express";
 import {
   reportSuspiciousActivityGet,
   reportSuspiciousActivityPost,
+  reportSuspiciousActivityConfirmation,
 } from "./report-suspicious-activity-controller";
 import { PATH_DATA } from "../../app.constants";
 import { asyncHandler } from "../../utils/async";
@@ -21,6 +22,12 @@ router.post(
   requiresAuthMiddleware,
   refreshTokenMiddleware(),
   asyncHandler(reportSuspiciousActivityPost)
+);
+
+router.get(
+  PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done",
+  requiresAuthMiddleware,
+  reportSuspiciousActivityConfirmation
 );
 
 export { router as reportSuspiciousActivityRouter };

--- a/src/components/report-suspicious-activity/tests/report-suspicious-activity-controller.test.ts
+++ b/src/components/report-suspicious-activity/tests/report-suspicious-activity-controller.test.ts
@@ -56,6 +56,7 @@ describe("report suspicious activity controller", () => {
         sessionId: "session-id",
       },
       render: sandbox.fake(),
+      redirect: sandbox.fake(),
     };
     next = sandbox.fake();
     dynamodbQueryOutput = {
@@ -191,15 +192,7 @@ describe("report suspicious activity controller", () => {
       await reportSuspiciousActivityPost(req as Request, res as Response, () => {});
 
       // Assert
-      expect(res.render).to.have.been.calledWith(
-        "report-suspicious-activity/success.njk",
-        {
-          backLink: "/activity-history?page=1",
-          email: "test@email.moc",
-          contactLink: sinon.match.any,
-          changePasswordLink: sinon.match.any,
-        }
-      );
+      expect(res.redirect).to.have.been.calledWith("/activity-history/report-activity/done?page=1");
 
       const snsCall = snsPublishSpy.getCalls()[0];
       const [topic_arn, message] = snsCall.args;

--- a/src/utils/activityHistory.ts
+++ b/src/utils/activityHistory.ts
@@ -95,7 +95,8 @@ export const generatePagination = (dataLength: number, page: any): [] => {
 export const formatActivityLog = (
   activityLogEntry: ActivityLogEntry,
   trace: string,
-  currentLanguage?: string
+  currentLanguage?: string,
+  pageNumber?: number
 ): FormattedActivityLog => {
   const formattedActivityLog: FormattedActivityLog = {} as FormattedActivityLog;
   formattedActivityLog.eventType = allowedTxmaEvents.includes(
@@ -117,7 +118,7 @@ export const formatActivityLog = (
   formattedActivityLog.clientId = activityLogEntry.client_id;
   formattedActivityLog.reportedSuspicious =
     activityLogEntry.reported_suspicious;
-  formattedActivityLog.reportSuspiciousActivityUrl = `${PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url}?event=${activityLogEntry.event_id}`;
+  formattedActivityLog.reportSuspiciousActivityUrl = `${PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url}?event=${activityLogEntry.event_id}&page=${pageNumber || 1}`;
 
   formattedActivityLog.time = prettifyDate({
     dateEpoch: Number(activityLogEntry["timestamp"]),
@@ -168,7 +169,8 @@ export const formatActivityLogs = (
     const row: FormattedActivityLog = formatActivityLog(
       activityLogEntries[i],
       trace,
-      currentLanguage
+      currentLanguage,
+      currentPage
     );
     if (row) formattedData.push(row);
   }


### PR DESCRIPTION
## Proposed changes

Add a redirect to the POST handler for suspicious activity, to redirect the user to the confirmation page.

### What changed

- Add a new GET handler for the `report-activity/done` route
- In the POST handler, redirect the user to the GET handler.
- Ensure the `page` parameter is added to the handler correctly.

### Why did it change

During testing, we discovered an issue where if a user reports activity, then clicks on the browser's back button; they would see a "Confirmation of resubmitting form" message. This stops that from happening. By using a 302 redirect, the POST page is not included in the history, so it wont be resubmitted when the user goes back.

## Testing

I have tested this locally, and on dev.
