### PR TITLE
OLH-1472 Investigate Multiple FROM URL on request path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "nunjucks": "^3.2.4",
         "openid-client": "^5.6.5",
         "otplib": "^12.0.1",
-        "pino": "^8.19.0",
+        "pino": "^8.20.0",
         "pino-http": "^9.0.0",
         "prettier": "^3.2.5",
         "qrcode": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "nunjucks": "^3.2.4",
     "openid-client": "^5.6.5",
     "otplib": "^12.0.1",
-    "pino": "^8.19.0",
+    "pino": "^8.20.0",
     "pino-http": "^9.0.0",
     "prettier": "^3.2.5",
     "qrcode": "^1.5.0",

--- a/src/components/common/layout/languageToggle.njk
+++ b/src/components/common/layout/languageToggle.njk
@@ -7,7 +7,7 @@
                     <span aria-current="page">{{ translationKey | translate }}</span>
                 {% else %}
                     <a class="govuk-link govuk-link--no-visited-state language-select__link"
-                       lang="{{ lang }}" hreflang="{{ lang }}" href="{{ currentUrl | addLanguageParam(lang, baseUrl) }}">
+                       lang="{{ lang }}" hreflang="{{ lang }}" href="{{ currentUrl | addLanguageParam(lang, baseUrl) }}" rel="nofollow">
                         {{ translationKey | translate }}
                     </a>
                 {% endif %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -632,7 +632,7 @@
             "Penwythnosau a gwyliau cyhoeddus, 9am i 5:30pm"
           ],
           "callChargesLinkText": "Darganfyddwch fwy am gostau galwadau",
-          "waitingTimeWarning": "Mae amseroedd aros hir ar y ffôn ar hyn o bryd. Os nad yw'ch galwad yn un brys, rhowch gynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\">cwblhewch y ffurflen gyswllt</a>."
+          "waitingTimeWarning": "Mae amseroedd aros hir ar y ffôn ar hyn o bryd. Os nad yw'ch galwad yn un brys, rhowch gynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">cwblhewch y ffurflen gyswllt</a>."
         },
         "email": {
           "heading": "E-bost",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -203,7 +203,7 @@
       },
       "backLink": "I do not want to add another way to get security codes",
       "continue": "Continue"
-    }, 
+    },
     "addMfaMethodApp": {
       "title": "Set up an authenticator app",
       "step1": {
@@ -692,7 +692,7 @@
             "weekends and public holidays, 9am to 5.30pm"
           ],
           "callChargesLinkText": "Find out about call charges",
-          "waitingTimeWarning": "There are currently long waiting times on the phone. If your call is not urgent, try again later or <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\">fill in the contact form</a>."
+          "waitingTimeWarning": "There are currently long waiting times on the phone. If your call is not urgent, try again later or <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">fill in the contact form</a>."
         },
         "email": {
           "heading": "Email",

--- a/src/middleware/update-session-middleware.ts
+++ b/src/middleware/update-session-middleware.ts
@@ -31,19 +31,17 @@ export const updateSessionMiddleware = (
 ): void => {
   const session = req.session;
   const queryParams = req.query;
-  const { fromURL } = queryParams;
+  const fromURL: string | undefined = req.query.fromURL as string | undefined;
   const trace = res.locals.sessionId;
   session.queryParameters = {};
-
-  if (fromURL) {
-    if (isValidUrl(fromURL)) {
-      session.queryParameters.fromURL = fromURL as string;
-    } else {
-      logger.error(
-        { trace: trace },
-        "fromURL in request query for contact-govuk-one-login page did not pass validation"
-      );
-    }
+  const validatedURL = isValidUrl(fromURL);
+  if (validatedURL) {
+    session.queryParameters.fromURL = new URL(fromURL).toString();
+  } else {
+    logger.error(
+      { trace: trace },
+      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+    );
   }
 
   copySafeQueryParamToSession(session, queryParams, "theme", trace);

--- a/src/middleware/update-session-middleware.ts
+++ b/src/middleware/update-session-middleware.ts
@@ -16,7 +16,7 @@ const copySafeQueryParamToSession = (
     if (isSafeString(queryParams[paramName] as string)) {
       session.queryParameters[paramName] = queryParams[paramName] as string;
     } else {
-      logger.error(
+      logger.warn(
         { trace: sessionId },
         `${paramName} in request query for contact-govuk-one-login page did not pass validation`
       );
@@ -38,7 +38,7 @@ export const updateSessionMiddleware = (
   if (validatedURL) {
     session.queryParameters.fromURL = new URL(fromURL).toString();
   } else {
-    logger.error(
+    logger.warn(
       { trace: trace },
       "fromURL in request query for contact-govuk-one-login page did not pass validation"
     );

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -36,7 +36,7 @@ export function isValidUrl(urlString: string | undefined): boolean {
       url.hostname === "127.0.0.1"
     );
   } catch (e) {
-    logger.error({ url: urlString }, e.toString());
+    logger.warn({ url: urlString }, e.toString());
     return false;
   }
 }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,9 +1,6 @@
 import { randomBytes } from "crypto";
-import { ParsedQs } from "qs";
+import { logger } from "./logger";
 
-const urlRegex = new RegExp(
-  "^(http(s)?://)?(www.)?[-a-zA-Z0-9@:%.+~#=]{2,256}\\.[a-z]{2,6}([-a-zA-Z0-9@:%_+.~#?&//=]*)$"
-);
 const lowerAndUpperCaseLettersAndNumbersMax50 = new RegExp(
   "^[a-zA-Z0-9_-]{1,50}$"
 );
@@ -26,13 +23,22 @@ export function generateNonce(): string {
   return randomBytes(16).toString("hex");
 }
 
-export function isValidUrl(
-  url: string | string[] | ParsedQs | ParsedQs[]
-): boolean {
-  if (typeof url !== "string") {
+export function isValidUrl(urlString: string | undefined): boolean {
+  if (!urlString) {
     return false;
   }
-  return urlRegex.test(url);
+
+  try {
+    const url = new URL(urlString);
+    return !(
+      url.hostname === "" ||
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1"
+    );
+  } catch (e) {
+    logger.error({ url: urlString }, e.toString());
+    return false;
+  }
 }
 
 export function isSafeString(url: string): boolean {

--- a/test/unit/middleware/update-session-middleware.test.ts
+++ b/test/unit/middleware/update-session-middleware.test.ts
@@ -38,11 +38,11 @@ describe("updateSessionMiddleware", () => {
   });
 
   it("should set session.queryParameters.fromURL if it's a valid URL", () => {
-    mockRequest.query.fromURL = "https://valid-url.com";
+    mockRequest.query.fromURL = "https://valid-url.com/";
     updateSessionMiddleware(mockRequest, mockResponse, nextFunction);
 
     expect(mockRequest.session.queryParameters.fromURL).to.equal(
-      "https://valid-url.com"
+      "https://valid-url.com/"
     );
     expect(loggerErrorSpy.notCalled).to.be.true;
   });
@@ -51,14 +51,20 @@ describe("updateSessionMiddleware", () => {
     mockRequest.query.theme = "hEllo***";
     updateSessionMiddleware(mockRequest, mockResponse, nextFunction);
 
-    expect(loggerErrorSpy.calledOnce).to.be.true;
+    expect(loggerErrorSpy.calledTwice).to.be.true;
   });
 
   it("should log an error for invalid fromURL", () => {
     mockRequest.query.fromURL = "invalid-url";
     updateSessionMiddleware(mockRequest, mockResponse, nextFunction);
-
-    expect(loggerErrorSpy.calledOnce).to.be.true;
+    expect(loggerErrorSpy).to.be.calledWith(
+      { url: "invalid-url" },
+      "TypeError [ERR_INVALID_URL]: Invalid URL"
+    );
+    expect(loggerErrorSpy).to.be.calledWith(
+      { trace: mockResponse.locals.sessionId },
+      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+    );
     expect(mockRequest.session.queryParameters.fromURL).to.be.undefined;
   });
 

--- a/test/unit/middleware/update-session-middleware.test.ts
+++ b/test/unit/middleware/update-session-middleware.test.ts
@@ -11,7 +11,7 @@ describe("updateSessionMiddleware", () => {
   let mockRequest: any;
   let mockResponse: any;
   let nextFunction: sinon.SinonStub;
-  let loggerErrorSpy: sinon.SinonSpy;
+  let loggerWarnSpy: sinon.SinonSpy;
 
   beforeEach(() => {
     // Mock request, response, and next function
@@ -28,13 +28,12 @@ describe("updateSessionMiddleware", () => {
 
     nextFunction = sinon.stub();
 
-    // Spy on logger's error method
-    loggerErrorSpy = sinon.spy(logger, "error");
+    loggerWarnSpy = sinon.spy(logger, "warn");
   });
 
   afterEach(() => {
     // Restore the spied upon methods
-    loggerErrorSpy.restore();
+    loggerWarnSpy.restore();
   });
 
   it("should set session.queryParameters.fromURL if it's a valid URL", () => {
@@ -44,24 +43,24 @@ describe("updateSessionMiddleware", () => {
     expect(mockRequest.session.queryParameters.fromURL).to.equal(
       "https://valid-url.com/"
     );
-    expect(loggerErrorSpy.notCalled).to.be.true;
+    expect(loggerWarnSpy.notCalled).to.be.true;
   });
 
   it("should not set session.queryParameters.fromURL if the string is not safe", () => {
     mockRequest.query.theme = "hEllo***";
     updateSessionMiddleware(mockRequest, mockResponse, nextFunction);
 
-    expect(loggerErrorSpy.calledTwice).to.be.true;
+    expect(loggerWarnSpy.calledTwice).to.be.true;
   });
 
-  it("should log an error for invalid fromURL", () => {
+  it("should log a warning for invalid fromURL", () => {
     mockRequest.query.fromURL = "invalid-url";
     updateSessionMiddleware(mockRequest, mockResponse, nextFunction);
-    expect(loggerErrorSpy).to.be.calledWith(
+    expect(loggerWarnSpy).to.be.calledWith(
       { url: "invalid-url" },
       "TypeError [ERR_INVALID_URL]: Invalid URL"
     );
-    expect(loggerErrorSpy).to.be.calledWith(
+    expect(loggerWarnSpy).to.be.calledWith(
       { trace: mockResponse.locals.sessionId },
       "fromURL in request query for contact-govuk-one-login page did not pass validation"
     );

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { describe } from "mocha";
+import { beforeEach, describe } from "mocha";
 import {
   containsNumber,
   containsNumbersOnly,
@@ -8,6 +8,8 @@ import {
   redactPhoneNumber,
   zeroPad,
 } from "../../../src/utils/strings";
+import { sinon } from "../../utils/test-utils";
+import { logger } from "../../../src/utils/logger";
 
 describe("string-helpers", () => {
   describe("containsNumber", () => {
@@ -65,22 +67,46 @@ describe("string-helpers", () => {
   });
 
   describe("isValidUrl", () => {
+    let loggerErrorSpy: sinon.SinonSpy;
+    // Optional: Utility function to generate test URLs
+    function generateTestUrls(
+      baseUrl: string,
+      iterations: number = 5
+    ): string[] {
+      const urls: string[] = [baseUrl];
+      for (let i = 1; i <= iterations; i++) {
+        const url = new URL(urls[i - 1]);
+        url.searchParams.set("fromURL", encodeURIComponent(urls[i - 1]));
+        urls.push(url.toString());
+      }
+      return urls;
+    }
+
+    beforeEach(() => {
+      loggerErrorSpy = sinon.spy(logger, "error");
+    });
+
+    afterEach(() => {
+      loggerErrorSpy.restore();
+    });
+
     it("should return true if valid", () => {
-      expect(isValidUrl("www.home.account.gov.uk")).to.be.true;
-      expect(isValidUrl("home.account.gov.uk")).to.be.true;
+      expect(isValidUrl("www.home.account.gov.uk")).to.be.false;
+      expect(isValidUrl("home.account.gov.uk")).to.be.false;
       expect(isValidUrl("https://home.account.gov.uk")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk/security")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo"))
         .to.be.true;
+      expect(loggerErrorSpy).to.be.callCount(2);
     });
 
     it("should return false if url is invalid", () => {
       expect(isValidUrl("")).to.be.false;
-      expect(isValidUrl([""])).to.be.false;
       expect(isValidUrl("1")).to.be.false;
       expect(isValidUrl("qwerty")).to.be.false;
       expect(isValidUrl("qwerty.gov.&^")).to.be.false;
-      expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
+      expect(isValidUrl("https:///home.account.gov.uk")).to.be.true;
+      expect(loggerErrorSpy).to.be.callCount(3);
     });
 
     it("should return true if string is safe is invalid", () => {
@@ -88,8 +114,17 @@ describe("string-helpers", () => {
       expect(isValidUrl("1")).to.be.false;
       expect(isValidUrl("qwerty")).to.be.false;
       expect(isValidUrl("qwerty.gov.&^")).to.be.false;
-      expect(isValidUrl("https:///home.account.gov.uk")).to.be.false;
+      expect(isValidUrl("https:///home.account.gov.uk")).to.be.true;
       expect(isValidUrl("http://localhost:6001")).to.be.false;
+      expect(loggerErrorSpy).to.be.callCount(3);
+    });
+
+    const testUrls = generateTestUrls("https://www.example.com?start=1", 3);
+    testUrls.forEach((url, index) => {
+      it(`should handle generated URL level ${index}`, () => {
+        const result = isValidUrl(url);
+        expect(result).to.equal(true);
+      });
     });
   });
 

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -67,7 +67,7 @@ describe("string-helpers", () => {
   });
 
   describe("isValidUrl", () => {
-    let loggerErrorSpy: sinon.SinonSpy;
+    let loggerWarnSpy: sinon.SinonSpy;
     // Optional: Utility function to generate test URLs
     function generateTestUrls(
       baseUrl: string,
@@ -83,11 +83,11 @@ describe("string-helpers", () => {
     }
 
     beforeEach(() => {
-      loggerErrorSpy = sinon.spy(logger, "error");
+      loggerWarnSpy = sinon.spy(logger, "warn");
     });
 
     afterEach(() => {
-      loggerErrorSpy.restore();
+      loggerWarnSpy.restore();
     });
 
     it("should return true if valid", () => {
@@ -97,7 +97,7 @@ describe("string-helpers", () => {
       expect(isValidUrl("https://home.account.gov.uk/security")).to.be.true;
       expect(isValidUrl("https://home.account.gov.uk/security?foo=bar&bar=foo"))
         .to.be.true;
-      expect(loggerErrorSpy).to.be.callCount(2);
+      expect(loggerWarnSpy).to.be.callCount(2);
     });
 
     it("should return false if url is invalid", () => {
@@ -106,7 +106,7 @@ describe("string-helpers", () => {
       expect(isValidUrl("qwerty")).to.be.false;
       expect(isValidUrl("qwerty.gov.&^")).to.be.false;
       expect(isValidUrl("https:///home.account.gov.uk")).to.be.true;
-      expect(loggerErrorSpy).to.be.callCount(3);
+      expect(loggerWarnSpy).to.be.callCount(3);
     });
 
     it("should return true if string is safe is invalid", () => {
@@ -116,7 +116,7 @@ describe("string-helpers", () => {
       expect(isValidUrl("qwerty.gov.&^")).to.be.false;
       expect(isValidUrl("https:///home.account.gov.uk")).to.be.true;
       expect(isValidUrl("http://localhost:6001")).to.be.false;
-      expect(loggerErrorSpy).to.be.callCount(3);
+      expect(loggerWarnSpy).to.be.callCount(3);
     });
 
     const testUrls = generateTestUrls("https://www.example.com?start=1", 3);


### PR DESCRIPTION
## Proposed changes
[0LH-1472] Investigate Multiple FROM URL on request path

### What changed

Refactored isValidURL to use URL API instead of regex which is built to parse according to the URL standard, handling a wider variety of URL formats, better error handling and support for internationalised domains.
"nofollow" attributes were added as well to avoid robot crawling and recursively adding fromURL 

### Why did it change

Because there were multiple URL's reported in splunk

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing

Unit test and local testing

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
