### PR TITLE
Set all log retention to 30 days

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -908,7 +908,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/ecs/${AWS::StackName}/server"
-      RetentionInDays: 1
+      RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   TaskLogGroupCSLSSubscription:
@@ -1495,7 +1495,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/apigateway/${AWS::StackName}/access"
-      RetentionInDays: 1
+      RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
       Tags:
         - Key: Product


### PR DESCRIPTION
## Proposed changes
Setting all log retention to 30 days.

See [SW-249](https://govukverify.atlassian.net/browse/SW-249) and associated epic [SW-241](https://govukverify.atlassian.net/browse/SW-241)

What changed
Log retention for deploy CFN template log groups set to 30 days

Why did it change
LZA will set any log retention below 30 days to 30 days. This PR supports remediation for [INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


[SW-249]: https://govukverify.atlassian.net/browse/SW-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SW-241]: https://govukverify.atlassian.net/browse/SW-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ