### PR TITLE
OLH-1575 use checkAllowedServicesList middleware in router

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
@@ -30,6 +30,7 @@ router.post(
 router.get(
   PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done",
   requiresAuthMiddleware,
+  checkAllowedServicesList,
   reportSuspiciousActivityConfirmation
 );
 


### PR DESCRIPTION
## Proposed changes

- Adds middleware to the report confirmation page, to check that the user is able to access the activity log

### Why did it change

This route was added at the same time that the middleware was being created, so it wasn't available at the time of creating the route.

### Related links

https://github.com/govuk-one-login/di-account-management-frontend/pull/1187