### PR TITLE
OLH-1623 Add a type definition for users' MFA methods to the frontend session

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -1,6 +1,6 @@
 import { Client } from "openid-client";
 import { User } from "../../src/types";
-import { QueryParameters } from "../../src/app.constants";
+import { QueryParameters, MfaMethod } from "../../src/app.constants";
 
 declare module "express-session" {
   interface Session {
@@ -14,6 +14,7 @@ declare module "express-session" {
     referenceCodeOwningSessionId?: string;
     queryParameters?: QueryParameters;
     sessionId?: string;
+    mfaMethods?: MfaMethod[];
   }
 }
 declare module "express-serve-static-core" {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -189,6 +189,14 @@ export interface QueryParameters {
   theme?: string;
 }
 
+export interface MfaMethod {
+  mfaIdentifier: number;
+  priorityIdentifier: "PRIMARY" | "SECONDARY";
+  mfaMethodType: "SMS" | "AUTH_APP";
+  endPoint: string;
+  methodVerified: boolean;
+}
+
 export const MISSING_APP_SESSION_ID_SPECIAL_CASE = "No app session ID";
 export const MISSING_SESSION_ID_SPECIAL_CASE = "No session ID";
 export const MISSING_PERSISTENT_SESSION_ID_SPECIAL_CASE =


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

- Create a MFA Method type (based on [this](https://github.com/govuk-one-login/openapi-specs/blob/main/auth/method-management-api.yaml#L169-L193))
- Add an array of the new type that to session type definition

### Why did it change

We will need this data available in the session object in order display the MFA methods to the user. 