### PR TITLE
OLH-1655 - improve alerting of 5xx errors.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1884,18 +1884,21 @@ Resources:
             Stat: Sum
 
   # 5xx Status Code
+  # Alarm should activate when the number of 5xx errors exceeds 5 in the current 24-hour period.
+  # Sample every 300 seconds (Period) and check the 288 preceeding sample persiods to cover the last 24 hours
+  # 288 * 300 seconds = 86,400 seconds = 24 hours.
   ApiGateway5xxStatusAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGateway5xxStatusAlarm"
-      AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
+      AlarmDescription: "Activate when 5 5xx events detected in the last 24 hours.  The Alarm will be raised within 300 seconds of the 5xx being raised."
       ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 5
-      DatapointsToAlarm: 2
-      Threshold: 1
+      EvaluationPeriods: 288
+      DatapointsToAlarm: 288
+      Threshold: 5
       TreatMissingData: missing
       Metrics:
         - Id: errorThreshold
@@ -1911,7 +1914,7 @@ Resources:
               Dimensions:
                 - Name: ApiId
                   Value: !Ref ApiGateway
-            Period: 60
+            Period: 300
             Stat: Sum
         - Id: errorPercentage
           Label: errorPercentage
@@ -1926,7 +1929,7 @@ Resources:
               Dimensions:
                 - Name: ApiId
                   Value: !Ref ApiGateway
-            Period: 60
+            Period: 300
             Stat: Sum
 
   # Latency


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
Change Alarm for 5xx errors to sample every 300 seconds and consider the last 24 hours when evaluating whether it should activate.  It will activate if there were 5 5xx errors in the last 24 hour period and the alarm will activate within 300 seconds of teh 5xx error.

### What changed

<!-- Describe the changes in detail - the "what"-->
The Alarm definition in the AWS SAM template was updated.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To provide a more useful alarm when error responses are returned to the users in production.
### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

## Testing

<!-- Provide a summary of any manual testing you've done -->

We will check this in production and monitor whether it gives us the required level of alerting.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
