### PR TITLE
OLH-1616: Increase frequency of application healthchecks

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -750,10 +750,10 @@ Resources:
               Value: !Ref TxMAPublishErrorDeadLetterQueue
             - Name: "GENERATOR_KEY_ARN"
               Value: !ImportValue
-                'Fn::Sub': "${BackendStackName}-GeneratorKey"
+                "Fn::Sub": "${BackendStackName}-GeneratorKey"
             - Name: "WRAPPING_KEY_ARN"
               Value: !ImportValue
-                'Fn::Sub': "${BackendStackName}-WrappingKey"
+                "Fn::Sub": "${BackendStackName}-WrappingKey"
             - Name: "ACCOUNT_ID"
               Value: !Sub "${AWS::AccountId}"
             - Name: "ENVIRONMENT"
@@ -1089,7 +1089,7 @@ Resources:
       HealthCheckPort: !Ref ContainerPort
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
-      HealthCheckIntervalSeconds: 30
+      HealthCheckIntervalSeconds: 15
       Port: !Ref ContainerPort
       Protocol: HTTP
       ProtocolVersion: HTTP1


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Reduce the interval between healthcheck requests from our load balancer to every 15 seconds.

### Why did it change

Currently the healthchecks are every 30 seconds and we wait for 2 consecutive failed checks before we mark an instance as unhealthy. This means that if a container does crash we're waiting for 60 seconds before starting a new one.

This may be one of the reasons why we're seeing so many failed requests under load in the performance tests. Making the requests more frequently means we'll detect crashed containers sooner.
### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've deployed this to dev to make sure the containers can start up successfully with this new timing.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
