### PR TITLE
OLH-1663 - Update the frontend state machine for adding an authenticator app

### DIFF
--- a/localstack/provision.sh
+++ b/localstack/provision.sh
@@ -352,7 +352,7 @@ create_state_machine() {
       --region eu-west-2 \
       --name "ExampleStateMachine" \
       --type "STANDARD" \
-      --role-arn "arn" \
+      --role-arn "arn:aws:iam::000000000000:role/stepfunctions-role" \
       --definition '
         {
           "Comment": "Example StepFunction",

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -1,4 +1,4 @@
-import { UserJourney } from "./utils/state-machine";
+import { AccountManagementEvent, UserJourney } from "./utils/state-machine";
 
 export const PATH_DATA: {
   [key: string]: { url: string; event?: string; type?: UserJourney };
@@ -11,9 +11,26 @@ export const PATH_DATA: {
   SECURITY: { url: "/security" },
   YOUR_SERVICES: { url: "/your-services" },
   ENTER_PASSWORD: { url: "/enter-password" },
-  ADD_MFA_METHOD: { url: "/add-mfa-method" },
-  ADD_MFA_METHOD_APP: { url: "/add-mfa-method-app" },
-  ADD_MFA_METHOD_SMS: { url: "/add-mfa-method-sms" },
+  ADD_MFA_METHOD: {
+    url: "/add-mfa-method",
+    event: "SELECTED_APP",
+    type: UserJourney.AddMfaMethod,
+  },
+  ADD_MFA_METHOD_APP: {
+    url: "/add-mfa-method-app",
+    event: "VALUE_UPDATED",
+    type: UserJourney.AddMfaMethod,
+  },
+  ADD_MFA_METHOD_APP_CONFIRMATION: {
+    url: "/add-mfa-method-app-confirmation",
+    event: "CONFIRMATION",
+    type: UserJourney.AddMfaMethod,
+  },
+  ADD_MFA_METHOD_SMS: {
+    url: "/add-mfa-method-sms",
+    event: "VALUE_UPDATED",
+    type: UserJourney.AddMfaMethod,
+  },
   CHANGE_EMAIL: {
     url: "/change-email",
     event: "VERIFY_CODE_SENT",
@@ -98,10 +115,12 @@ export const MFA_METHODS = {
   SMS: {
     type: "sms",
     path: PATH_DATA.ADD_MFA_METHOD_SMS,
+    event: "SELECTED_SMS" as AccountManagementEvent,
   },
   APP: {
     type: "app",
     path: PATH_DATA.ADD_MFA_METHOD_APP,
+    event: "SELECTED_APP" as AccountManagementEvent,
   },
 };
 
@@ -156,6 +175,7 @@ export interface LanguageCodes {
   en: "en-GB";
   cy: "cy-CY";
 }
+
 export const LANGUAGE_CODES: LanguageCodes = {
   en: "en-GB",
   cy: "cy-CY",

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,6 +62,7 @@ import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-
 import { trackAndRedirectRouter } from "./components/track-and-redirect/track-and-redirect-route";
 import { reportSuspiciousActivityRouter } from "./components/report-suspicious-activity/report-suspicious-activity-routes";
 import { addMfaMethodRouter } from "./components/add-mfa-method/add-mfa-method-routes";
+import { addMfaMethodAppRouter } from "./components/add-mfa-method-app/add-mfa-method-app-routes";
 import { csrfErrorHandler } from "./handlers/csrf-error-handler";
 
 const APP_VIEWS = [
@@ -170,6 +171,7 @@ async function createApp(): Promise<express.Application> {
   }
   if (supportChangeMfa()) {
     app.use(addMfaMethodRouter);
+    app.use(addMfaMethodAppRouter);
   }
   app.use(trackAndRedirectRouter);
 

--- a/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
+++ b/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
@@ -1,0 +1,134 @@
+import { Request, Response, NextFunction } from "express";
+import { HTTP_STATUS_CODES, PATH_DATA } from "../../app.constants";
+import {
+  addMfaMethod,
+  generateMfaSecret,
+  generateQRCodeValue,
+  verifyMfaCode,
+} from "../../utils/mfa";
+import QRCode from "qrcode";
+import assert from "node:assert";
+import { splitSecretKeyIntoFragments } from "../../utils/strings";
+import { formatValidationError } from "../../utils/validation";
+import { getNextState } from "../../utils/state-machine";
+
+async function renderMfaMethodAppPage(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  errors: ReturnType<typeof formatValidationError>
+): Promise<void> {
+  try {
+    assert(req.session.user.email, "email not set in session");
+
+    const authAppSecret = req.body.authAppSecret || generateMfaSecret();
+
+    const qrCodeText = generateQRCodeValue(
+      authAppSecret,
+      req.session.user.email,
+      "GOV.UK One Login"
+    );
+
+    const qrCode = await QRCode.toDataURL(qrCodeText);
+    return res.render("add-mfa-method-app/index.njk", {
+      authAppSecret,
+      qrCode,
+      formattedSecret: splitSecretKeyIntoFragments(authAppSecret).join(" "),
+      errorList: Object.keys(errors || {}).map((key) => {
+        return {
+          text: errors[key].text,
+          href: `#${key}`,
+        };
+      }),
+    });
+  } catch (e) {
+    req.log.error(e);
+    return next(e);
+  }
+}
+
+export async function addMfaAppMethodGet(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  return renderMfaMethodAppPage(req, res, next, {});
+}
+
+export async function addMfaAppMethodPost(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const { code, authAppSecret } = req.body;
+
+    assert(authAppSecret, "authAppSecret not set in body");
+
+    if (!code) {
+      return renderMfaMethodAppPage(
+        req,
+        res,
+        next,
+        formatValidationError(
+          "code",
+          req.t("pages.addMfaMethodApp.errors.required")
+        )
+      );
+    }
+
+    if (code.length !== 6) {
+      return renderMfaMethodAppPage(
+        req,
+        res,
+        next,
+        formatValidationError(
+          "code",
+          req.t("pages.addMfaMethodApp.errors.maxLength")
+        )
+      );
+    }
+
+    const isValid = verifyMfaCode(authAppSecret, code);
+
+    if (!isValid) {
+      return renderMfaMethodAppPage(
+        req,
+        res,
+        next,
+        formatValidationError(
+          "code",
+          req.t("pages.addMfaMethodApp.errors.invalidCode")
+        )
+      );
+    }
+
+    const { status } = await addMfaMethod({
+      email: req.session.user.email,
+      otp: code,
+      credential: authAppSecret,
+      mfaMethod: {
+        priorityIdentifier: "SECONDARY",
+        mfaMethodType: "AUTH_APP",
+      },
+      accessToken: req.session.user.tokens.accessToken,
+      sourceIp: req.ip,
+      sessionId: req.session.id,
+      persistentSessionId: res.locals.persistentSessionId,
+    });
+
+    if (status !== HTTP_STATUS_CODES.OK) {
+      throw Error(`Failed to add MFA method, response status: ${status}`);
+    }
+
+    req.session.user.state.addMfaMethod = getNextState(
+      req.session.user.state.addMfaMethod.value,
+      "VALUE_UPDATED"
+    );
+
+    return res.redirect(PATH_DATA.ADD_MFA_METHOD_APP_CONFIRMATION.url);
+  } catch (e) {
+    req.log.error(e);
+    return next(e);
+  }
+}

--- a/src/components/add-mfa-method-app/add-mfa-method-app-routes.ts
+++ b/src/components/add-mfa-method-app/add-mfa-method-app-routes.ts
@@ -2,24 +2,24 @@ import * as express from "express";
 import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import {
-  addMfaMethodGet,
-  addMfaMethodPost,
-} from "./add-mfa-methods-controller";
+  addMfaAppMethodGet,
+  addMfaAppMethodPost,
+} from "./add-mfa-method-app-controller";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 
 const router = express.Router();
 
 router.get(
-  PATH_DATA.ADD_MFA_METHOD.url,
+  PATH_DATA.ADD_MFA_METHOD_APP.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  addMfaMethodGet
+  addMfaAppMethodGet
 );
 
 router.post(
-  PATH_DATA.ADD_MFA_METHOD.url,
+  PATH_DATA.ADD_MFA_METHOD_APP.url,
   requiresAuthMiddleware,
-  addMfaMethodPost
+  addMfaAppMethodPost
 );
 
-export { router as addMfaMethodRouter };
+export { router as addMfaMethodAppRouter };

--- a/src/components/add-mfa-method-app/index.njk
+++ b/src/components/add-mfa-method-app/index.njk
@@ -4,6 +4,8 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set pageTitleName = 'pages.addMfaMethod.app.title' | translate %}
+
 {% block pageContent %}
     {{ govukErrorSummary({
         errorList: errorList,

--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -1,0 +1,179 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { Request, Response } from "express";
+import { SinonSandbox } from "sinon";
+import { sinon } from "../../../../test/utils/test-utils";
+
+import {
+  addMfaAppMethodGet,
+  addMfaAppMethodPost,
+} from "../add-mfa-method-app-controller";
+import { PATH_DATA } from "../../../app.constants";
+import * as mfaModule from "../../../utils/mfa";
+import QRCode from "qrcode";
+
+describe("addMfaAppMethodGet", () => {
+  let sandbox: SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render the add app page", async () => {
+    const req = {
+      session: { user: { email: "test@test.com" } },
+      body: {},
+      log: { error: sinon.fake() },
+    };
+    const res = {
+      render: sinon.fake(),
+    };
+    const next = sinon.spy();
+
+    sandbox.replace(mfaModule, "generateMfaSecret", () => "A".repeat(20));
+    sandbox.replace(mfaModule, "generateQRCodeValue", () => "qrcode");
+
+    await addMfaAppMethodGet(
+      req as unknown as Request,
+      res as unknown as Response,
+      next
+    );
+
+    expect(res.render).to.have.been.calledWith("add-mfa-method-app/index.njk", {
+      authAppSecret: "A".repeat(20),
+      qrCode: await QRCode.toDataURL("qrcode"),
+      formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      errorList: [],
+    });
+  });
+
+  it("should return an error if there is no email in the session", async () => {
+    const req = {
+      session: { user: {} },
+      log: { error: sinon.fake() },
+    };
+    const res = {};
+    const next = sinon.spy();
+
+    await addMfaAppMethodGet(
+      req as unknown as Request,
+      res as unknown as Response,
+      next
+    );
+
+    expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error));
+  });
+});
+
+describe("addMfaAppMethodPost", () => {
+  let sandbox: SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should redirect to add mfa app confirmation page", async () => {
+    const req = {
+      body: {
+        code: "123456",
+        authAppSecret: "A".repeat(20),
+      },
+      session: {
+        id: "session_id",
+        user: {
+          email: "test@test.com",
+          tokens: { accessToken: "token" },
+          state: { addMfaMethod: ["VALUE_UPDATED"] },
+        },
+      },
+      log: { error: sinon.fake() },
+      ip: "127.0.0.1",
+      t: (t: string) => t,
+    };
+    const res = {
+      locals: {
+        persistentSessionId: "persistentSessionId",
+      },
+      redirect: sandbox.fake(() => {}),
+    };
+    const next = sinon.spy();
+    const addMfaMethod = sinon.fake.returns(
+      Promise.resolve({
+        status: 200,
+        data: {
+          endPoint: "endPoint",
+          mfaIdentifier: 1,
+          methodVerified: true,
+          mfaMethodType: "AUTH_APP",
+          priorityIdentifier: "SECONDARY",
+        },
+      })
+    );
+
+    sandbox.replace(mfaModule, "verifyMfaCode", () => true);
+    sandbox.replace(
+      mfaModule,
+      "addMfaMethod",
+      addMfaMethod as typeof mfaModule.addMfaMethod
+    );
+
+    await addMfaAppMethodPost(
+      req as unknown as Request,
+      res as unknown as Response,
+      next
+    );
+
+    expect(addMfaMethod).to.have.been.calledWith({
+      email: "test@test.com",
+      otp: "123456",
+      credential: "AAAAAAAAAAAAAAAAAAAA",
+      mfaMethod: { priorityIdentifier: "SECONDARY", mfaMethodType: "AUTH_APP" },
+      accessToken: "token",
+      sourceIp: "127.0.0.1",
+      sessionId: "session_id",
+      persistentSessionId: "persistentSessionId",
+    });
+
+    expect(res.redirect).to.have.been.calledWith(
+      PATH_DATA.ADD_MFA_METHOD_APP_CONFIRMATION.url
+    );
+  });
+
+  it("should render an error if the code is invalid", async () => {
+    const req = {
+      body: {
+        code: "123456",
+        authAppSecret: "A".repeat(20),
+      },
+      session: {
+        id: "session_id",
+        user: { email: "test@test.com", tokens: { accessToken: "token" } },
+      },
+      log: { error: sinon.fake() },
+      ip: "127.0.0.1",
+    };
+    const res = {
+      locals: {
+        persistentSessionId: "persistentSessionId",
+      },
+      render: sinon.fake(),
+    };
+    const next = sinon.spy();
+
+    sandbox.replace(mfaModule, "verifyMfaCode", () => false);
+
+    await addMfaAppMethodPost(
+      req as unknown as Request,
+      res as unknown as Response,
+      next
+    );
+  });
+});

--- a/src/components/add-mfa-method/index.njk
+++ b/src/components/add-mfa-method/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-
+{% set pageTitleName = 'pages.addMfaMethod.title' | translate %}
 {% block pageContent %}
     <form action="{{ "ADD_MFA_METHOD" | getPath }}" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/src/components/add-mfa-method/tests/add-mfa-methods-controller.test.ts
+++ b/src/components/add-mfa-method/tests/add-mfa-methods-controller.test.ts
@@ -1,19 +1,52 @@
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import { Request, Response } from "express";
-import sinon, { SinonSandbox } from "sinon";
+import { SinonSandbox } from "sinon";
+import { sinon } from "../../../../test/utils/test-utils";
+
 import {
   addMfaMethodPost,
-  addMfaAppMethodGet,
-  addMfaAppMethodPost,
+  addMfaMethodGet,
 } from "../add-mfa-methods-controller";
 import { PATH_DATA } from "../../../app.constants";
-import * as mfaModule from "../../../utils/mfa";
-import QRCode from "qrcode";
+
+describe("addMfaMethodGet", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = {
+      body: {},
+      session: { user: { state: { addMfaMethod: ["AUTHENTICATED"] } } } as any,
+      cookies: { lng: "en" },
+      i18n: { language: "en" },
+      t: sandbox.fake(),
+    };
+    res = {
+      render: sandbox.fake(),
+      redirect: sandbox.fake(() => {}),
+      locals: {},
+      status: sandbox.fake(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should add mfa method page", () => {
+    addMfaMethodGet(req as Request, res as Response);
+
+    expect(res.render).to.have.calledWith("add-mfa-method/index.njk");
+  });
+});
 
 describe("addMfaMethodPost", () => {
   let sandbox: SinonSandbox;
-  let req: Partial<Request>;
+  let req: any;
   let res: Partial<Response>;
   let next: sinon.SinonSpy;
 
@@ -34,7 +67,11 @@ describe("addMfaMethodPost", () => {
         return {} as Response; // You should return a proper type here, matching your test environment needs
       }
     );
-    req = { body: {}, log: { error: sandbox.fake() } as any };
+    req = {
+      body: {},
+      log: { error: sandbox.fake() } as any,
+      session: { user: { state: { addMfaMethod: ["SELECT_APP"] } } } as any,
+    };
     res = {
       status: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
@@ -75,175 +112,5 @@ describe("addMfaMethodPost", () => {
     const call: sinon.SinonSpyCall<Error[], unknown> = next.getCall(0);
 
     expect(call.args[0].message).to.equal("Unknown addMfaMethod: unknown");
-  });
-});
-
-describe("addMfaAppMethodGet", () => {
-  let sandbox: SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("should render the add app page", async () => {
-    const req = {
-      session: { user: { email: "test@test.com" } },
-      body: {},
-      log: { error: sinon.fake() },
-    };
-    const res = {
-      render: sinon.fake(),
-    };
-    const next = sinon.spy();
-
-    sandbox.replace(mfaModule, "generateMfaSecret", () => "A".repeat(20));
-    sandbox.replace(mfaModule, "generateQRCodeValue", () => "qrcode");
-
-    await addMfaAppMethodGet(
-      req as unknown as Request,
-      res as unknown as Response,
-      next
-    );
-
-    expect(res.render).to.have.been.calledWith("add-mfa-method/add-app.njk", {
-      authAppSecret: "A".repeat(20),
-      qrCode: await QRCode.toDataURL("qrcode"),
-      formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
-      errors: {},
-      errorList: [],
-    });
-  });
-
-  it("should return an error if there is no email in the session", async () => {
-    const req = {
-      session: { user: {} },
-      log: { error: sinon.fake() },
-    };
-    const res = {};
-    const next = sinon.spy();
-
-    await addMfaAppMethodGet(
-      req as unknown as Request,
-      res as unknown as Response,
-      next
-    );
-
-    expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error));
-  });
-});
-
-describe("addMfaAppMethodPost", () => {
-  let sandbox: SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("should send the request to add mfaMethod", async () => {
-    const req = {
-      body: {
-        code: "123456",
-        authAppSecret: "A".repeat(20),
-      },
-      session: {
-        id: "session_id",
-        user: { email: "test@test.com", tokens: { accessToken: "token" } },
-      },
-      log: { error: sinon.fake() },
-      ip: "127.0.0.1",
-      t: (t: string) => t,
-    };
-    const res = {
-      locals: {
-        persistentSessionId: "persistentSessionId",
-      },
-      render: sinon.fake(),
-    };
-    const next = sinon.spy();
-    const addMfaMethod = sinon.fake.returns(
-      Promise.resolve({
-        status: 200,
-        data: {
-          endPoint: "endPoint",
-          mfaIdentifier: 1,
-          methodVerified: true,
-          mfaMethodType: "AUTH_APP",
-          priorityIdentifier: "SECONDARY",
-        },
-      })
-    );
-
-    sandbox.replace(mfaModule, "verifyMfaCode", () => true);
-    sandbox.replace(
-      mfaModule,
-      "addMfaMethod",
-      addMfaMethod as typeof mfaModule.addMfaMethod
-    );
-
-    await addMfaAppMethodPost(
-      req as unknown as Request,
-      res as unknown as Response,
-      next
-    );
-
-    expect(addMfaMethod).to.have.been.calledWith({
-      email: "test@test.com",
-      otp: "123456",
-      credential: "AAAAAAAAAAAAAAAAAAAA",
-      mfaMethod: { priorityIdentifier: "SECONDARY", mfaMethodType: "AUTH_APP" },
-      accessToken: "token",
-      sourceIp: "127.0.0.1",
-      sessionId: "session_id",
-      persistentSessionId: "persistentSessionId",
-    });
-
-    expect(res.render).to.be.calledWith(
-      "common/confirmation-page/confirmation.njk",
-      {
-        heading: "pages.confirmAddMfaMethod.heading",
-        message: "pages.confirmAddMfaMethod.message",
-        backLinkText: "pages.confirmAddMfaMethod.backLinkText",
-        backLink: PATH_DATA.SECURITY.url,
-      }
-    );
-  });
-
-  it("should render an error if the code is invalid", async () => {
-    const req = {
-      body: {
-        code: "123456",
-        authAppSecret: "A".repeat(20),
-      },
-      session: {
-        id: "session_id",
-        user: { email: "test@test.com", tokens: { accessToken: "token" } },
-      },
-      log: { error: sinon.fake() },
-      ip: "127.0.0.1",
-      t: (t: string) => t,
-    };
-    const res = {
-      locals: {
-        persistentSessionId: "persistentSessionId",
-      },
-      render: sinon.fake(),
-    };
-    const next = sinon.spy();
-
-    sandbox.replace(mfaModule, "verifyMfaCode", () => false);
-
-    await addMfaAppMethodPost(
-      req as unknown as Request,
-      res as unknown as Response,
-      next
-    );
   });
 });

--- a/src/components/common/confirmation-page/confirmation.njk
+++ b/src/components/common/confirmation-page/confirmation.njk
@@ -1,6 +1,5 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-
 {% block pageContent %}
     {{ govukPanel({
         titleText: heading

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -1,15 +1,17 @@
 import { expect } from "chai";
-import { describe } from "mocha";
+import { describe, it } from "mocha";
 
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 
 import {
+  addMfaAppMethodConfirmationGet,
   deleteAccountConfirmationGet,
   updateEmailConfirmationGet,
   updatePasswordConfirmationGet,
   updatePhoneNumberConfirmationGet,
 } from "../update-confirmation-controller";
+import { PATH_DATA } from "../../../app.constants";
 
 describe("update confirmation controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -65,5 +67,46 @@ describe("update confirmation controller", () => {
 
       expect(res.render).to.have.calledWith("update-confirmation/index.njk");
     });
+  });
+});
+
+describe("addMfaMethodAppConfirmationGet", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = {
+      body: {},
+      cookies: { lng: "en" },
+      i18n: { language: "en" },
+      t: (t: string) => t,
+    };
+    res = {
+      render: sandbox.fake(),
+      locals: {},
+      status: sandbox.fake(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render add mfa app confirmation page", () => {
+    addMfaAppMethodConfirmationGet(req as Request, res as Response);
+
+    expect(res.render).to.be.calledWith(
+      "common/confirmation-page/confirmation.njk",
+      {
+        pageTitleName: "pages.confirmAddMfaMethod.title",
+        heading: "pages.confirmAddMfaMethod.heading",
+        message: "pages.confirmAddMfaMethod.message",
+        backLinkText: "pages.confirmAddMfaMethod.backLinkText",
+        backLink: PATH_DATA.SECURITY.url,
+      }
+    );
   });
 });

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { redactPhoneNumber } from "../../utils/strings";
+import { PATH_DATA } from "../../app.constants";
 
 const oplValues = {
   updateEmailConfirmation: {
@@ -77,5 +78,18 @@ export function deleteAccountConfirmationGet(
     summaryText: req.t("pages.deleteAccountConfirmation.summaryText"),
     showGovUKButton: true,
     hideAccountNavigation: true,
+  });
+}
+
+export async function addMfaAppMethodConfirmationGet(
+  req: Request,
+  res: Response
+): Promise<void> {
+  return res.render("common/confirmation-page/confirmation.njk", {
+    pageTitleName: req.t("pages.confirmAddMfaMethod.title"),
+    heading: req.t("pages.confirmAddMfaMethod.heading"),
+    message: req.t("pages.confirmAddMfaMethod.message"),
+    backLinkText: req.t("pages.confirmAddMfaMethod.backLinkText"),
+    backLink: PATH_DATA.SECURITY.url,
   });
 }

--- a/src/components/update-confirmation/update-confirmation-routes.ts
+++ b/src/components/update-confirmation/update-confirmation-routes.ts
@@ -2,6 +2,7 @@ import { PATH_DATA } from "../../app.constants";
 
 import * as express from "express";
 import {
+  addMfaAppMethodConfirmationGet,
   deleteAccountConfirmationGet,
   updateEmailConfirmationGet,
   updatePasswordConfirmationGet,
@@ -33,6 +34,13 @@ router.get(
 router.get(
   PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,
   deleteAccountConfirmationGet
+);
+
+router.get(
+  PATH_DATA.ADD_MFA_METHOD_APP_CONFIRMATION.url,
+  requiresAuthMiddleware,
+  validateStateMiddleware,
+  addMfaAppMethodConfirmationGet
 );
 
 export { router as updateConfirmationRouter };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -182,6 +182,7 @@
       }
     },
     "confirmAddMfaMethod": {
+      "title": "You've added another way to get security codes",
       "heading": "You've added another way to get security codes",
       "message": "If your usual way to get security codes is not available, you can get a code from this authenticator app instead",
       "backLinkText": "Back to security"

--- a/src/middleware/validate-state-middleware.ts
+++ b/src/middleware/validate-state-middleware.ts
@@ -14,6 +14,7 @@ export function validateStateMiddleware(
       pageState.type
     )
   ) {
+    req.log.info(`state exists but no value for ${pageState.type}`);
     req.log.warn(`state exists but no value for ${pageState.type}`);
     return res.redirect(PATH_DATA.YOUR_SERVICES.url);
   }

--- a/src/utils/state-machine.ts
+++ b/src/utils/state-machine.ts
@@ -5,14 +5,16 @@ enum UserJourney {
   ChangePassword = "changePassword",
   ChangePhoneNumber = "changePhoneNumber",
   DeleteAccount = "deleteAccount",
-  AddMfaMethod = "addMFAMethod",
+  AddMfaMethod = "addMfaMethod",
 }
 
 type AccountManagementEvent =
   | "VALUE_UPDATED"
   | "VERIFY_CODE_SENT"
   | "AUTHENTICATED"
-  | "RESEND_CODE";
+  | "RESEND_CODE"
+  | "SELECTED_APP"
+  | "SELECTED_SMS";
 
 interface StateAction {
   value: StateValue;
@@ -32,6 +34,18 @@ const amStateMachine = createMachine<AccountManagementEvent>({
       on: {
         VALUE_UPDATED: "CONFIRMATION",
         VERIFY_CODE_SENT: "VERIFY_CODE",
+        SELECTED_APP: "APP",
+        SELECTED_SMS: "SMS",
+      },
+    },
+    APP: {
+      on: {
+        VALUE_UPDATED: "CONFIRMATION",
+      },
+    },
+    SMS: {
+      on: {
+        VALUE_UPDATED: "CONFIRMATION",
       },
     },
     VERIFY_CODE: {
@@ -77,4 +91,5 @@ export {
   UserJourney,
   getInitialState,
   StateAction,
+  AccountManagementEvent,
 };

--- a/test/unit/middleware/validate-state-middleware.test.ts
+++ b/test/unit/middleware/validate-state-middleware.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { NextFunction, Request, Response } from "express";
+import { sinon } from "../../utils/test-utils";
+import * as mfa from "../../../src/utils/mfa";
+import { validateStateMiddleware } from "../../../src/middleware/validate-state-middleware";
+
+describe("validate state middleware", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+  let mfaStub: sinon.SinonStub;
+  const info: sinon.SinonSpy = sinon.spy();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    next = sinon.fake(() => {});
+    mfaStub = sinon.stub(mfa, "default");
+
+    req = {
+      url: "/add-mfa-method",
+      body: {},
+      query: {},
+      session: {
+        user: {
+          email: "test@example.com",
+          tokens: { accessToken: "dummytoken" },
+          state: {
+            addMfaMethod: { value: "CHNAGE_VALUE", events: ["SELECTED_APP"] },
+          },
+        },
+      } as any,
+      oidc: { authorizationUrl: sinon.fake(), metadata: {} as any } as any,
+      log: {
+        info,
+      } as any,
+    };
+    res = {
+      render: sinon.fake(),
+      redirect: sandbox.fake(() => {}),
+      locals: { trace: {} },
+    };
+  });
+
+  afterEach(() => {
+    mfaStub.restore();
+    sandbox.restore();
+  });
+
+  it("should continue to next middleware and pass validation", async () => {
+    res.locals.sessionId = "sessionId";
+    res.locals.persistentSessionId = "persistentSessionId";
+
+    validateStateMiddleware(req as Request, res as Response, next);
+
+    expect(next).to.have.been.called;
+  });
+});

--- a/test/unit/utils/state-machine.test.ts
+++ b/test/unit/utils/state-machine.test.ts
@@ -23,6 +23,8 @@ describe("state-machine", () => {
       expect(nextState.events).to.all.members([
         "VALUE_UPDATED",
         "VERIFY_CODE_SENT",
+        "SELECTED_APP",
+        "SELECTED_SMS",
       ]);
     });
 
@@ -58,11 +60,45 @@ describe("state-machine", () => {
       expect(nextState.events).to.all.members([
         "VALUE_UPDATED",
         "VERIFY_CODE_SENT",
+        "SELECTED_APP",
+        "SELECTED_SMS",
       ]);
     });
 
-    it("should move state from change value state to value updated state", () => {
+    it("should move state from   change value state to value updated state", () => {
       const nextState = getNextState("CHANGE_VALUE", "VALUE_UPDATED");
+      expect(nextState.value).to.equal("CONFIRMATION");
+      expect(nextState.events).to.all.members([]);
+    });
+  });
+
+  describe("getNextState for mfa process", () => {
+    it("should move state from initial state to change value state", () => {
+      const state = getInitialState();
+      const nextState = getNextState(state.value, "AUTHENTICATED");
+      expect(nextState.value).to.equal("CHANGE_VALUE");
+      expect(nextState.events).to.all.members([
+        "VALUE_UPDATED",
+        "VERIFY_CODE_SENT",
+        "SELECTED_APP",
+        "SELECTED_SMS",
+      ]);
+    });
+
+    it("should move state from CHANGE_VALUE state to APP state when SELECTED_APP action event ", () => {
+      const nextState = getNextState("CHANGE_VALUE", "SELECTED_APP");
+      expect(nextState.value).to.equal("APP");
+      expect(nextState.events).to.all.members(["VALUE_UPDATED"]);
+    });
+
+    it("should move state from CHANGE_VALUE state to SMS state when SELECTED_SMS action event ", () => {
+      const nextState = getNextState("CHANGE_VALUE", "SELECTED_SMS");
+      expect(nextState.value).to.equal("SMS");
+      expect(nextState.events).to.all.members(["VALUE_UPDATED"]);
+    });
+
+    it("should move state from APP state to CONFIRMATION state when VALUE_UPDATED action event ", () => {
+      const nextState = getNextState("APP", "VALUE_UPDATED");
       expect(nextState.value).to.equal("CONFIRMATION");
       expect(nextState.events).to.all.members([]);
     });


### PR DESCRIPTION
## Proposed changes
OLH-1663 - Update the frontend state machine for adding an authenticator app
### What changed

- Update the state machine to include states and events for adding MFA method
- Add the validator to MFA pages to ensure state transitions are as expected
- Test additional state transitions works as expected

### Why did it change

So that we can use state engine to manage/validate user interactions with our platform and handle errors appropriately

### Related links

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing
Integration test
Local Test
Test in dev environment
## How to review

Code completeness and tests