### PR TITLE
OLH-1695: Load production webchat in integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -228,7 +228,7 @@ Mappings:
       SERVICEDOMAIN: "integration.account.gov.uk"
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "1"
-      WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app"
+      WEBCHATSOURCEURL: "https://chat-loader.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Point our integration environment at our supplier's production webchat instance. See [Ben's message in Slack](https://gds.slack.com/archives/C012GEZBZM0/p1712591841543219) confirming the production URL.

### Why did it change

This is a temporary measure to allow us to test the English and Welsh flows & configuration before we try to go live on Monday.
