### PR TITLE
OLH-1724 Delete account and backchannel logout journeys don't delete user's sessions

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -182,7 +182,6 @@ export const LANGUAGE_CODES: LanguageCodes = {
 };
 
 export const LOG_MESSAGES = {
-  ATTEMPTING_TO_DESTROY_SESSION: "Attempting to destroy session",
   GS_COOKIE_NOT_IN_REQUEST: "gs cookie not in request.",
   DI_PERSISTENT_SESSION_ID_COOKIE_NOT_IN_REQUEST:
     "di-persistent-session-id cookie not in request.",

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -85,7 +85,7 @@ export function deleteAccountPost(
         getBaseUrl() + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,
     });
 
-    await destroyUserSessions(subjectId, req.app.locals.sessionStore);
+    await destroyUserSessions(req, subjectId, req.app.locals.sessionStore);
 
     return res.redirect(logoutUrl);
   };

--- a/src/components/delete-account/tests/delete-account-controller.test.ts
+++ b/src/components/delete-account/tests/delete-account-controller.test.ts
@@ -148,6 +148,7 @@ describe("delete account controller", () => {
         expect(req.oidc.endSessionUrl).to.have.been.calledOnce;
         expect(res.redirect).to.have.been.calledWith("logout-url");
         expect(sessionStore.destroyUserSessions).to.have.been.calledWith(
+          req,
           "public-subject-id"
         );
       });

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -65,7 +65,7 @@ export async function globalLogoutPost(
   const token = await verifyLogoutToken(req);
 
   if (token && validateLogoutTokenClaims(token, req)) {
-    await destroyUserSessions(token.sub, req.app.locals.sessionStore);
+    await destroyUserSessions(req, token.sub, req.app.locals.sessionStore);
     res.send(HTTP_STATUS_CODES.OK);
     return;
   }

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -310,7 +310,7 @@ describe("global logout controller", () => {
       await globalLogoutPost(req as Request, res as Response);
 
       expect(res.send).to.have.been.calledWith(HTTP_STATUS_CODES.OK);
-      expect(destroyUserSessions).to.have.been.calledWith("123456");
+      expect(destroyUserSessions).to.have.been.calledWith(req, "123456");
     });
   });
 });

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -1,22 +1,13 @@
 import { Request, Response } from "express";
-import { logger } from "../../utils/logger";
-import { LOG_MESSAGES } from "../../app.constants";
-import { ERROR_MESSAGES } from "../../app.constants";
+import { destroyUserSessions } from "../../utils/session-store";
 
 export async function logoutPost(req: Request, res: Response): Promise<void> {
   const idToken = req.session.user.tokens.idToken;
-  logger.info(
-    { trace: res.locals.trace },
-    LOG_MESSAGES.ATTEMPTING_TO_DESTROY_SESSION
+  await destroyUserSessions(
+    req,
+    req.session.user.subjectId,
+    req.app.locals.sessionStore
   );
-  req.session.destroy((err) => {
-    if (err) {
-      logger.error(
-        { trace: res.locals.trace },
-        ERROR_MESSAGES.FAILED_TO_DESTROY_SESSION(err)
-      );
-    }
-  });
   res.cookie("lo", "true");
   res.redirect(req.oidc.endSessionUrl({ id_token_hint: idToken }));
 }

--- a/src/components/logout/tests/logout-controller.test.ts
+++ b/src/components/logout/tests/logout-controller.test.ts
@@ -1,10 +1,9 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-
+import * as sessionStore from "../../../utils/session-store";
 import { sinon } from "../../../../test/utils/test-utils";
 import { logoutPost } from "../logout-controller";
 import { logger } from "../../../utils/logger";
-import { ERROR_MESSAGES, LOG_MESSAGES } from "../../../app.constants";
 
 const TEST_TRACE_ID = "trace-id";
 
@@ -21,8 +20,9 @@ describe("logout controller", () => {
     errorLoggerSpy = sinon.spy(logger, "error");
     req = {
       body: {},
-      session: { user: {} } as any,
+      session: { user: { subjectId: "subject-id" } } as any,
       oidc: { endSessionUrl: sandbox.fake() },
+      app: { locals: { sessionStore: sandbox.fake() } },
     };
     res = {
       render: sandbox.fake(),
@@ -44,47 +44,23 @@ describe("logout controller", () => {
     errorLoggerSpy.restore();
   });
 
-  it("should execute logout process", () => {
+  it("should execute logout process", async () => {
     req.session.user.tokens = {
       idToken: "id-token",
     } as any;
 
     req.session.destroy = sandbox.fake();
 
-    logoutPost(req, res);
-
-    expect(req.session.destroy).to.have.been.calledOnce;
-    expect(res.mockCookies.lo).to.equal("true");
-    expect(req.oidc.endSessionUrl).to.have.been.calledOnce;
-    expect(res.redirect).to.have.called;
-    expect(loggerSpy).to.have.been.calledWith(
-      { trace: TEST_TRACE_ID },
-      LOG_MESSAGES.ATTEMPTING_TO_DESTROY_SESSION
+    const destroyUserSessionsStub = sinon.stub(
+      sessionStore,
+      "destroyUserSessions"
     );
-  });
 
-  it("should log error when session destroy fails and continue with logout process", () => {
-    const ERROR_MESSAGE = "error";
-    req.session = {
-      user: {
-        tokens: {
-          idToken: "id-token",
-        },
-      },
-      destroy: (callback: (err: string) => void) => {
-        callback(ERROR_MESSAGE);
-      },
-    };
-
-    logoutPost(req, res);
-
-    expect(errorLoggerSpy).to.have.been.calledWith(
-      { trace: TEST_TRACE_ID },
-      ERROR_MESSAGES.FAILED_TO_DESTROY_SESSION(ERROR_MESSAGE)
-    );
+    await logoutPost(req, res);
 
     expect(res.mockCookies.lo).to.equal("true");
     expect(req.oidc.endSessionUrl).to.have.been.calledOnce;
     expect(res.redirect).to.have.called;
+    expect(destroyUserSessionsStub.called);
   });
 });


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

When a user deletes their account or logs out via the global logout also delete the Express session.

### What changed

<!-- Describe the changes in detail - the "what"-->

The destroyUserSessions function and its callers.

### Why did it change

The destroyUserSessions function in the session-store module attempts to delete all entries in the user sessions table.  However, it did not destroy the Express session which resulted in the session persisting after the user thought they were logged out.  Adding a final call to delete the Express session ensured everything was removed.  The session-store destroyUserSessions function was refactored to highlight the two distinct actions that it takes, firstly to find all the users records in the session store and delete them and secondly to destroy the Express session.

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->


## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
