### PR TITLE
OLH-1588: Filter activity log to items which have content

### DIFF
--- a/src/components/activity-history/tests/activity-history-integration.test.ts
+++ b/src/components/activity-history/tests/activity-history-integration.test.ts
@@ -60,6 +60,7 @@ describe("Integration:: Activity history", () => {
         user_id: "string",
         timestamp: "1689210000",
         truncated: false,
+        client_id: "vehicleOperatorLicense",
       },
       {
         event_type: "AUTH_AUTH_CODE_ISSUED",
@@ -67,6 +68,7 @@ describe("Integration:: Activity history", () => {
         user_id: "string",
         timestamp: "1699210000",
         truncated: false,
+        client_id: "vehicleOperatorLicense",
       },
     ];
     const app = await appWithMiddlewareSetup(dataShort);
@@ -87,6 +89,7 @@ describe("Integration:: Activity history", () => {
       user_id: "string",
       timestamp: "1699210000",
       truncated: false,
+      client_id: "vehicleOperatorLicense",
     };
 
     const dataLong = new Array(12).fill(event);

--- a/src/config.ts
+++ b/src/config.ts
@@ -134,6 +134,7 @@ const DVSA_NON_PROD: string = "vehicleOperatorLicense";
 const STUB_RP_PROD: string = 'Y6YaRZ9bjCwS6HxaB34zvRhZJgBQyryT';
 const STUB_RP_INTEGRATION: string = 'cVCXupm3pykG8OJV0foZFAOtVeT3gukI';
 const STUB_RP_STAGING: string = '8u21cESiFjAcO4IUC6H3ANNgkmu4MpH8';
+export const ONE_LOGIN_HOME_NON_PROD: string = "oneLoginHome";
 
 export const getAllowedAccountListClientIDs: string[] = [
   "LcueBVCnGZw-YFdTZ4S07XbQx7I",

--- a/src/utils/activityHistory.ts
+++ b/src/utils/activityHistory.ts
@@ -13,6 +13,19 @@ import { dynamoDBService } from "./dynamo";
 import { decryptData } from "./decrypt-data";
 import { PATH_DATA } from "../app.constants";
 import { logger } from "./logger";
+import {
+  getOIDCClientId,
+  getAllowedAccountListClientIDs,
+  hmrcClientIds,
+  getAllowedServiceListClientIDs,
+} from "../config";
+
+const servicesWithContent: string[] = [
+  getOIDCClientId(),
+  ...hmrcClientIds,
+  ...getAllowedAccountListClientIDs,
+  ...getAllowedServiceListClientIDs,
+];
 
 export const generatePagination = (dataLength: number, page: any): [] => {
   const pagination: any = {
@@ -218,7 +231,14 @@ export async function filterAndDecryptActivity(
   const filteredActivityLogs: ActivityLogEntry[] = [];
 
   for (const activityLog of activityLogs) {
-    if (!activityLog.user_id || !activityLog.event_type) {
+    if (
+      !activityLog.user_id ||
+      !activityLog.event_type ||
+      !activityLog.client_id
+    ) {
+      continue;
+    }
+    if (!servicesWithContent.includes(activityLog.client_id)) {
       continue;
     }
     let eventType = activityLog.event_type;

--- a/src/utils/activityHistory.ts
+++ b/src/utils/activityHistory.ts
@@ -18,9 +18,11 @@ import {
   getAllowedAccountListClientIDs,
   hmrcClientIds,
   getAllowedServiceListClientIDs,
+  ONE_LOGIN_HOME_NON_PROD,
 } from "../config";
 
 const servicesWithContent: string[] = [
+  ONE_LOGIN_HOME_NON_PROD,
   getOIDCClientId(),
   ...hmrcClientIds,
   ...getAllowedAccountListClientIDs,


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Filters the activity log down to items which either have a service card, appear on the 'services you can use' list or are for the One Login Home RP.

Filtering happens before we decrypt, sort and paginate so this should also reduce our use of KMS which is likely the slowest part of rendering the page.

### Why did it change

This is needed because the activity log database includes items from RPs which don't have content eg. the programme's stub RPs. We need to exclude these to prevent errors when rendering the page. This also protects us against a new RP onboarding before we've added content for their service card and activity log. Now if that happens, the activity log won't display items for that new RP until we have content.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've deployed this into dev and added an item to the activity log with a client ID that shouldn't be displayed. 

Before: 
<img width="500" alt="Screenshot 2024-03-14 at 11 45 58" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/4b9247ed-8689-407c-ae80-18bc43416017">

Afterwards this item doesn't appear in my activity log