### PR TITLE
OLH-1604: Update services content

### DIFF
--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -27,7 +27,7 @@
       </div>
       {% if not (servicesList.length or accountsList.length) %}
         {# Display an empty state when no accounts nor services have been used #}
-        {# This should be an edge case as the only pathways into the account would be signing up via other services #}
+        {# This should be an edge case as the only pathways into the account would be signing up via other services #} 
       <div class="your-services__card your-services__card--empty" data-test-id="empty-state">
         <div class="your-services__card__content">
           <p class="govuk-body">{{ 'pages.yourServices.empty' | translate }}</p>
@@ -99,12 +99,8 @@
       <div class="information-box">
         <h2 class="govuk-heading-m">{{ 'pages.yourServices.informationBox.heading' | translate }}</h2>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph1' | translate }}</p>
-        {{ govukDetails({
-          summaryText: 'pages.yourServices.informationBox.details.summary' | translate,
-          html: detailsHTML
-        }) }}
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph2' | translate }}</p>
-        <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph3' | translate }}</p>
+        <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph3' | translate | replace("[servicesLink]", "https://www.gov.uk/using-your-gov-uk-one-login/services") | safe}}</p>
       </div>
     </div>
   </div>

--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -1,10 +1,10 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageTitleName = 'pages.yourServices.title' | translate %}
-{% set serviceLinks =  'pages.yourServices.informationBox.details.listItems' | translate({ returnObjects: true }) %}
 {% set activeNav = 'your-services' %}
 {% set showSecondaryHeadings = servicesList.length and accountsList.length %}
 {% set serviceHeadingLevel =  "h3" if showSecondaryHeadings else "h2" %}
+{% set serviceListLink = 'pages.yourServices.informationBox.link' | translate | safe %}
 
 {% if not (servicesList.length or accountsList.length) %}
     {% set contentId = "886900f6-178f-41e7-9051-c8428cca86dd" %}
@@ -100,7 +100,7 @@
         <h2 class="govuk-heading-m">{{ 'pages.yourServices.informationBox.heading' | translate }}</h2>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph1' | translate }}</p>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph2' | translate }}</p>
-        <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph3' | translate | replace("[servicesLink]", "https://www.gov.uk/using-your-gov-uk-one-login/services") | safe}}</p>
+        <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph3' | translate | replace("[serviceListLink]", serviceListLink) | safe}}</p>
       </div>
     </div>
   </div>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -254,7 +254,8 @@
         "heading": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login",
         "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond ei ddefnyddio i gael mynediad i rai gwasanaethau'r llywodraeth.",
         "paragraph2": "Yn y dyfodol, byddwch yn gallu defnyddio GOV.UK One Login i gael mynediad i'r holl wasanaethau ar GOV.UK.",
-        "paragraph3": "Gweler y <a class=\"govuk-link\" href=\"[servicesLink]\">gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login</a>."
+        "paragraph3": "Gweler y <a class=\"govuk-link\" href=\"[serviceListLink]\">gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login</a>.",
+        "link": "https://www.gov.uk/defnyddio-eich-gov-uk-one-login/gwasanaethau"
       }
     },
     "enterPassword": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -253,86 +253,8 @@
       "informationBox": {
         "heading": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login",
         "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond ei ddefnyddio i gael mynediad i rai gwasanaethau'r llywodraeth.",
-        "details": {
-          "summary": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login",
-          "paragraph": "Gallwch ddefnyddio GOV.UK One Login gyda:",
-          "listItems": [
-            {
-              "text": "Cofrestr darparwr prentisiaeth ac asesiad",
-              "href": "https://apply.apprenticeships.education.gov.uk/"
-            },
-            {
-              "text": "Cofrestrfa datganiad caethwasiaeth modern",
-              "href": "https://www.gov.uk/guidance/add-your-modern-slavery-statement-to-the-statement-registry"
-            },
-            {
-              "text": "Cyfrif arbenigwr pwnc Ofqual",
-              "href": "https://www.gov.uk/guidance/subject-matter-specialists-for-ofqual"
-            },
-            {
-              "text": "Cysylltu teuluoedd i gymorth",
-              "href": "https://www.connect-families-to-support.education.gov.uk"
-            },
-            {
-              "text": "Darganfod a gwneud cais am grant",
-              "href": "https://www.gov.uk/guidance/find-government-grants"
-            },
-            {
-              "text": "Darganfod corff asesu cydymffurfiaeth marchnad y DU",
-              "href": "https://find-a-conformity-assessment-body.service.gov.uk"
-            },
-            {
-              "text": "Digolledau anafiadau troseddol",
-              "href": "https://www.gov.uk/claim-compensation-criminal-injury/make-claim"
-            },
-            {
-              "text": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-              "href": "https://beta-find-and-use-an-api.education.gov.uk"
-            },
-            {
-              "text": "Gwasanaeth asesu prentisiaeth (AAS)",
-              "href": "https://assessors.apprenticeships.education.gov.uk/"
-            },
-            {
-              "text": "Gwneud cais am drwydded gweithredwr cerbyd",
-              "href": "https://www.gov.uk/apply-vehicle-operator-licence"
-            },
-            {
-              "text": "Gwneud cais am Gerdyn Cyn-filwyr Lluoedd Arfog EF",
-              "href": "https://www.gov.uk/veteran-card"
-            },
-            {
-              "text": "Gwneud cais am wiriad DBS sylfaenol",
-              "href": "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol"
-            },
-            {
-              "text": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
-              "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
-            },
-            {
-              "text": "Hyfforddiant datblygiad plant blynyddoedd cynnar",
-              "href": "https://child-development-training.education.gov.uk/"
-            },
-            {
-              "text": "Llofnodwch eich gweithred morgais",
-              "href": "https://sign-your-mortgage-deed.landregistry.gov.uk"
-            },
-            {
-              "text": "Rheoli gwasanaethau a chyfrifon cymorth i deuluoedd",
-              "href": "https://manage-family-support-services-and-accounts.education.gov.uk"
-            },
-            {
-              "text": "Rheoli prentisiaethau",
-              "href": "https://www.gov.uk/sign-in-apprenticeship-service-account"
-            },
-            {
-              "text": "Tanysgrifiadau e-byst GOV.UK",
-              "href": "https://www.gov.uk/email/manage?from=your-services"
-            }
-          ]
-        },
-        "paragraph2": "Nid yw GOV.UK One Login yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
-        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich GOV.UK One Login i gael mynediad i holl wasanaethau ar GOV.UK."
+        "paragraph2": "Yn y dyfodol, byddwch yn gallu defnyddio GOV.UK One Login i gael mynediad i'r holl wasanaethau ar GOV.UK.",
+        "paragraph3": "Gweler y <a class=\"govuk-link\" href=\"[servicesLink]\">gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login</a>."
       }
     },
     "enterPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -313,7 +313,8 @@
         "paragraph1": "GOV.UK One Login is new. At the moment you can only use it to access some government services.",
 
         "paragraph2": "In the future, you'll be able to use GOV.UK One Login to access all services on GOV.UK.",
-        "paragraph3": "See the <a class=\"govuk-link\" href=\"[servicesLink]\">services you can use with GOV.UK One Login</a>."
+        "paragraph3": "See the <a class=\"govuk-link\" href=\"[serviceListLink]\">services you can use with GOV.UK One Login</a>.",
+        "link": "https://www.gov.uk/using-your-gov-uk-one-login/services"
       }
     },
     "enterPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -311,86 +311,9 @@
       "informationBox": {
         "heading": "Services you can use with GOV.UK One Login",
         "paragraph1": "GOV.UK One Login is new. At the moment you can only use it to access some government services.",
-        "details": {
-          "summary": "Services you can use with GOV.UK One Login",
-          "paragraph": "You can use GOV.UK One Login with:",
-          "listItems": [
-            {
-              "text": "Apply for a vehicle operator licence",
-              "href": "https://www.gov.uk/apply-vehicle-operator-licence"
-            },
-            {
-              "text": "Apply for an HM Armed Forces Veteran Card",
-              "href": "https://www.gov.uk/veteran-card"
-            },
-            {
-              "text": "Apply to become a registered social worker in England",
-              "href": "https://www.socialworkengland.org.uk/registration/apply-for-registration"
-            },
-            {
-              "text": "Apprenticeship assessment service (AAS)",
-              "href": "https://assessors.apprenticeships.education.gov.uk/"
-            },
-            {
-              "text": "Apprenticeship provider and assessment register",
-              "href": "https://apply.apprenticeships.education.gov.uk/"
-            },
-            {
-              "text": "Connect families to support",
-              "href": "https://www.connect-families-to-support.education.gov.uk"
-            },
-            {
-              "text": "Criminal injuries compensation",
-              "href": "https://www.gov.uk/claim-compensation-criminal-injury/make-claim"
-            },
-            {
-              "text": "Early years child development training",
-              "href": "https://child-development-training.education.gov.uk/"
-            },
-            {
-              "text": "Find a UK market conformity assessment body",
-              "href": "https://find-a-conformity-assessment-body.service.gov.uk"
-            },
-            {
-              "text": "Find and apply for a grant",
-              "href": "https://www.gov.uk/guidance/find-government-grants"
-            },
-            {
-              "text": "Find and use an API from the Department for Education",
-              "href": "https://beta-find-and-use-an-api.education.gov.uk"
-            },
-            {
-              "text": "GOV.UK email subscriptions",
-              "href": "https://www.gov.uk/email/manage?from=your-services"
-            },
-            {
-              "text": "Manage apprenticeships",
-              "href": "https://www.gov.uk/sign-in-apprenticeship-service-account"
-            },
-            {
-              "text": "Manage family support services and accounts",
-              "href": "https://manage-family-support-services-and-accounts.education.gov.uk"
-            },
-            {
-              "text": "Modern slavery statement registry",
-              "href": "https://www.gov.uk/guidance/add-your-modern-slavery-statement-to-the-statement-registry"
-            },
-            {
-              "text": "Ofqual subject matter specialist account",
-              "href": "https://www.gov.uk/guidance/subject-matter-specialists-for-ofqual"
-            },
-            {
-              "text": "Request a basic DBS check",
-              "href": "https://www.gov.uk/request-copy-criminal-record"
-            },
-            {
-              "text": "Sign your mortgage deed",
-              "href": "https://sign-your-mortgage-deed.landregistry.gov.uk"
-            }
-          ]
-        },
-        "paragraph2": "GOV.UK One Login does not work with all government accounts and services yet (for example Government Gateway or Universal Credit).",
-        "paragraph3": "In the future, you'll be able to use GOV.UK One Login to access all services on GOV.UK."
+
+        "paragraph2": "In the future, you'll be able to use GOV.UK One Login to access all services on GOV.UK.",
+        "paragraph3": "See the <a class=\"govuk-link\" href=\"[servicesLink]\">services you can use with GOV.UK One Login</a>."
       }
     },
     "enterPassword": {


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update the content in the information box on the `/your-services` page. We now link out to the GOV.UK guidance for One Login rather than maintaining our own list of services as well.

### Why did it change

This makes it clearer to users now HMRC are onboarding and also gives us one less thing to maintain.
### Related links

[Figma](https://www.figma.com/file/0JbNRTnq5ibRtfg8BMxXDL/One-Login-Home---Design-thinking?type=design&node-id=7563-18869&mode=design&t=6OKUlOQIVSyVOwhy-0)
[Jira ticket with Welsh translation
](https://govukverify.atlassian.net/jira/software/c/projects/OLH/boards/195?selectedIssue=OLH-1604)
## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## How to review
Please check the English and Welsh content against the content in the ticket. 

Before:
![image](https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/e96f6d64-0780-4f2c-b85a-85b31358f1a7)

After:
![Screenshot 2024-04-22 at 11 53 16](https://github.com/govuk-one-login/di-account-management-frontend/assets/6362602/e5c0128c-4a3c-468d-95b1-4b4e2d6531b2)

