### PR TITLE
BAU: inline style causing CSP error

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -176,6 +176,10 @@ $govuk-new-link-styles: true;
   }
 }
 
+.govuk-header__link--homepage {
+  margin-right: govuk-spacing(4);
+}
+
 .account-navigation {
   background-color: govuk-colour("light-grey");
   border-bottom: 1px solid $govuk-border-colour;

--- a/src/components/common/layout/header.njk
+++ b/src/components/common/layout/header.njk
@@ -1,7 +1,7 @@
 <header class="govuk-header {{ headerClasses }}" role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
-            <a href="{{ accountHome }}" class="govuk-header__link govuk-header__link--homepage" style="margin-right: 20px;">
+            <a href="{{ accountHome }}" class="govuk-header__link govuk-header__link--homepage">
                 <span class="govuk-header__logotype">
                   <!--[if gt IE 8]><!-->
                     <svg


### PR DESCRIPTION
Some inline CSS was applied to the header component. There was a CSP error relating to this. 


<img width="1558" alt="Screenshot 2024-03-25 at 17 03 24" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/9b193d04-22a6-48d2-b57f-684939008932">

There is no reason this CSS would need to be inline. This removes the inline CSS and applies the same rule in our application css sheet.



## How to review
Verify that the CSP error is gone and the styling is still applied on the `.govuk-header__link--homepage` element
<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
