### PR TITLE
BAU: Add pre-commit config to run prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.2.5

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Clones the repository to the `your_folder_name` directory.
 
 ## Developer notes
 
+### Pre-commit
+
+This repository uses [pre-commit](https://pre-commit.com/) to run linting on all staged files before they're committed.
+Install & setup pre-commit by running:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+When you make your first commit, pre-commit will fetch and install the hook configuration.
+This may take a few minutes but won't need to be repeated for future commits.
+
 ### Logging with a trace id
 
 See [One Login home developer notes](https://team-manual.account.gov.uk/teams/home-team/) in our section of the DI Manual.


### PR DESCRIPTION

## Proposed changes
### What changed

This will run prettier on all staged files before a new commit is created. If any files are modified, the hook will fail and we'll need to check and stage the changes.

### Why did it change

To keep our formatting consistent and reduce the number of linting changes / commits we need to review.

### Related links

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I ran the new install commands from the README before committing the changes in this PR to test the hook behaviour.
