### PR TITLE
OLH-1649 - Onboard RP: Find and use a DfE API - Make corrections.

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -776,7 +776,7 @@
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
         "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
@@ -907,7 +907,7 @@
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
         "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
@@ -1026,7 +1026,7 @@
       },
       "dfeFindAndUseAnApi": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
         "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
@@ -1145,7 +1145,7 @@
       },
       "dfeFindAndUseAnApi": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
         "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
@@ -1264,7 +1264,7 @@
       },
       "dfeFindAndUseAnApi": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
         "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
@@ -1383,7 +1383,7 @@
       },
       "dfeFindAndUseAnApi": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+        "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
         "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -838,7 +838,7 @@
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Find and use an API from the Department for Education",
         "description": "Find and use a Department for Education API to connect to their digital services.",
-        "link_text": "Go to your DfE API account",
+        "link_text": "Go to your DfE find and use an API account",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
     },
@@ -975,7 +975,7 @@
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Find and use an API from the Department for Education",
         "description": "Find and use a Department for Education API to connect to their digital services.",
-        "link_text": "Go to your DfE API account",
+        "link_text": "Go to your DfE find and use an API account",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
     },
@@ -1225,7 +1225,7 @@
       "dfeFindAndUseAnApi": {
         "header": "Find and use an API from the Department for Education",
         "description": "Find and use a Department for Education API to connect to their digital services.",
-        "link_text": "Go to your DfE API account",
+        "link_text": "Go to your DfE find and use an API account",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
     },
@@ -1350,7 +1350,7 @@
       "dfeFindAndUseAnApi": {
         "header": "Find and use an API from the Department for Education",
         "description": "Find and use a Department for Education API to connect to their digital services.",
-        "link_text": "Go to your DfE API account",
+        "link_text": "Go to your DfE find and use an API account",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
     },
@@ -1475,7 +1475,7 @@
       "dfeFindAndUseAnApi": {
         "header": "Find and use an API from the Department for Education",
         "description": "Find and use a Department for Education API to connect to their digital services.",
-        "link_text": "Go to your DfE API account",
+        "link_text": "Go to your DfE find and use an API account",
         "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
       }
     }


### PR DESCRIPTION
## Proposed changes

OLH-1649 - Onboard RP: Find and use a DfE API

### What changed

Make corrections to link text and service description

### Why did it change

Found this as part of UCD review

### Related links

Fix on top of https://github.com/govuk-one-login/di-account-management-frontend/pull/1257

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing
UCD Review in dev

## How to review
