### PR TITLE
OLH-1588: Rename the activity log table parameter

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -99,7 +99,7 @@ Parameters:
   ServiceStoreTableName:
     Type: String
     Default: user_services
-  ActivityLogStoreTableName:
+  ActivityLogTableName:
     Type: String
     Default: activity_log
   CodeSigningConfigArn:
@@ -392,7 +392,7 @@ Resources:
                   - dynamodb:GetItem
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ServiceStoreTableName}"
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ActivityLogStoreTableName}"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ActivityLogTableName}"
               - Effect: Allow
                 Action:
                   - dynamodb:DescribeTable
@@ -670,7 +670,7 @@ Resources:
             - Name: "SERVICE_STORE_TABLE_NAME"
               Value: !Ref ServiceStoreTableName
             - Name: "ACTIVITY_LOG_STORE_TABLE_NAME"
-              Value: !Ref ActivityLogStoreTableName
+              Value: !Ref ActivityLogTableName
             - Name: "SUPPORT_TRIAGE_PAGE"
               Value:
                 !FindInMap [


### PR DESCRIPTION
## Proposed changes

### What changed

Rename the activity log table parameter

### Why did it change

We renamed the table in the backend and updated the default parameter value, but this doesn't update the value on stacks that are already deployed.

Force the new value through by renaming the parameter.

### Related links

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing

I've deployed this to dev to make sure it still works (it does!)