### PR TITLE
OLH-1653 - Add link to guidance for helpers from contact triage page.

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -101,6 +101,7 @@
         {% endfor %}
       </ul>
       {% endif %}
+      <p class="govuk-body">{{ 'pages.contact.section1.guidance-for-helpers' | translate | safe }}</p>
     </section>
     <hr class="govuk-section-break govuk-section-break--m">
   {% endif %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -574,7 +574,8 @@
             "href": "https://www.gov.uk/guidance/deleting-your-govuk-one-login.cy",
             "text": "Dileu eich GOV.UK One Login"
           }
-        ]
+        ],
+        "guidance-for-helpers": "Os ydych yn cael trafferth defnyddio GOV.UK One Login ar eich pen eich hun, gallwch gael help gan rywun rydych yn ei adnabod ac yn ymddiried ynddynt. Darganfyddwch <a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/help-someone-use-govuk-one-login\",>beth gall ac na all y person sy'n eich helpu ei wneud</a>."
       },
       "section2": {
         "heading": "Pan fyddwch yn cysylltu â ni"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -605,7 +605,8 @@
             "href": "https://www.gov.uk/guidance/deleting-your-govuk-one-login",
             "text": "Deleting your GOV.UK One Login"
           }
-        ]
+        ],
+        "guidance-for-helpers": "If you're having trouble using GOV.UK One Login by yourself, you can get help from someone you know and trust. Find out <a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/help-someone-use-govuk-one-login\">what the person who helps you can and cannot do</a>."
       },
       "section2": {
         "heading": "When you contact us"


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
Add a link to guidance for helpers to the contact triage page.

### What changed
Link added after the links in the ‘Before you contact us’ section of the contact triage page.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

So people who help users with setting up their one login or proving their ID can find the guidance.

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

<!-- Provide a summary of any manual testing you've done -->

Can be deployed to dev.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->

Check links and welsh displaying correctly.
