### PR TITLE
OLH-1562: Show One Login Home in activity history

### DIFF
--- a/src/components/activity-history/activity-history-controller.ts
+++ b/src/components/activity-history/activity-history-controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { getAppEnv, activityLogItemsPerPage } from "../../config";
+import {
+  getAppEnv,
+  activityLogItemsPerPage,
+  getOIDCClientId,
+} from "../../config";
 import { PATH_DATA } from "../../app.constants";
 import {
   presentActivityHistory,
@@ -60,7 +64,8 @@ export async function activityHistoryGet(
       pagination: pagination,
       backLink: backLink,
       changePasswordLink: PATH_DATA.SECURITY.url,
-      contactLink: PATH_DATA.CONTACT.url
+      contactLink: PATH_DATA.CONTACT.url,
+      homeClientId: getOIDCClientId(),
     });
   } catch (e) {
     res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);

--- a/src/components/activity-history/tests/activity-history-controller.test.ts
+++ b/src/components/activity-history/tests/activity-history-controller.test.ts
@@ -22,12 +22,19 @@ describe("Activity history controller", () => {
   describe("sign in history get", () => {
     sandbox = sinon.createSandbox();
     const activityHistory = require("../../../utils/activityHistory");
+    const config = require("../../../config");
     it("should render the sign in history page with data", async () => {
       sandbox.stub(activityHistory, "presentActivityHistory").callsFake(() => {
         return new Promise((resolve) => {
           resolve([]);
         });
       });
+
+      const clientId = "clientId";
+      sandbox.stub(config, "getOIDCClientId").callsFake(() => {
+        return clientId;
+      });
+
       const req: any = {
         app: {
           locals: {
@@ -47,7 +54,7 @@ describe("Activity history controller", () => {
           destroy: sandbox.fake(),
         },
         log: { error: sandbox.fake(), info: sandbox.fake() },
-        i18n: { language: "en"}
+        i18n: { language: "en" },
       };
       await activityHistoryGet(req as Request, res as Response).then(() => {
         expect(res.render).to.have.been.calledWith(
@@ -58,11 +65,11 @@ describe("Activity history controller", () => {
             pagination: {},
             backLink: PATH_DATA.SECURITY.url,
             changePasswordLink: PATH_DATA.SECURITY.url,
-            contactLink: PATH_DATA.CONTACT.url
+            contactLink: PATH_DATA.CONTACT.url,
+            homeClientId: clientId,
           }
         );
       });
     });
   });
 });
-

--- a/src/components/common/activity-history/event.njk
+++ b/src/components/common/activity-history/event.njk
@@ -1,9 +1,9 @@
 
 {% set contentLocale = ['pages.activityHistory.activities.', event.eventType] | join %}
 {% set eventId = event.visitedServiceId %}
-{%- if (eventId == "ol") -%}
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ [contentLocale, '.', eventId, '.header'] | join | translate }}</h2>
-  <p class="govuk-body govuk-hint">{{[contentLocale, '.', eventId, '.hint'] | join | translate}}</p>
+{%- if (eventId == "oneLoginHome") or (eventId == homeClientId) -%}
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ [contentLocale, '.', 'oneLoginHome', '.header'] | join | translate }}</h2>
+  <p class="govuk-body govuk-hint">{{[contentLocale, '.', 'oneLoginHome', '.hint'] | join | translate}}</p>
 {%- else -%}
   <h2 class="govuk-heading-s">{{ ['clientRegistry.', env, '.', eventId, '.header'] | join | translate }}</h2>
 {%- endif -%}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -186,7 +186,7 @@
       "reported": "Adroddwyd gweithgaredd ar [time]",
       "activities": {
         "signedIn": {
-          "ol": {
+          "oneLoginHome": {
             "header": "Eich GOV.UK One Login",
             "hint": " Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'"
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -186,7 +186,7 @@
       "reported": "Activity reported on [time]",
       "activities": {
         "signedIn": {
-          "ol": {
+          "oneLoginHome": {
             "header": "Your GOV.UK One Login",
             "hint": "This includes ‘Security’ and ‘Your services’"
           }


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update the check in the activity history template to use the same test ID as the backend is expecting (see https://github.com/govuk-one-login/di-account-management-backend/pull/208), or against the Home app's client ID.

### Why did it change

We don't currently show sign ins to One Login Home in the history because there's no content for the client ID in the translation files. This is intentional because we don't want to show a service card for Home.

### Related links

https://github.com/govuk-one-login/di-account-management-backend/pull/208

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've run this locally and tested that events with client IDs of both `oneLoginHome` and the local dev ID show up and are rendered correctly. 

![image](https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/c231bede-b00b-4307-897c-bdb42f13e835)
