### PR TITLE
OLH-1636 - Refresh Token Middleware Error

### DIFF
--- a/src/middleware/refresh-token-middleware.ts
+++ b/src/middleware/refresh-token-middleware.ts
@@ -17,16 +17,19 @@ export function refreshTokenMiddleware(
           req.oidc.issuer.metadata.token_endpoint
         );
 
-        const tokenSet = await retryableFunction(req.oidc.refresh, [
-          req.session.user.tokens.refreshToken,
-          {
-            exchangeBody: {
-              client_assertion_type:
-                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-              client_assertion: clientAssertion,
+        const tokenSet = await retryableFunction(
+          req.oidc.refresh.bind(req.oidc) as typeof req.oidc.refresh,
+          [
+            req.session.user.tokens.refreshToken,
+            {
+              exchangeBody: {
+                client_assertion_type:
+                  "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                client_assertion: clientAssertion,
+              },
             },
-          },
-        ]);
+          ]
+        );
         req.session.user.tokens.accessToken = tokenSet.access_token;
         req.session.user.tokens.refreshToken = tokenSet.refresh_token;
       } catch (err) {


### PR DESCRIPTION
## Proposed changes
OLH-1636 - Refresh Token Middleware Error

### What changed
Bind the OIDC object to the retryable method call because we observed this is returning as null when called.

### Why did it change
Prod error when refreshing access token

### Related links
https://govukverify.atlassian.net/browse/OLH-1636

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing

Deployed up to a tested in staging

## How to review

Code completeness and test
