### PR TITLE
OLH-1712 - Send the TxMA header value in the SNS message when a user reports activity

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -14,6 +14,7 @@ import assert from "node:assert";
 import { formatActivityLogs } from "../../utils/activityHistory";
 import { decryptData } from "../../utils/decrypt-data";
 import { snsService } from "../../utils/sns";
+import { getTxmaHeader } from "../../utils/txma-header";
 
 const activityLogDynamoDBRequest = (
   subjectId: string,
@@ -34,6 +35,7 @@ interface ReportSuspiciousActivityParams {
   persistent_session_id: string;
   session_id: string;
   reported_suspicious_time: number;
+  device_information?: string;
   topic_arn?: string;
 }
 
@@ -44,6 +46,7 @@ const publishToSuspiciousActivityTopic = async function ({
   persistent_session_id,
   session_id,
   reported_suspicious_time,
+  device_information,
   topic_arn = getSNSSuspicousActivityTopic(),
 }: ReportSuspiciousActivityParams): Promise<void> {
   const sns = snsService();
@@ -56,6 +59,7 @@ const publishToSuspiciousActivityTopic = async function ({
       persistent_session_id,
       session_id,
       reported_suspicious_time,
+      device_information,
     })
   );
 };
@@ -156,6 +160,7 @@ export async function reportSuspiciousActivityPost(
       persistent_session_id: res.locals.persistentSessionId,
       session_id: res.locals.sessionId,
       reported_suspicious_time: new Date().getTime(),
+      device_information: getTxmaHeader(req, res.locals.trace),
     });
   } catch (err) {
     req.log.error(err.message);


### PR DESCRIPTION
## Proposed changes
OLH-1712 - Send the TxMA header value in the SNS message when a user reports activity

### What changed

Add device information to the SNS message sent as part of report suspicious activity the header key/value pair for `"txma-audit-encoded"` exists.

### Why did it change

So that we can capture the device and submit as part of Audit Event to TxMA when a suspicious activity is reported.

### Related links

https://govukverify.atlassian.net/browse/OLH-1712

## Checklists


### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing

Deploy to dev

1. Add the `txma-audit-encoded` header and ensure it does not break report suspicious ativity process
2. Do not add the `txma-audit-encoded` and ensure it does not break the report suspiciouus activity process
3. Publish an RSA SNS message directly to SNS topic with and without the `txma-audit-encoded` and ensure it does not break the report suspicious activity process

## How to review

Code completeness and test.