### PR TITLE
OLH-1709: Add helper function for TxMA header

### DIFF
--- a/src/utils/test/txma-header.test.ts
+++ b/src/utils/test/txma-header.test.ts
@@ -40,7 +40,7 @@ describe("getTxmaHeader", () => {
 
     const result = getTxmaHeader(request as Request, TRACE);
 
-    expect(result).to.eq("");
+    expect(result).to.be.undefined;
     expect(loggerWarnSpy.calledOnce).to.be.true;
   });
 });

--- a/src/utils/test/txma-header.test.ts
+++ b/src/utils/test/txma-header.test.ts
@@ -1,0 +1,31 @@
+import { describe } from "mocha";
+import { expect } from "chai";
+import { Request } from "express";
+
+import { getTxmaHeader } from "../txma-header";
+
+describe("getTxmaHeader", () => {
+  it("returns the header value when the header is present", () => {
+    const TXMA_HEADER_VALUE = "TXMA_HEADER_VALUE";
+    const request: Partial<Request> = {
+      headers: {
+        "txma-audit-encoded": TXMA_HEADER_VALUE,
+      },
+    };
+
+    const result = getTxmaHeader(request as Request);
+
+    expect(result).to.eq(TXMA_HEADER_VALUE);
+  });
+  it("returns an empty string when the header is not present", () => {
+    const request: Partial<Request> = {
+      headers: {
+        "a-different-header": "a-different-value",
+      },
+    };
+
+    const result = getTxmaHeader(request as Request);
+
+    expect(result).to.eq("");
+  });
+});

--- a/src/utils/test/txma-header.test.ts
+++ b/src/utils/test/txma-header.test.ts
@@ -1,10 +1,23 @@
 import { describe } from "mocha";
 import { expect } from "chai";
 import { Request } from "express";
+import { spy, SinonSpy } from "sinon";
 
+import { logger } from "../../utils/logger";
 import { getTxmaHeader } from "../txma-header";
 
 describe("getTxmaHeader", () => {
+  const TRACE = "trace";
+  let loggerWarnSpy: SinonSpy;
+
+  beforeEach(() => {
+    loggerWarnSpy = spy(logger, "warn");
+  });
+
+  afterEach(() => {
+    loggerWarnSpy.restore();
+  });
+
   it("returns the header value when the header is present", () => {
     const TXMA_HEADER_VALUE = "TXMA_HEADER_VALUE";
     const request: Partial<Request> = {
@@ -13,9 +26,10 @@ describe("getTxmaHeader", () => {
       },
     };
 
-    const result = getTxmaHeader(request as Request);
+    const result = getTxmaHeader(request as Request, TRACE);
 
     expect(result).to.eq(TXMA_HEADER_VALUE);
+    expect(loggerWarnSpy.notCalled).to.be.true;
   });
   it("returns an empty string when the header is not present", () => {
     const request: Partial<Request> = {
@@ -24,8 +38,9 @@ describe("getTxmaHeader", () => {
       },
     };
 
-    const result = getTxmaHeader(request as Request);
+    const result = getTxmaHeader(request as Request, TRACE);
 
     expect(result).to.eq("");
+    expect(loggerWarnSpy.calledOnce).to.be.true;
   });
 });

--- a/src/utils/txma-header.ts
+++ b/src/utils/txma-header.ts
@@ -1,0 +1,5 @@
+import { Request } from "express";
+
+export function getTxmaHeader(req: Request): string {
+  return (req.headers["txma-audit-encoded"] as string) ?? "";
+}

--- a/src/utils/txma-header.ts
+++ b/src/utils/txma-header.ts
@@ -1,11 +1,10 @@
 import { Request } from "express";
 import { logger } from "./logger";
 
-export function getTxmaHeader(req: Request, trace: string): string {
+export function getTxmaHeader(req: Request, trace: string): string | undefined {
   if (req.headers["txma-audit-encoded"]) {
     return req.headers["txma-audit-encoded"] as string;
   } else {
     logger.warn({ trace: trace }, "Missing Txma-Audit-Encoded header");
-    return "";
   }
 }

--- a/src/utils/txma-header.ts
+++ b/src/utils/txma-header.ts
@@ -1,5 +1,11 @@
 import { Request } from "express";
+import { logger } from "./logger";
 
-export function getTxmaHeader(req: Request): string {
-  return (req.headers["txma-audit-encoded"] as string) ?? "";
+export function getTxmaHeader(req: Request, trace: string): string {
+  if (req.headers["txma-audit-encoded"]) {
+    return req.headers["txma-audit-encoded"] as string;
+  } else {
+    logger.warn({ trace: trace }, "Missing Txma-Audit-Encoded header");
+    return "";
+  }
 }


### PR DESCRIPTION


## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add a helper function to get the value of the TxMA device information header.

I considered extending the set-local-vars middleware to put this value in `res.locals` instead, but it's possible that in the future we'll send audit events in a context that doesn't have clean access to the `Response` object. I thought it'd be a nicer pattern to call this function in the controller and pass the result down to the service that's making the API call or sending the audit event.

There's also a tiny amount of logic here, so a separate function is easier to unit test.

This function isn't called anywhere yet - we have other tickets to deal with including the value in our audit events.

### Why did it change

 We'll need to use this value everywhere we send audit events so we want to have one place we deal with fetching it.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
