### PR TITLE
OLH-1316: focus order fix for accessibility

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -6,13 +6,13 @@
 {% set languageToggle = true %}
 {% set secondaryContactMethodEnabled = contactPhoneEnabled or contactWebchatEnabled %}
 
-{% if contactWebchatEnabled %}
-  {% block head %} 
-    {{ super() }}
+{% block head %} 
+  {{ super() }}
+  {% if contactWebchatEnabled %}
     <link rel="stylesheet" nonce="{{scriptNonce}}" href="https://fonts.cdnfonts.com/css/rubik">
     <link rel="stylesheet" nonce="{{scriptNonce}}" href="{{webchatSource}}/css/loader.css">
-  {% endblock %}
-{% endif %}
+  {% endif %}
+{% endblock %}
 
 {% set emailBlock %}
   <section>
@@ -199,4 +199,5 @@
     }, 10000)
   </script>
 {% endif %}
+
 {% endblock %}

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -77,7 +77,6 @@
 {# START page content #}
 
 {% block pageContent %}
-
 <h1 class="govuk-heading-xl">{{'pages.contact.header' | translate}}</h1>
 
 {% if not showContactGuidance and not contactWebchatEnabled and not contactPhoneEnabled %}
@@ -146,7 +145,7 @@
 {% endif %}
 
 {% if contactWebchatEnabled %}
-  <script id="smartagent" type="module" defer 
+  <script id="smartagent" type="module" defer
     src="{{ webchatSource }}/loader/main.js" 
     data-company="hgsgds" data-brand="hgsgds"
     nonce="{{ nonce }}">
@@ -155,12 +154,24 @@
     var launchWebchatButton = document.querySelector("[data-launch-webchat]");
 
     launchWebchatButton.addEventListener("click", function() {
-      if (window._sa) {
-        window._sa.openChat();
-          const webchat = document.querySelector("iframe.sa-chat-iframe");
-          if (webchat) {
-            webchat.focus();
-          }
+      const webchatWindow = document.querySelector(".sa-chat-slideout");
+      if (window._sa && webchatWindow) {
+        try {
+          window._sa.toggleChat();
+          // setTimeout is only necessary here because the toggleChat() function uses setTimeout when setting focus and toggling the isOpen state
+          setTimeout(() => {
+            if (window._sa.isOpen()) {
+              // when the webchat is opened using the "Use webchat" button, move focus to the first focusable element in the window
+              webchatWindow.querySelector('button').focus();
+            } else {
+              // when the webchat is closed using the "Use webchat" button, move focus back to the "Use webchat" button
+              launchWebchatButton.focus();
+            }
+          },0)
+        }
+        catch(err) {
+          console.error(err);
+        }
       }
     });
 


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed


[OLH-1316: Fix webchat focus order issue](https://github.com/govuk-one-login/di-account-management-frontend/commit/7c374d75e1cb6d27496c5c673091b7f8865ea747) 

The purpose of these changes is to address an issue as described in the DAC audit report ([link in JIRA](https://govukverify.atlassian.net/browse/OLH-1316)). The issue is that focus order does not follow logically when the Webchat is activated using the "Use webchat" button in the content of the page (WCAG 2.4.3 Focus Order (Level A))

When navigating by keyboard or screen reader software, the following should happen:
- when the webchat is opened using the "Use webchat" button, focus should move to the webchat window (whereas currently users have to tab through the entire content of the page to reach the webchat window)
- when the webchat is closed using the "Use webchat" button, focus should move back to the "Use webchat" button (whereas currently focus remains on the floating button)

[Webchat asset conditional rendering](https://github.com/govuk-one-login/di-account-management-frontend/commit/587b9181fd7fee7daee210e9c053ff07227bfddc) 

Moved the `contactWebchatEnabled` condition into the `head` block on the webchat template. 
The reason for this change is I noticed that a request was being made for the stylesheet in production and other
environments where the webchat was off.
Moving this conditional block inside the head block instead of attempting to make the head block conditional upon `contactWebchatEnabled` being true seemed to fix the issue. It might have been a case of nunjucks being quirky.

Similarly: added the webchat related scripts to the scripts block which gets appended at the end of the body tag.


<!-- Describe the changes in detail - the "what"-->

### Why did it change
These issues must be addressed before the webchat feature goes live. 
<!-- Describe the reason these changes were made - the "why" -->

### Related links
Jira: https://govukverify.atlassian.net/browse/OLH-1316 
Accessibility report: https://drive.google.com/file/d/1drLiDgz5afi3rgyQot_eGl-ZN-wWEVLB/view?pli=1 
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Test
- the feature flag still works and no styles/scripts are loading when the flag is off
- the "Use webchat" button behaves as described above when navigating by keyboard 
<!-- Provide a summary of any manual testing you've done -->

