### PR TITLE
BAU: Add webchat font style to CSP

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -50,6 +50,7 @@ export const webchatHelmetConfiguration: Parameters<typeof helmet>[0] = {
           `'nonce-${res.locals.scriptNonce}'`,
         "'self'",
         "https://*.smartagent.app",
+        "https://fonts.cdnfonts.com",
       ],
       scriptSrc: [
         "'self'",


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add the domain the webchat loads font styles from to our content security policy.

### Why did it change

We already have the nonce in this `<style>` tag, but that only permits inline styles. We also need to add the domain to the `style-src` in our CSP to permit loading the font.

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've run this locally and checked the CSP error is gone and that the stylesheet loads: 
![image](https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/8c27312b-2090-4e46-a0e3-5b1010d637de)

