### PR TITLE
OLH-1521 Add checkAllowedServicesList middleware to GET report-suspicios-activity

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
@@ -30,6 +30,7 @@ router.post(
 router.get(
   PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done",
   requiresAuthMiddleware,
+  checkAllowedServicesList,
   reportSuspiciousActivityConfirmation
 );
 


### PR DESCRIPTION
[OLH-1521] Add checkAllowedServicesList middleware to GET report-suspicious-activity

## Proposed changes
This is to add the allowed services middleware to the path added here https://github.com/govuk-one-login/di-account-management-frontend/pull/1189

### What changed

report-suspicious-activity GET path

### Why did it change

To integrate 

https://github.com/govuk-one-login/di-account-management-frontend/pull/1189
and
https://github.com/govuk-one-login/di-account-management-frontend/pull/1187


[OLH-1521]: https://govukverify.atlassian.net/browse/OLH-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ