### PR TITLE
OLH-1636 - Error Recording Activity history

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-routes.ts
@@ -7,7 +7,6 @@ import {
 import { PATH_DATA } from "../../app.constants";
 import { asyncHandler } from "../../utils/async";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
-import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 import { checkRSAAllowedServicesList } from "../../middleware/check-allowed-services-list";
 
 const router = express.Router();
@@ -22,7 +21,6 @@ router.get(
 router.post(
   PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done",
   requiresAuthMiddleware,
-  refreshTokenMiddleware(),
   checkRSAAllowedServicesList,
   asyncHandler(reportSuspiciousActivityPost)
 );


### PR DESCRIPTION
## Proposed changes

### What changed
OLH-1636 - Error Recording Activity history
Remove refreshMiddlewareToken from RSA route.


### Why did it change

We discovered the refreshMiddlewareToken potentially always fails. 

### Related links

https://govukverify.atlassian.net/browse/OLH-1636

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing

Deploy to dev and ensure RSA journey is not broken

## How to review
