### PR TITLE
OLH-1525: add tests for HMRC card

### DIFF
--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -53,9 +53,10 @@
       <ul class="govuk-list your-services__list">
         {% for service in servicesList %}
           {% set locale = ['clientRegistry.', env, '.', service.client_id, '.'] | join %}
-          <li class="your-services__card">
+          {% set testIdValue = "service-card-long" if service.hasDetailedCard else "service-card-short" %}
+          <li class="your-services__card" data-test-id={{testIdValue}}>
             <div class="your-services__card__content">
-            {% if service.isHMRC %}
+            {% if service.hasDetailedCard %}
             {# The HMRC service card contains more information than the regular ones #}
               <{{serviceHeadingLevel}} class="govuk-heading-s" data-test-id="service-card-heading">
                 {{ [locale, 'header'] | join | translate }}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,7 +13,7 @@ export interface Service {
   count_successful_logins: number;
   last_accessed: number;
   last_accessed_readable_format: string;
-  isHMRC?: boolean;
+  hasDetailedCard?: boolean;
 }
 
 export interface YourServices {

--- a/src/utils/yourServices.ts
+++ b/src/utils/yourServices.ts
@@ -98,13 +98,13 @@ export const formatService = (
     dateEpoch: service.last_accessed,
     locale: currentLanguage,
   });
-  const isHMRC = hmrcClientIds.includes(service.client_id);
+  const hasDetailedCard = hmrcClientIds.includes(service.client_id);
   return {
     client_id: service.client_id,
     count_successful_logins: service.count_successful_logins,
     last_accessed: service.last_accessed,
     last_accessed_readable_format: readable_format_date,
-    isHMRC: isHMRC,
+    hasDetailedCard: hasDetailedCard,
   };
 };
 

--- a/test/unit/utils/yourServices.test.ts
+++ b/test/unit/utils/yourServices.test.ts
@@ -14,7 +14,7 @@ describe("YourService Util", () => {
         client_id: "a_client_id",
         count_successful_logins: 1,
         last_accessed: dateEpochInSeconds,
-        last_accessed_readable_format: undefined,
+        last_accessed_readable_format: "1673356836",
       };
 
       const formattedService: Service = formatService(serviceFromDb, "en");
@@ -24,6 +24,20 @@ describe("YourService Util", () => {
       expect(formattedService.last_accessed_readable_format).equal(
         "10 January 2023"
       );
+    });
+
+    it("format service object with hasDetailedCard if service is hmrc", async () => {
+      const dateEpochInSeconds = 1673358736;
+      const serviceFromDb: Service = {
+        client_id: "hmrc",
+        count_successful_logins: 1,
+        last_accessed: dateEpochInSeconds,
+        last_accessed_readable_format: "1673356836",
+      };
+
+      const formattedService: Service = formatService(serviceFromDb, "en");
+
+      expect(formattedService.hasDetailedCard).equal(true);
     });
   });
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Address the comments on [this PR](https://github.com/govuk-one-login/di-account-management-frontend/pull/1179).


The points that were left unaddressed: 
1.  enquiring whether the conditional rendering of the longer service card design with `{% if service.isHMRC %}` can be made more semantic by checking whether a `paragraph1` field exists instead.
2. adding tests for the longer service card design

In this PR I addressed question 2. 

I attempted to address question 1, however I could not find a good way to conditionally display pieces of UI if a translation exists, or to determine whether a translation exists from the template layer in general. 

This doesn't seem to be something that we are currently doing anywhere else, and it doesn't seem straightforward to do, so I'm not sure whether it would warrant the effort that would be necessary to implement it (but let me know what you think).

It doesn't sound as if there are plans to use this longer style of card for any other service, however I did change the flag from `isHMRC` to `hasDetailedCard` to make it more generic. In the backend it's still HMRC specific (as in there is a check that determines whether the service client id is a HMRC one, and adds `hasDetailedCard` to the formatted data object if that is the case)

https://govukverify.atlassian.net/browse/OLH-1525 
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The changes had to go live before addressing the comments on the PR.
This addresses them retrospectively.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review
A code review plus checking the HMRC card still displays correctly.

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
