### PR TITLE
Use the prettier recommended linting plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
+    "plugin:prettier/recommended",
   ],
   rules: {
     "@typescript-eslint/no-var-requires": 0,

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -134,13 +134,13 @@ export enum LOCALE {
 }
 
 export interface LanguageCodes {
-  en: 'en-GB',
-  cy: 'cy-CY'
+  en: "en-GB";
+  cy: "cy-CY";
 }
 export const LANGUAGE_CODES: LanguageCodes = {
   en: "en-GB",
   cy: "cy-CY",
-}
+};
 
 export const LOG_MESSAGES = {
   ATTEMPTING_TO_DESTROY_SESSION: "Attempting to destroy session",
@@ -151,7 +151,8 @@ export const LOG_MESSAGES = {
     `Malformed gs cookie contained: ${details}`,
   EVENT_SENT_SUCCESSFULLY: (queue: string, messageId: string): string =>
     `Event sent to ${queue} with message id ${messageId}`,
-  ILLEGAL_ATTEMPT_TO_ACCESS_RSA: "An attempt to access RSA without having visited one of the allowed services was made.",
+  ILLEGAL_ATTEMPT_TO_ACCESS_RSA:
+    "An attempt to access RSA without having visited one of the allowed services was made.",
 };
 
 export const ERROR_MESSAGES = {

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -108,10 +108,10 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "Enter your new password"
         );
-        expect($(testComponent('confirm-password-error')).text()).to.contains(
+        expect($(testComponent("confirm-password-error")).text()).to.contains(
           "Re-type your new password"
         );
       })
@@ -130,7 +130,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('confirm-password-error')).text()).to.contains(
+        expect($(testComponent("confirm-password-error")).text()).to.contains(
           "Enter the same password in both fields"
         );
       })
@@ -149,7 +149,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
@@ -168,7 +168,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
@@ -192,7 +192,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers"
         );
       })
@@ -211,7 +211,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
@@ -235,7 +235,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "You are already using that password. Enter a different password"
         );
       })
@@ -259,7 +259,7 @@ describe("Integration:: change password", () => {
       })
       .expect(function (res) {
         const $ = load(res.text);
-        expect($(testComponent('error-heading')).text()).to.not.be.empty;
+        expect($(testComponent("error-heading")).text()).to.not.be.empty;
       })
       .expect(500, done);
   });

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -111,7 +111,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('phoneNumber-error')).text()).to.contains(
+        expect($(testComponent("phoneNumber-error")).text()).to.contains(
           "Enter a UK mobile phone number"
         );
       })
@@ -129,7 +129,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('phoneNumber-error')).text()).to.contains(
+        expect($(testComponent("phoneNumber-error")).text()).to.contains(
           "Enter a UK mobile phone number"
         );
       })
@@ -147,7 +147,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('phoneNumber-error')).text()).to.contains(
+        expect($(testComponent("phoneNumber-error")).text()).to.contains(
           "Enter a UK mobile phone number using only numbers or the + symbol"
         );
       })
@@ -165,7 +165,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('phoneNumber-error')).text()).to.contains(
+        expect($(testComponent("phoneNumber-error")).text()).to.contains(
           "Enter a UK mobile phone number, like 07700 900000"
         );
       })
@@ -183,7 +183,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('phoneNumber-error')).text()).to.contains(
+        expect($(testComponent("phoneNumber-error")).text()).to.contains(
           "Enter a UK mobile phone number, like 07700 900000"
         );
       })
@@ -277,10 +277,10 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
-          "Enter a mobile phone number"
-        );
-        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
+        expect(
+          $(testComponent("internationalPhoneNumber-error")).text()
+        ).to.contains("Enter a mobile phone number");
+        expect($(testComponent("phoneNumber-error")).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -302,10 +302,12 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
+        expect(
+          $(testComponent("internationalPhoneNumber-error")).text()
+        ).to.contains(
           "You’re already using that phone number. Enter a different phone number."
         );
-        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
+        expect($(testComponent("phoneNumber-error")).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -326,7 +328,7 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('phoneNumber-error')).text()).to.contains(
+        expect($(testComponent("phoneNumber-error")).text()).to.contains(
           "You’re already using that phone number. Enter a different phone number."
         );
       })
@@ -345,10 +347,12 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
+        expect(
+          $(testComponent("internationalPhoneNumber-error")).text()
+        ).to.contains(
           "Enter a mobile phone number in the correct format, including the country code"
         );
-        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
+        expect($(testComponent("phoneNumber-error")).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -365,10 +369,12 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
+        expect(
+          $(testComponent("internationalPhoneNumber-error")).text()
+        ).to.contains(
           "Enter a mobile phone number using only numbers or the + symbol"
         );
-        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
+        expect($(testComponent("phoneNumber-error")).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -385,10 +391,12 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
+        expect(
+          $(testComponent("internationalPhoneNumber-error")).text()
+        ).to.contains(
           "Enter a mobile phone number in the correct format, including the country code"
         );
-        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
+        expect($(testComponent("phoneNumber-error")).text()).to.contains("");
       })
       .expect(400, done);
   });
@@ -405,10 +413,12 @@ describe("Integration:: change phone number", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('internationalPhoneNumber-error')).text()).to.contains(
+        expect(
+          $(testComponent("internationalPhoneNumber-error")).text()
+        ).to.contains(
           "Enter a mobile phone number in the correct format, including the country code"
         );
-        expect($(testComponent('phoneNumber-error')).text()).to.contains("");
+        expect($(testComponent("phoneNumber-error")).text()).to.contains("");
       })
       .expect(400, done);
   });

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -11,7 +11,10 @@ import { getNextState } from "../../utils/state-machine";
 import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/types";
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
 import xss from "xss";
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../utils/types";
 
 const TEMPLATE_NAME = "check-your-email/index.njk";
 
@@ -26,29 +29,26 @@ export function checkYourEmailPost(
   publishingService: GovUkPublishingServiceInterface = govUkPublishingService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const {
-      email,
-      newEmailAddress,
-      publicSubjectId,
-      legacySubjectId,
-    } = req.session.user;
+    const { email, newEmailAddress, publicSubjectId, legacySubjectId } =
+      req.session.user;
 
-    const updateInput : UpdateInformationInput = {
+    const updateInput: UpdateInformationInput = {
       email: email,
       updatedValue: newEmailAddress,
-      otp: req.body["code"]
+      otp: req.body["code"],
     };
 
-    const sessionDetails : UpdateInformationSessionValues = {
-      accessToken : req.session.user.tokens.accessToken,
+    const sessionDetails: UpdateInformationSessionValues = {
+      accessToken: req.session.user.tokens.accessToken,
       sourceIp: req.ip,
       sessionId: res.locals.sessionId,
-      persistentSessionId : res.locals.persistentSessionId,
-      userLanguage: xss(req.cookies.lng as string)
-    }
+      persistentSessionId: res.locals.persistentSessionId,
+      userLanguage: xss(req.cookies.lng as string),
+    };
 
     const isEmailUpdated = await service.updateEmail(
-      updateInput, sessionDetails
+      updateInput,
+      sessionDetails
     );
 
     if (isEmailUpdated) {

--- a/src/components/check-your-email/check-your-email-service.ts
+++ b/src/components/check-your-email/check-your-email-service.ts
@@ -2,20 +2,23 @@ import { getRequestConfig, Http, http } from "../../utils/http";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { CheckYourEmailServiceInterface } from "./types";
 import { AxiosResponse } from "axios";
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../utils/types";
 
 export function checkYourEmailService(
   axios: Http = http
 ): CheckYourEmailServiceInterface {
   const updateEmail = async function (
-    updateInput : UpdateInformationInput,
-    sessionDetails: UpdateInformationSessionValues,
+    updateInput: UpdateInformationInput,
+    sessionDetails: UpdateInformationSessionValues
   ): Promise<boolean> {
     const { status }: AxiosResponse = await axios.client.post(
       API_ENDPOINTS.UPDATE_EMAIL,
       {
-        existingEmailAddress : updateInput.email,
-        replacementEmailAddress : updateInput.updatedValue,
+        existingEmailAddress: updateInput.email,
+        replacementEmailAddress: updateInput.updatedValue,
         otp: updateInput.otp,
       },
       getRequestConfig(

--- a/src/components/check-your-email/tests/check-your-email-service.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-service.test.ts
@@ -4,7 +4,10 @@ import { checkYourEmailService } from "../check-your-email-service";
 import { expect } from "chai";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../../app.constants";
 import { getApiBaseUrl } from "../../../config";
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../../utils/types";
 
 const baseUrl = getApiBaseUrl();
 
@@ -44,22 +47,23 @@ describe("checkYourEmailService", () => {
       })
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    const updateInput : UpdateInformationInput = {
+    const updateInput: UpdateInformationInput = {
       email: existingEmailAddress,
       updatedValue: replacementEmailAddress,
-      otp
+      otp,
     };
 
-    const sessionDetails : UpdateInformationSessionValues = {
+    const sessionDetails: UpdateInformationSessionValues = {
       accessToken,
       sourceIp,
       sessionId,
       persistentSessionId,
-      userLanguage
+      userLanguage,
     };
 
     const emailUpdated = await checkYourEmailService().updateEmail(
-      updateInput, sessionDetails
+      updateInput,
+      sessionDetails
     );
 
     expect(emailUpdated).to.be.true;

--- a/src/components/check-your-email/types.ts
+++ b/src/components/check-your-email/types.ts
@@ -1,8 +1,11 @@
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../utils/types";
 
 export interface CheckYourEmailServiceInterface {
   updateEmail: (
-    updateInput : UpdateInformationInput,
-    sessionDetails: UpdateInformationSessionValues,
+    updateInput: UpdateInformationInput,
+    sessionDetails: UpdateInformationSessionValues
   ) => Promise<boolean>;
 }

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -10,7 +10,10 @@ import {
 } from "../../utils/validation";
 import { redactPhoneNumber } from "../../utils/strings";
 import xss from "xss";
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../utils/types";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 
@@ -18,7 +21,7 @@ export function checkYourPhoneGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: redactPhoneNumber(req.session.user.newPhoneNumber),
     resendCodeLink: PATH_DATA.RESEND_PHONE_CODE.url,
-    changePhoneNumberLink: PATH_DATA.CHANGE_PHONE_NUMBER.url
+    changePhoneNumberLink: PATH_DATA.CHANGE_PHONE_NUMBER.url,
   });
 }
 
@@ -28,22 +31,23 @@ export function checkYourPhonePost(
   return async function (req: Request, res: Response) {
     const { email, newPhoneNumber } = req.session.user;
 
-    const updateInput : UpdateInformationInput = {
+    const updateInput: UpdateInformationInput = {
       email,
       updatedValue: newPhoneNumber,
-      otp: req.body["code"]
+      otp: req.body["code"],
     };
 
-    const sessionDetails : UpdateInformationSessionValues = {
-      accessToken : req.session.user.tokens.accessToken,
+    const sessionDetails: UpdateInformationSessionValues = {
+      accessToken: req.session.user.tokens.accessToken,
       sourceIp: req.ip,
       sessionId: res.locals.sessionId,
-      persistentSessionId : res.locals.persistentSessionId,
-      userLanguage: xss(req.cookies.lng as string)
-    }
+      persistentSessionId: res.locals.persistentSessionId,
+      userLanguage: xss(req.cookies.lng as string),
+    };
 
     const isPhoneNumberUpdated = await service.updatePhoneNumber(
-        updateInput, sessionDetails
+      updateInput,
+      sessionDetails
     );
 
     if (isPhoneNumberUpdated) {

--- a/src/components/check-your-phone/check-your-phone-service.ts
+++ b/src/components/check-your-phone/check-your-phone-service.ts
@@ -1,20 +1,24 @@
 import { getRequestConfig, Http, http } from "../../utils/http";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { CheckYourPhoneServiceInterface } from "./types";
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../utils/types";
 
 export function checkYourPhoneService(
   axios: Http = http
 ): CheckYourPhoneServiceInterface {
   const updatePhoneNumber = async function (
-    updateInput : UpdateInformationInput, sessionDetails : UpdateInformationSessionValues
+    updateInput: UpdateInformationInput,
+    sessionDetails: UpdateInformationSessionValues
   ): Promise<boolean> {
     const { status } = await axios.client.post<void>(
       API_ENDPOINTS.UPDATE_PHONE_NUMBER,
       {
-        email : updateInput.email,
-        phoneNumber : updateInput.updatedValue,
-        otp : updateInput.otp,
+        email: updateInput.email,
+        phoneNumber: updateInput.updatedValue,
+        otp: updateInput.otp,
       },
       getRequestConfig(
         sessionDetails.accessToken,

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -107,7 +107,9 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('code-error')).text()).to.contains("Enter the security code");
+        expect($(testComponent("code-error")).text()).to.contains(
+          "Enter the security code"
+        );
       })
       .expect(400, done);
   });
@@ -123,7 +125,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('code-error')).text()).to.contains(
+        expect($(testComponent("code-error")).text()).to.contains(
           "Enter the security code using only 6 digits"
         );
       })
@@ -141,7 +143,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('code-error')).text()).to.contains(
+        expect($(testComponent("code-error")).text()).to.contains(
           "Enter the security code using only 6 digits"
         );
       })
@@ -159,7 +161,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('code-error')).text()).to.contains(
+        expect($(testComponent("code-error")).text()).to.contains(
           "Enter the security code using only 6 digits"
         );
       })
@@ -194,7 +196,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('code-error')).text()).to.contains(
+        expect($(testComponent("code-error")).text()).to.contains(
           "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
         );
       })

--- a/src/components/check-your-phone/tests/check-your-phone-service.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-service.test.ts
@@ -4,7 +4,10 @@ import { checkYourPhoneService } from "../check-your-phone-service";
 import { expect } from "chai";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../../app.constants";
 import { getApiBaseUrl } from "../../../config";
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../../utils/types";
 
 const baseUrl = getApiBaseUrl();
 
@@ -44,22 +47,23 @@ describe("checkYourPhoneService", () => {
       })
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    const updateInput : UpdateInformationInput = {
+    const updateInput: UpdateInformationInput = {
       email,
       updatedValue: phoneNumber,
       otp,
     };
 
-    const sessionDetails : UpdateInformationSessionValues = {
+    const sessionDetails: UpdateInformationSessionValues = {
       accessToken,
       sourceIp,
       sessionId,
       persistentSessionId,
-      userLanguage
-    }
+      userLanguage,
+    };
 
     const phoneNumberUpdated = await checkYourPhoneService().updatePhoneNumber(
-      updateInput, sessionDetails
+      updateInput,
+      sessionDetails
     );
 
     expect(phoneNumberUpdated).to.be.true;

--- a/src/components/check-your-phone/types.ts
+++ b/src/components/check-your-phone/types.ts
@@ -1,8 +1,11 @@
-import { UpdateInformationInput, UpdateInformationSessionValues } from "../../utils/types";
+import {
+  UpdateInformationInput,
+  UpdateInformationSessionValues,
+} from "../../utils/types";
 
 export interface CheckYourPhoneServiceInterface {
   updatePhoneNumber: (
-    updateInput : UpdateInformationInput,
+    updateInput: UpdateInformationInput,
     sessionDetails: UpdateInformationSessionValues
   ) => Promise<boolean>;
 }

--- a/src/components/contact-govuk-one-login/types.ts
+++ b/src/components/contact-govuk-one-login/types.ts
@@ -1,7 +1,5 @@
 export interface EventServiceInterface {
-  send: (
-    data: Event,
-  ) => void;
+  send: (data: Event) => void;
 }
 
 export interface Event {

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -148,9 +148,11 @@ describe("Integration:: delete account", () => {
       .get(PATH_DATA.DELETE_ACCOUNT.url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('no-services-content')).text()).to.not.be.empty;
-        expect($(testComponent('govuk-email-subscription-info')).text()).to.be.empty;
-        expect($(testComponent('service-list-item')).text()).to.be.empty;
+        expect($(testComponent("no-services-content")).text()).to.not.be.empty;
+        expect(
+          $(testComponent("govuk-email-subscription-info")).text()
+        ).to.be.empty;
+        expect($(testComponent("service-list-item")).text()).to.be.empty;
       })
       .expect(200, done);
   });
@@ -162,8 +164,10 @@ describe("Integration:: delete account", () => {
       .get(PATH_DATA.DELETE_ACCOUNT.url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('govuk-email-subscription-info')).text()).to.not.be.empty;
-        expect($(testComponent('service-list-item')).text()).to.not.be.empty;
+        expect(
+          $(testComponent("govuk-email-subscription-info")).text()
+        ).to.not.be.empty;
+        expect($(testComponent("service-list-item")).text()).to.not.be.empty;
       })
       .expect(200, done);
   });
@@ -175,8 +179,10 @@ describe("Integration:: delete account", () => {
       .get(PATH_DATA.DELETE_ACCOUNT.url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('service-list-item')).text()).to.not.be.empty;
-        expect($(testComponent('govuk-email-subscription-info')).text()).to.be.empty;
+        expect($(testComponent("service-list-item")).text()).to.not.be.empty;
+        expect(
+          $(testComponent("govuk-email-subscription-info")).text()
+        ).to.be.empty;
       })
       .expect(200, done);
   });

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -117,7 +117,9 @@ describe("Integration::enter password", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains("Enter your password");
+        expect($(testComponent("password-error")).text()).to.contains(
+          "Enter your password"
+        );
       })
       .expect(400, done);
   });
@@ -137,7 +139,7 @@ describe("Integration::enter password", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($(testComponent('password-error')).text()).to.contains(
+        expect($(testComponent("password-error")).text()).to.contains(
           "Enter the correct password"
         );
       })

--- a/src/components/logout/tests/logout-controller.test.ts
+++ b/src/components/logout/tests/logout-controller.test.ts
@@ -51,7 +51,7 @@ describe("logout controller", () => {
 
     req.session.destroy = sandbox.fake();
 
-      logoutPost(req, res);
+    logoutPost(req, res);
 
     expect(req.session.destroy).to.have.been.calledOnce;
     expect(res.mockCookies.lo).to.equal("true");

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -1,6 +1,11 @@
 import { Request, Response } from "express";
 import { CallbackParamsType, TokenSet, UserinfoResponse } from "openid-client";
-import { HTTP_STATUS_CODES, OIDC_ERRORS, PATH_DATA, VECTORS_OF_TRUST } from "../../app.constants";
+import {
+  HTTP_STATUS_CODES,
+  OIDC_ERRORS,
+  PATH_DATA,
+  VECTORS_OF_TRUST,
+} from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { ClientAssertionServiceInterface } from "../../utils/types";
 import { clientAssertionGenerator } from "../../utils/oidc";

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -4,7 +4,11 @@ import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 import { oidcAuthCallbackGet } from "../call-back-controller";
-import { HTTP_STATUS_CODES, PATH_DATA, VECTORS_OF_TRUST } from "../../../app.constants";
+import {
+  HTTP_STATUS_CODES,
+  PATH_DATA,
+  VECTORS_OF_TRUST,
+} from "../../../app.constants";
 import { ClientAssertionServiceInterface } from "../../../utils/types";
 
 describe("callback controller", () => {
@@ -111,7 +115,10 @@ describe("callback controller", () => {
     });
 
     it("response status code should be 403 when access denied error occurs", async () => {
-      req.oidc.callbackParams = sandbox.fake.returns({"error":"access_denied","state":"m0H_2VvrhKR0qA"});
+      req.oidc.callbackParams = sandbox.fake.returns({
+        error: "access_denied",
+        state: "m0H_2VvrhKR0qA",
+      });
       const fakeService: ClientAssertionServiceInterface = {
         generateAssertionJwt: sandbox.fake.returns("testassert"),
       };

--- a/src/components/redirects/redirects-routes.ts
+++ b/src/components/redirects/redirects-routes.ts
@@ -11,20 +11,15 @@ router.get(
   redirectToSecurity
 );
 
-router.get(PATH_DATA.SECURITY_TXT.url, (_, res) => (
-    res.redirect(302, WELL_KNOWN_FILES.SECURITY_TEXT_URL)
-  )
+router.get(PATH_DATA.SECURITY_TXT.url, (_, res) =>
+  res.redirect(302, WELL_KNOWN_FILES.SECURITY_TEXT_URL)
 );
 
-router.get(PATH_DATA.THANKS_TXT.url, (_, res) => (
-    res.redirect(302, WELL_KNOWN_FILES.THANKS_TEXT_URL)
-  )
+router.get(PATH_DATA.THANKS_TXT.url, (_, res) =>
+  res.redirect(302, WELL_KNOWN_FILES.THANKS_TEXT_URL)
 );
 
-function redirectToSecurity(
-  req: Request,
-  res: Response
-) {
+function redirectToSecurity(req: Request, res: Response) {
   return res.redirect(PATH_DATA.SECURITY.url);
 }
 

--- a/src/components/redirects/tests/redirects-integration.test.ts
+++ b/src/components/redirects/tests/redirects-integration.test.ts
@@ -22,7 +22,8 @@ describe("Integration::redirects", () => {
 
   describe("security.txt", async () => {
     it("302 redirects to cabinet office security.txt", (done) => {
-      request(app).get(PATH_DATA.SECURITY_TXT.url)
+      request(app)
+        .get(PATH_DATA.SECURITY_TXT.url)
         .expect("Location", WELL_KNOWN_FILES.SECURITY_TEXT_URL)
         .expect(302, done());
     });
@@ -30,7 +31,8 @@ describe("Integration::redirects", () => {
 
   describe("thanks.txt", async () => {
     it("302 redirects to cabinet office thanks.txt", (done) => {
-      request(app).get(PATH_DATA.THANKS_TXT.url)
+      request(app)
+        .get(PATH_DATA.THANKS_TXT.url)
         .expect("Location", WELL_KNOWN_FILES.THANKS_TEXT_URL)
         .expect(302, done());
     });

--- a/src/components/report-suspicious-activity/tests/report-suspicious-activity-controller.test.ts
+++ b/src/components/report-suspicious-activity/tests/report-suspicious-activity-controller.test.ts
@@ -26,26 +26,26 @@ describe("report suspicious activity controller", () => {
     [awsConfig?: AwsConfig],
     DynamoDBService
   >;
-  let snsPublishSpy : sinon.SinonSpy;
+  let snsPublishSpy: sinon.SinonSpy;
   let clock: sinon.SinonFakeTimers;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     loggerSpy = sinon.spy(logger, "info");
     errorLoggerSpy = sinon.spy(logger, "error");
-    clock = sinon.useFakeTimers(new Date(101))
+    clock = sinon.useFakeTimers(new Date(101));
 
     req = {
       query: { event: "event-id", reported: "false" },
       session: {
-        user_id: 'user-id',
+        user_id: "user-id",
         user: {
           email: "test@email.moc",
         },
       } as any,
       log: logger,
       body: {
-        event_id: 'event-id',
+        event_id: "event-id",
         page: "",
       },
     };
@@ -86,7 +86,6 @@ describe("report suspicious activity controller", () => {
     sinon.stub(sns, "snsService").returns({
       publish: snsPublishSpy,
     });
-
   });
 
   afterEach(() => {
@@ -189,25 +188,29 @@ describe("report suspicious activity controller", () => {
       req.body.page = "1";
 
       // Act
-      await reportSuspiciousActivityPost(req as Request, res as Response, () => {});
+      await reportSuspiciousActivityPost(
+        req as Request,
+        res as Response,
+        () => {}
+      );
 
       // Assert
-      expect(res.redirect).to.have.been.calledWith("/activity-history/report-activity/done?page=1");
+      expect(res.redirect).to.have.been.calledWith(
+        "/activity-history/report-activity/done?page=1"
+      );
 
       const snsCall = snsPublishSpy.getCalls()[0];
       const [topic_arn, message] = snsCall.args;
 
       expect(topic_arn).to.equal(process.env.SUSPICIOUS_ACTIVITY_TOPIC_ARN);
       expect(JSON.parse(message)).to.deep.equal({
-          "user_id":"user-id",
-          "email":"test@email.moc",
-          "event_id":"event-id",
-          "persistent_session_id":"persistent-session-id",
-          "session_id":"session-id",
-          "reported_suspicious_time":101
-        })
+        user_id: "user-id",
+        email: "test@email.moc",
+        event_id: "event-id",
+        persistent_session_id: "persistent-session-id",
+        session_id: "session-id",
+        reported_suspicious_time: 101,
+      });
     });
   });
 });
-
-

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -17,7 +17,7 @@ const TEMPLATE_NAME = "resend-phone-code/index.njk";
 export function resendPhoneCodeGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumberRedacted: redactPhoneNumber(req.session.user.newPhoneNumber),
-    phoneNumber: req.session.user.newPhoneNumber
+    phoneNumber: req.session.user.newPhoneNumber,
   });
 }
 

--- a/src/components/resend-phone-code/resend-phone-code-routes.ts
+++ b/src/components/resend-phone-code/resend-phone-code-routes.ts
@@ -3,7 +3,7 @@ import { PATH_DATA } from "../../app.constants";
 
 import {
   resendPhoneCodeGet,
-  resendPhoneCodePost
+  resendPhoneCodePost,
 } from "./resend-phone-code-controller";
 import { asyncHandler } from "../../utils/async";
 import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";

--- a/src/components/security/security-routes.ts
+++ b/src/components/security/security-routes.ts
@@ -5,10 +5,6 @@ import { requiresAuthMiddleware } from "../../middleware/requires-auth-middlewar
 
 const router = express.Router();
 
-router.get(
-  PATH_DATA.SECURITY.url,
-  requiresAuthMiddleware,
-  securityGet
-);
+router.get(PATH_DATA.SECURITY.url, requiresAuthMiddleware, securityGet);
 
 export { router as securityRouter };

--- a/src/components/your-services/tests/your-services-controller.test.ts
+++ b/src/components/your-services/tests/your-services-controller.test.ts
@@ -30,7 +30,7 @@ describe("your services controller", () => {
         destroy: sandbox.fake(),
       },
       log: { error: sandbox.fake() },
-      i18n: { language: "en"},
+      i18n: { language: "en" },
     };
   }
 

--- a/src/components/your-services/tests/your-services-integration.test.ts
+++ b/src/components/your-services/tests/your-services-integration.test.ts
@@ -33,51 +33,68 @@ describe("Integration:: your services", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($(testComponent('empty-state')).length).to.not.equal(0);
+        expect($(testComponent("empty-state")).length).to.not.equal(0);
       });
   });
 
   it("should display accounts without a section heading when only accounts but not services have been added", async () => {
-    const app = await appWithMiddlewareSetup({hasAccounts: true});
+    const app = await appWithMiddlewareSetup({ hasAccounts: true });
     await request(app)
       .get(url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($(`h2${testComponent('accounts-heading')}`).length).to.equal(0);
-        expect($(`h2${testComponent('account-card-heading')}`).length).to.not.equal(0);
+        expect($(`h2${testComponent("accounts-heading")}`).length).to.equal(0);
+        expect(
+          $(`h2${testComponent("account-card-heading")}`).length
+        ).to.not.equal(0);
       });
   });
 
   it("should display services without a section heading when only services but not accounts have been added", async () => {
-    const app = await appWithMiddlewareSetup({hasServices: true});
+    const app = await appWithMiddlewareSetup({ hasServices: true });
     await request(app)
       .get(url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($(`h2${testComponent('services-heading')}`).length).to.equal(0);
-        expect($(`h2${testComponent('service-card-heading')}`).length).to.not.equal(0);
+        expect($(`h2${testComponent("services-heading")}`).length).to.equal(0);
+        expect(
+          $(`h2${testComponent("service-card-heading")}`).length
+        ).to.not.equal(0);
       });
   });
 
-
   it("should display services and accounts with section headings when both services and accounts have been added", async () => {
-    const app = await appWithMiddlewareSetup({hasAccounts: true, hasServices: true});
+    const app = await appWithMiddlewareSetup({
+      hasAccounts: true,
+      hasServices: true,
+    });
     await request(app)
       .get(url)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect(res.status).to.equal(200);
-        expect($(`h3${testComponent('account-card-heading')}`).length).to.not.equal(0);
-        expect($(`h3${testComponent('service-card-heading')}`).length).to.not.equal(0);
-        expect($(`h2${testComponent('services-heading')}`).length).to.not.equal(0);
-        expect($(`h2${testComponent('accounts-heading')}`).length).to.not.equal(0);
+        expect(
+          $(`h3${testComponent("account-card-heading")}`).length
+        ).to.not.equal(0);
+        expect(
+          $(`h3${testComponent("service-card-heading")}`).length
+        ).to.not.equal(0);
+        expect($(`h2${testComponent("services-heading")}`).length).to.not.equal(
+          0
+        );
+        expect($(`h2${testComponent("accounts-heading")}`).length).to.not.equal(
+          0
+        );
       });
   });
 });
 
-const appWithMiddlewareSetup = async (data?: {hasAccounts?: boolean, hasServices?: boolean}) => {
+const appWithMiddlewareSetup = async (data?: {
+  hasAccounts?: boolean;
+  hasServices?: boolean;
+}) => {
   decache("../../../app");
   decache("../../../middleware/requires-auth-middleware");
   const sandbox = sinon.createSandbox();
@@ -94,23 +111,31 @@ const appWithMiddlewareSetup = async (data?: {hasAccounts?: boolean, hasServices
       req.session.user = DEFAULT_USER_SESSION;
       next();
     });
-  
-  sandbox.stub(yourServices, "presentYourServices").callsFake(function() {
+
+  sandbox.stub(yourServices, "presentYourServices").callsFake(function () {
     return {
-      accountsList: accounts ? [{
-        client_id: "gov-uk",
-        count_successful_logins: "1",
-        last_accessed: "",
-        last_accessed_readable_format: "",
-      }] : [],
-      servicesList: services ? [{
-        client_id: "dbs",
-        count_successful_logins: "1",
-        last_accessed: "",
-        last_accessed_readable_format: "",
-      }] : [],
+      accountsList: accounts
+        ? [
+            {
+              client_id: "gov-uk",
+              count_successful_logins: "1",
+              last_accessed: "",
+              last_accessed_readable_format: "",
+            },
+          ]
+        : [],
+      servicesList: services
+        ? [
+            {
+              client_id: "dbs",
+              count_successful_logins: "1",
+              last_accessed: "",
+              last_accessed_readable_format: "",
+            },
+          ]
+        : [],
     };
-  })
+  });
   sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
     return new Promise((resolve) => {
       resolve({});

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,8 +132,8 @@ const FIND_AND_APPLY_FOR_A_GRANT_NON_PROD: string = "findAndApplyForAGrant";
 const DVSA_PROD: string = "oLciSn5b6-cqcJjzgMMwCw1moD8";
 const DVSA_NON_PROD: string = "vehicleOperatorLicense";
 const STUB_RP_PROD: string = "mTGf7RHk09WyEYUNZ71IUGIFJxEQ5hn1";
-const STUB_RP_INTEGRATION: string = 'cVCXupm3pykG8OJV0foZFAOtVeT3gukI';
-const STUB_RP_STAGING: string = '8u21cESiFjAcO4IUC6H3ANNgkmu4MpH8';
+const STUB_RP_INTEGRATION: string = "cVCXupm3pykG8OJV0foZFAOtVeT3gukI";
+const STUB_RP_STAGING: string = "8u21cESiFjAcO4IUC6H3ANNgkmu4MpH8";
 export const ONE_LOGIN_HOME_NON_PROD: string = "oneLoginHome";
 
 export const getAllowedAccountListClientIDs: string[] = [
@@ -176,7 +176,7 @@ export const rsaAllowList: string[] = [
   ...hmrcClientIds,
   STUB_RP_INTEGRATION,
   STUB_RP_PROD,
-  STUB_RP_STAGING
+  STUB_RP_STAGING,
 ];
 
 export const getAllowedServiceListClientIDs: string[] = [

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -8,9 +8,9 @@ export function getCSRFCookieOptions(isProdEnv: boolean): CookieOptions {
 }
 
 export function getSessionCookieOptions(
-    isProdEnv: boolean,
-    expiry: number,
-    secret: string
+  isProdEnv: boolean,
+  expiry: number,
+  secret: string
 ): any {
   return {
     name: "ams",

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -47,9 +47,9 @@ export const webchatHelmetConfiguration: Parameters<typeof helmet>[0] = {
       defaultSrc: ["'self'"],
       styleSrc: [
         (req: Request, res: Response): string =>
-        `'nonce-${res.locals.scriptNonce}'`,
-        "'self'", 
-        "https://*.smartagent.app", 
+          `'nonce-${res.locals.scriptNonce}'`,
+        "'self'",
+        "https://*.smartagent.app",
       ],
       scriptSrc: [
         "'self'",
@@ -69,7 +69,7 @@ export const webchatHelmetConfiguration: Parameters<typeof helmet>[0] = {
         "data:",
         "https://www.googletagmanager.com",
         "https://www.google-analytics.com",
-        "https://*.s3.eu-west-2.amazonaws.com"
+        "https://*.s3.eu-west-2.amazonaws.com",
       ],
       objectSrc: ["'none'"],
       connectSrc: [

--- a/src/middleware/check-allowed-services-list.ts
+++ b/src/middleware/check-allowed-services-list.ts
@@ -42,7 +42,10 @@ export async function checkRSAAllowedServicesList(
   if (await hasAllowedRSAServices(req, res)) {
     next();
   } else {
-    req.log.info({trace: res.locals.trace}, LOG_MESSAGES.ILLEGAL_ATTEMPT_TO_ACCESS_RSA);
+    req.log.info(
+      { trace: res.locals.trace },
+      LOG_MESSAGES.ILLEGAL_ATTEMPT_TO_ACCESS_RSA
+    );
     res.redirect(PATH_DATA.SECURITY.url);
   }
 }

--- a/src/middleware/outbound-contact-us-links-middleware.ts
+++ b/src/middleware/outbound-contact-us-links-middleware.ts
@@ -25,7 +25,9 @@ export function outboundContactUsLinksMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  let contactUsLinkUrl = `${req.protocol}://${req.get("host")}${PATH_DATA.CONTACT.url}`;
+  let contactUsLinkUrl = `${req.protocol}://${req.get("host")}${
+    PATH_DATA.CONTACT.url
+  }`;
   const fromUrl = buildUrlFromRequest(req);
 
   contactUsLinkUrl = appendFromUrlWhenTriagePageUrl(contactUsLinkUrl, fromUrl);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,6 @@
 import { createApp } from "./app";
 import { logger } from "./utils/logger";
 
-
 const port: number | string = process.env.PORT || 6001;
 
 (async () => {
@@ -18,4 +17,3 @@ const port: number | string = process.env.PORT || 6001;
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);
 });
-

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -3,7 +3,8 @@ import {
   EventServiceInterface,
   EventNameType,
   AuditEvent,
-  Event, CurrentTimeDescriptor,
+  Event,
+  CurrentTimeDescriptor,
 } from "./types";
 import { SqsService } from "../utils/types";
 import { sqsService } from "../utils/sqs";
@@ -44,7 +45,6 @@ export function eventService(
   const isSignedIn = (session: Session): boolean =>
     session.user?.isAuthenticated || false;
 
-
   /**
    * A function for calculating and returning an object containing the current timestamp.
    *
@@ -57,7 +57,6 @@ export function eventService(
       seconds: Math.floor(date.valueOf() / 1000),
     };
   }
-
 
   const buildAuditEvent = (
     req: Request,

--- a/src/utils/prettifyDate.ts
+++ b/src/utils/prettifyDate.ts
@@ -1,15 +1,16 @@
 import { LANGUAGE_CODES } from "../app.constants";
 
-export const prettifyDate = ({ 
-    dateEpoch, 
-    locale, 
-    options = { dateStyle: "long" }
-  }: {
-    dateEpoch: number,
-    locale?: string,
-    options?: Intl.DateTimeFormatOptions
-  }): string => {
-  const languageCode = LANGUAGE_CODES[locale as keyof typeof LANGUAGE_CODES] || "en-GB";
+export const prettifyDate = ({
+  dateEpoch,
+  locale,
+  options = { dateStyle: "long" },
+}: {
+  dateEpoch: number;
+  locale?: string;
+  options?: Intl.DateTimeFormatOptions;
+}): string => {
+  const languageCode =
+    LANGUAGE_CODES[locale as keyof typeof LANGUAGE_CODES] || "en-GB";
   let dateEpochInMilliSeconds: number;
   if (dateEpoch.toString().length === 10) {
     // Epoch is in seconds

--- a/src/utils/sns.ts
+++ b/src/utils/sns.ts
@@ -7,13 +7,13 @@ export function snsService(config: SnsConfig = getSNSConfig()): SnsService {
     topic_arn: string,
     message: string
   ): Promise<SNS.Types.PublishResponse> {
-    const sns = new SNS(config.awsConfig)
+    const sns = new SNS(config.awsConfig);
 
     const request: SNS.PublishInput = {
       TopicArn: topic_arn,
       Message: message,
     };
-    
+
     return await sns.publish(request).promise();
   };
   return {

--- a/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
+++ b/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
@@ -67,8 +67,10 @@ describe("Middleware", () => {
       expect(res.locals).to.not.have.property("contactUsLinkUrl");
       outboundContactUsLinksMiddleware(req, res, next);
       expect(res.locals).to.have.property("contactUsLinkUrl");
-      expect(res.locals.contactUsLinkUrl).to.equal("https://home.account.gov.uk/contact-gov-uk-one-login?" +
-        "fromURL=https%3A%2F%2Fhome.account.gov.uk%2Fcontact-gov-uk-one-login");
+      expect(res.locals.contactUsLinkUrl).to.equal(
+        "https://home.account.gov.uk/contact-gov-uk-one-login?" +
+          "fromURL=https%3A%2F%2Fhome.account.gov.uk%2Fcontact-gov-uk-one-login"
+      );
     });
   });
 

--- a/test/unit/utils/prettifyDate.test.ts
+++ b/test/unit/utils/prettifyDate.test.ts
@@ -5,34 +5,47 @@ import { prettifyDate } from "../../../src/utils/prettifyDate";
 describe("PrettifyDate util", () => {
   it("takes a date epoch in seconds and returns a pretty formatted date", async () => {
     const dateEpochInSeconds = 1673358736;
-    expect(prettifyDate({dateEpoch: dateEpochInSeconds})).equal("10 January 2023");
+    expect(prettifyDate({ dateEpoch: dateEpochInSeconds })).equal(
+      "10 January 2023"
+    );
   });
-    
+
   it("takes a date epoch in milliseconds and returns a pretty formatted date", async () => {
     const dateEpochInSeconds = 2382450028987;
-    expect(prettifyDate({dateEpoch: dateEpochInSeconds })).equal("30 June 2045");
+    expect(prettifyDate({ dateEpoch: dateEpochInSeconds })).equal(
+      "30 June 2045"
+    );
   });
 
   it("allows passing formatting options", async () => {
     const dateEpochInSeconds = 1673358736;
-    expect(prettifyDate({dateEpoch: dateEpochInSeconds, options: {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "numeric",
-      hourCycle: "h12",
-      timeZone: "GB",
-    }})).equal("10 January 2023 at 1:52 pm");
+    expect(
+      prettifyDate({
+        dateEpoch: dateEpochInSeconds,
+        options: {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          hourCycle: "h12",
+          timeZone: "GB",
+        },
+      })
+    ).equal("10 January 2023 at 1:52 pm");
   });
 
   it("returns Welsh version when locale parameter is 'cy'", async () => {
     const dateEpochInSeconds = 2382450028987;
-    expect(prettifyDate({dateEpoch: dateEpochInSeconds, locale: "cy" })).equal("30 Mehefin 2045");
+    expect(prettifyDate({ dateEpoch: dateEpochInSeconds, locale: "cy" })).equal(
+      "30 Mehefin 2045"
+    );
   });
 
   it("returns date in English if locale parameter is invalid", async () => {
     const dateEpochInSeconds = 2382450028987;
-    expect(prettifyDate({dateEpoch: dateEpochInSeconds, locale: "asdf" })).equal("30 June 2045");
+    expect(
+      prettifyDate({ dateEpoch: dateEpochInSeconds, locale: "asdf" })
+    ).equal("30 June 2045");
   });
-}) 
+});


### PR DESCRIPTION
This PR changes the eslint rules we use to match what we use in the backend. From `prettier` to `prettier/recommended`

I think it makes sense to be consistent with the backend. It enforces indentation around code blocks, which makes the code much more readable (imo)