### PR TITLE
BAU: Update stub RP client IDs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -131,9 +131,9 @@ const FIND_AND_APPLY_FOR_A_GRANT_PROD: string = "tya4DoMpw_B7FK5YvuMAj3asc0A";
 const FIND_AND_APPLY_FOR_A_GRANT_NON_PROD: string = "findAndApplyForAGrant";
 const DVSA_PROD: string = "oLciSn5b6-cqcJjzgMMwCw1moD8";
 const DVSA_NON_PROD: string = "vehicleOperatorLicense";
-const STUB_RP_PROD: string = "mTGf7RHk09WyEYUNZ71IUGIFJxEQ5hn1";
-const STUB_RP_INTEGRATION: string = "cVCXupm3pykG8OJV0foZFAOtVeT3gukI";
-const STUB_RP_STAGING: string = "8u21cESiFjAcO4IUC6H3ANNgkmu4MpH8";
+const STUB_RP_PROD: string = "5Vfplamzln0AoarlnX5CX4UTqyh59xfA";
+const STUB_RP_INTEGRATION: string = "gjWNvoLYietMjeaOE6Zoww533u18ZUfr";
+const STUB_RP_STAGING: string = "3NKFv679oYlMdyrhKErrTGbzBy2h8rrd";
 export const ONE_LOGIN_HOME_NON_PROD: string = "oneLoginHome";
 
 export const getAllowedAccountListClientIDs: string[] = [


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update stub RP client IDs. This fixes the issue we're having where people can't view the activity history in production.

### Why did it change

The client IDs for all the stub RPs recently changed due to Orchestration changing the way they're provisioned. See https://github.com/govuk-one-login/relying-party-stub/pull/105 for more details and to verify the new IDs.

After this change we don't expect any further changes to the IDs.

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
