### PR TITLE
OLH-1409: Support Welsh webchat

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -5,6 +5,7 @@
 {% set hideAccountNavigation = true %}
 {% set languageToggle = true %}
 {% set secondaryContactMethodEnabled = contactPhoneEnabled or contactWebchatEnabled %}
+{% set webchatLang = "welsh" if language == "cy" else "hgsgds" %}
 
 {% block head %} 
   {{ super() }}
@@ -147,9 +148,10 @@
 {% if contactWebchatEnabled %}
   <script id="smartagent" type="module" defer
     src="{{ webchatSource }}/loader/main.js" 
-    data-company="hgsgds" data-brand="hgsgds"
+    data-company="hgsgds" facia="{{webchatLang}}"
     nonce="{{ nonce }}">
   </script>
+
   <script type="text/javascript" nonce='{{scriptNonce}}'>
     var launchWebchatButton = document.querySelector("[data-launch-webchat]");
 


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->



### What changed

Add support for Welsh version of Webchat by replacing the `data-brand` attribute with a `facia` attribute whose values should be: 
- "hgsgds" when the language of the page is English
-  "welsh" when the language of the page is Welsh.


<!-- Describe the changes in detail - the "what"-->

### Why did it change
Webchat must support Welsh. These are the updates we were instructed to make, in order to support it. 
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Switched language to Welsh, checked the attribute was correct and that Welsh chat was loading.
Switched back to English, checked that English chat was loading. 
<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
