### PR TITLE
OLH-1670: Remove 'Find a grant' from services list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -192,8 +192,6 @@ export const getAllowedServiceListClientIDs: string[] = [
   "mortgageDeed",
   VETERANS_CARD_PROD,
   VETERANS_CARD_NON_PROD,
-  FIND_AND_APPLY_FOR_A_GRANT_PROD,
-  FIND_AND_APPLY_FOR_A_GRANT_NON_PROD,
   ...hmrcClientIds,
 ];
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import {
+  getAllowedAccountListClientIDs,
+  getAllowedServiceListClientIDs,
+} from "../../src/config";
+
+describe("config", () => {
+  describe("Service configuration", () => {
+    it("should have no services in the accounts list that are in the other services list", () => {
+      expect(
+        getAllowedAccountListClientIDs.filter((service) =>
+          getAllowedServiceListClientIDs.includes(service)
+        ).length
+      ).to.eq(0);
+    });
+
+    it("should have no services in the other services list that are in the accounts list", () => {
+      expect(
+        getAllowedServiceListClientIDs.filter((service) =>
+          getAllowedAccountListClientIDs.includes(service)
+        ).length
+      ).to.eq(0);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

The 'Find and apply for a grant' service was wrongly in both the list of account services and standalone services. This meant that if a user had the service card they'd see it under both 'Your accounts' and 'Other services you've used'.

### Why did it change


We missed this duplication when we changed these lists in #1192. I've checked all the other IDs in the lists and there's no other duplicate entries so this is the only service we need to check.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
I've run this locally and given myself a card for this service. I can see it now only appears once in the correct section:

![localhost_6001_your-services (1)](https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/33e50d9a-bc89-4447-9b10-0626368ac726)
