### PR TITLE
OLH-1559: Add activity log start date

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -181,7 +181,7 @@
       "empty": "Mae problem dangos hanes eich gweithgaredd ar hyn o bryd. Gallwch roi cynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[link]\">cysylltwch â'r tîm GOV.UK One Login </a>.",
       "notice": "Os ydych yn gweld rhywbeth nad ydych yn ei adnabod, rhowch wybod amdano a <a class=\"govuk-link\" href=\"[changePassword]\"> newidiwch eich cyfrinair</a>.",
       "timeInfo": "Amser y DU",
-      "featureIntro": " Dechreuodd GOV.UK One Login gofnodi hanes gweithgaredd ar [date].",
+      "featureIntro": "Dechreuodd GOV.UK One Login gofnodi hanes gweithgaredd ar 12 Mawrth 2024.",
       "report": "Adrodd am weithgaredd o [time]",
       "reported": "Adroddwyd gweithgaredd ar [time]",
       "activities": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -181,7 +181,7 @@
       "empty": "There is a problem showing your activity history at the moment. You can try again later or <a class=\"govuk-link\" href=\"[link]\">contact the GOV.UK One Login team</a>.",
       "notice": "If you see something you do not recognise, report it and <a class=\"govuk-link\" href=\"[changePassword]\"> change your password</a>.",
       "timeInfo": "UK time",
-      "featureIntro": "GOV.UK One Login started recording activity history on [date].",
+      "featureIntro": "GOV.UK One Login started recording activity history on 12 March 2024.",
       "report": "Report activity from [time]",
       "reported": "Activity reported on [time]",
       "activities": {


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add today's date to the translation files for English and Welsh where we display the "GOV.UK One Login started recording..." message.

### Why did it change

We released the backend to production this morning and are now storing data. This will explain to users why they don't see history before today. 

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Testing
I've tested this in dev in both English and Welsh
<img width="400" alt="image" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/bf25c5ec-9348-43ae-b046-1854ee8d6217">
<img width="400" alt="image" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/548ec31f-718c-4ff7-a6d7-2993e3bf47bd">
