### PR TITLE
OLH-1580: Sort activity history to display newest items first

### DIFF
--- a/src/components/activity-history/activity-history-controller.ts
+++ b/src/components/activity-history/activity-history-controller.ts
@@ -6,11 +6,11 @@ import {
 } from "../../config";
 import { PATH_DATA } from "../../app.constants";
 import {
-  presentActivityHistory,
   generatePagination,
   formatActivityLogs,
   filterAndDecryptActivity,
 } from "../../utils/activityHistory";
+import { presentActivityHistory } from "../../utils/present-activity-history";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 import { logger } from "../../utils/logger";
 import { ActivityLogEntry, FormattedActivityLog } from "../../utils/types";

--- a/src/components/activity-history/tests/activity-history-controller.test.ts
+++ b/src/components/activity-history/tests/activity-history-controller.test.ts
@@ -21,14 +21,16 @@ describe("Activity history controller", () => {
 
   describe("sign in history get", () => {
     sandbox = sinon.createSandbox();
-    const activityHistory = require("../../../utils/activityHistory");
     const config = require("../../../config");
+    const presentActivityHistoryModule = require("../../../utils/present-activity-history");
     it("should render the sign in history page with data", async () => {
-      sandbox.stub(activityHistory, "presentActivityHistory").callsFake(() => {
-        return new Promise((resolve) => {
-          resolve([]);
+      sandbox
+        .stub(presentActivityHistoryModule, "presentActivityHistory")
+        .callsFake(() => {
+          return new Promise((resolve) => {
+            resolve([]);
+          });
         });
-      });
 
       const clientId = "clientId";
       sandbox.stub(config, "getOIDCClientId").callsFake(() => {

--- a/src/components/activity-history/tests/activity-history-integration.test.ts
+++ b/src/components/activity-history/tests/activity-history-integration.test.ts
@@ -127,7 +127,7 @@ const appWithMiddlewareSetup = async (data?: any, config?: any) => {
   decache("../../../middleware/requires-auth-middleware");
   const oidc = require("../../../utils/oidc");
   const configFuncs = require("../../../config");
-  const activityHistory = require("../../../utils/activityHistory");
+  const presentActivityHistory = require("../../../utils/present-activity-history");
   const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
   const sandbox = sinon.createSandbox();
   const showActivityLog = !config?.hideActivityLog;
@@ -177,7 +177,7 @@ const appWithMiddlewareSetup = async (data?: any, config?: any) => {
   });
 
   sandbox
-    .stub(activityHistory, "presentActivityHistory")
+    .stub(presentActivityHistory, "presentActivityHistory")
     .callsFake(function () {
       return activity;
     });

--- a/src/utils/activityHistory.ts
+++ b/src/utils/activityHistory.ts
@@ -118,7 +118,9 @@ export const formatActivityLog = (
   formattedActivityLog.clientId = activityLogEntry.client_id;
   formattedActivityLog.reportedSuspicious =
     activityLogEntry.reported_suspicious;
-  formattedActivityLog.reportSuspiciousActivityUrl = `${PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url}?event=${activityLogEntry.event_id}&page=${pageNumber || 1}`;
+  formattedActivityLog.reportSuspiciousActivityUrl = `${
+    PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url
+  }?event=${activityLogEntry.event_id}&page=${pageNumber || 1}`;
 
   formattedActivityLog.time = prettifyDate({
     dateEpoch: Number(activityLogEntry["timestamp"]),
@@ -188,7 +190,7 @@ const activityLogDynamoDBRequest = (
   ScanIndexForward: false, // Set to 'true' for ascending order
 });
 
-const getActivityLogEntry = async (
+export const getActivityLogEntry = async (
   user_id: string,
   trace: string
 ): Promise<ActivityLogEntry[]> => {
@@ -234,15 +236,3 @@ export async function filterAndDecryptActivity(
 
   return filteredActivityLogs;
 }
-
-export const presentActivityHistory = async (
-  subjectId: string,
-  trace: string
-): Promise<ActivityLogEntry[]> => {
-  const activityLogEntry = await getActivityLogEntry(subjectId, trace);
-  if (activityLogEntry) {
-    return activityLogEntry;
-  } else {
-    return [];
-  }
-};

--- a/src/utils/present-activity-history.ts
+++ b/src/utils/present-activity-history.ts
@@ -1,0 +1,14 @@
+import { getActivityLogEntry } from "./activityHistory";
+import type { ActivityLogEntry } from "./types";
+
+export const presentActivityHistory = async (
+  subjectId: string,
+  trace: string
+): Promise<ActivityLogEntry[]> => {
+  const activityLogEntry = await getActivityLogEntry(subjectId, trace);
+  if (activityLogEntry) {
+    return activityLogEntry;
+  } else {
+    return [];
+  }
+};

--- a/src/utils/present-activity-history.ts
+++ b/src/utils/present-activity-history.ts
@@ -7,7 +7,10 @@ export const presentActivityHistory = async (
 ): Promise<ActivityLogEntry[]> => {
   const activityLogEntry = await getActivityLogEntry(subjectId, trace);
   if (activityLogEntry) {
-    return activityLogEntry;
+    const sorted = activityLogEntry.sort((first, second) => {
+      return second.timestamp - first.timestamp;
+    });
+    return sorted;
   } else {
     return [];
   }

--- a/test/unit/utils/present-activity-history.test.ts
+++ b/test/unit/utils/present-activity-history.test.ts
@@ -1,0 +1,50 @@
+import { describe } from "mocha";
+import { SinonStub, stub } from "sinon";
+import { expect } from "chai";
+
+import { presentActivityHistory } from "../../../src/utils/present-activity-history";
+import type { ActivityLogEntry } from "../../../src/utils/types";
+
+const activityLogEntry: ActivityLogEntry = {
+  event_type: "AUTH_AUTH_CODE_ISSUED",
+  session_id: "asdf",
+  user_id: "1234",
+  timestamp: 1689210000,
+  client_id: "dontshowme",
+  event_id: "12345",
+  reported_suspicious: false,
+  truncated: false,
+};
+
+describe("presentActivityHistory", () => {
+  let getActivityLogEntryStub: SinonStub;
+  const subjectId = "subject-id";
+  const trace = "trace";
+
+  const activityHistoryModule = require("../../../src/utils/activityHistory");
+  beforeEach(() => {
+    getActivityLogEntryStub = stub(
+      activityHistoryModule,
+      "getActivityLogEntry"
+    );
+  });
+
+  afterEach(() => {
+    getActivityLogEntryStub.restore();
+  });
+  it("returns an empty list when there is no history", async () => {
+    getActivityLogEntryStub.resolves([]);
+
+    const history = await presentActivityHistory(subjectId, trace);
+
+    expect(history.length).to.eq(0);
+  });
+
+  it("returns the history if it exists", async () => {
+    getActivityLogEntryStub.resolves([activityLogEntry, activityLogEntry]);
+
+    const history = await presentActivityHistory(subjectId, trace);
+
+    expect(history.length).to.eq(2);
+  });
+});

--- a/test/unit/utils/present-activity-history.test.ts
+++ b/test/unit/utils/present-activity-history.test.ts
@@ -47,4 +47,19 @@ describe("presentActivityHistory", () => {
 
     expect(history.length).to.eq(2);
   });
+
+  it("sorts the history in descending order by timestamp", async () => {
+    const oldest = activityLogEntry;
+    const newest = activityLogEntry;
+    newest.timestamp = oldest.timestamp - 1000;
+
+    // oldest first - opposite to what we need
+    getActivityLogEntryStub.resolves([oldest, newest]);
+
+    const history = await presentActivityHistory(subjectId, trace);
+
+    expect(history.length).to.eq(2);
+    // expecting newest item first in the list
+    expect(history[0].timestamp).to.eq(newest.timestamp);
+  });
 });


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Sort the activity history with the newest entry first.

We can't do this in the DynamoDB query because it only supports sorting using the sort key, and our sort key has to be the event ID because timestamp may not be unique. This means the entries come back from DynamoDB in an effectively random order.

The presenter is called before we do pagination, so sorting here means the order stays consistent across all the displayed pages.

This PR also moves the presenter into a separate file. This is so we can use `sinon` to stub the call to `getActivityLogEntry` and control the 

### Why did it change

Currently the activity history displays items in a random order.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've run this locally and checked the order is correct and consistent across pages (see below)

## How to review

I've put the refactor as its own commit to make it easier to review the change in logic.

![Screenshot 2024-03-13 at 09 46 22](https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/d365ec7c-37bc-48ea-8705-f2b11ef2c722)