### PR TITLE
OLH-1591 Render One Login Home activity correctly 

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { PATH_DATA } from "../../app.constants";
 // import { formatEvent } from "../../utils/activityHistory";
-import { getAppEnv, getDynamoActivityLogStoreTableName } from "../../config";
+import { getAppEnv, getDynamoActivityLogStoreTableName, getOIDCClientId } from "../../config";
 import { DynamoDB } from "aws-sdk";
 import { dynamoDBService } from "../../utils/dynamo";
 import { getSNSSuspicousActivityTopic } from "../../config";
@@ -121,6 +121,7 @@ export async function reportSuspiciousActivityGet(
     eventId: req.query.event,
     reportSuspiciousActivityUrl: PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url,
     alreadyReported: formattedActivityLogs?.reportedSuspicious,
+    homeClientId: getOIDCClientId()
   };
 
   res.render("report-suspicious-activity/index.njk", {


### PR DESCRIPTION
## Proposed changes

### What changed

Pass the Home Login OIDC to the template when rendering the report acitivty page

### Why did it change

So that when a user is reporting the One Login Home login itself, we render it correctly.

