### PR TITLE
OLH-1748: Fix bug on Change email page

### DIFF
--- a/src/components/change-email/change-email-validation.ts
+++ b/src/components/change-email/change-email-validation.ts
@@ -19,16 +19,17 @@ export function validateChangeEmailRequest(): ValidationChainFunc {
         });
       })
       .isEmail()
+      .withMessage((value, { req }) => {
+        return req.t("pages.changeEmail.email.validationError.email", {
+          value,
+        });
+      })
+      .bail()
       .normalizeEmail({
         gmail_remove_dots: false,
         gmail_remove_subaddress: false,
         outlookdotcom_remove_subaddress: false,
         icloud_remove_subaddress: false,
-      })
-      .withMessage((value, { req }) => {
-        return req.t("pages.changeEmail.email.validationError.email", {
-          value,
-        });
       }),
     validateBodyMiddleware("change-email/index.njk"),
   ];

--- a/src/components/change-email/tests/change-email-integration.test.ts
+++ b/src/components/change-email/tests/change-email-integration.test.ts
@@ -125,6 +125,25 @@ describe("Integration:: change email", () => {
       .expect(400);
   });
 
+  it("should return validation error when email too long", async () => {
+    await request(app)
+      .post(PATH_DATA.CHANGE_EMAIL.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        email:
+          "grbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierbgrbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierbgrbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierbgrbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierbgrbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierbgrbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierbgrbweuiieugbui4bg4gbuiebruiebguirebguirebguirebgiurebgirebuigrbuigrebguierb@gmail.com",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($(testComponent("email-error")).text()).to.contains(
+          "Email address must be 256 characters or fewer"
+        );
+      })
+      .expect(400);
+  });
+
   it("should return validation error when invalid email entered", async () => {
     await request(app)
       .post(PATH_DATA.CHANGE_EMAIL.url)


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
There is an issue on the "Enter your new email address" page where when there is an error (the form is submitted with an invalid address or the form is submitted with an empty email field), there is an additional "@" character prepended on the input field.


https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/b74df4df-a0c7-4b42-af74-4baefed67d3e

As far as I could ascertain, this bug does not appear to be as a result of an issue on our side, but rather it seems like it's coming from  the `express-validator` middleware. This made it difficult to debug/fix, however I have found a workaround which seems to fix it by changing the order of the functions in the validation chain, making the `normalizeEmail` one execute after other checks.

Tests were missing for the maximum length validator which were added as part of this commit as well.
<!-- Describe the changes in detail - the "what"-->





### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Did manual testing of all the error states on the form. Manual testing of the happy path locally  but might be valuable to get a second pair of eyes on that as well.
<!-- Provide a summary of any manual testing you've done -->

## How to review
Double check the above and any potential pitfalls you can think of please 🙏 
<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
