### PR TITLE
OLH-1750: Enter password error state content issue

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -49,14 +49,6 @@ const OPL_VALUES: {
   },
 };
 
-const getStringsForForm = (req: Request, requestType: string) => {
-  return {
-    header: req.t(`pages.enterPassword.${requestType}.header`),
-    paragraph: req.t(`pages.enterPassword.${requestType}.paragraph`),
-    backLinkText: req.t(`pages.enterPassword.${requestType}.backLink`),
-  };
-};
-
 export function enterPasswordGet(req: Request, res: Response): void {
   const requestType = req.query.type as UserJourney;
 
@@ -68,7 +60,6 @@ export function enterPasswordGet(req: Request, res: Response): void {
 
   res.render(`enter-password/index.njk`, {
     requestType,
-    ...getStringsForForm(req, requestType),
     oplValues: OPL_VALUES[requestType] || {},
   });
 }

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -2,10 +2,13 @@
 {% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set paragraph = ['pages.enterPassword.', requestType, '.paragraph'] | join | translate %}
+{% set backLinkText = ['pages.enterPassword.', requestType, '.backLink'] | join | translate %}
+{% set header = ['pages.enterPassword.', requestType, '.header'] | join | translate %}
 
 {% if requestType == 'changePassword' %}
     {% set pageTitleName = 'pages.enterPassword.changePassword.title' | translate %}
-{%  else %}
+{% else %}
     {% set pageTitleName = 'pages.enterPassword.title' | translate %}
 {% endif %}
 


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Fix bug where some of the content is missing on the "Enter password" page when there is an empty field validation error. What is happening is that the logic that renders different pieces of content for different "states" of this page was moved into the controller, with the strings being passed into the view as local vars. 

This works fine in the normal/default state of the view, but it doesn't work when the form is POSTed and the `validateEnterPasswordRequest()` chain function fails with an error, triggering `renderBadRequest()` which renders the view again minus those local vars.

My initial intention was to modify `renderBadRequest` to allow it to receive locals but I ran into some difficulties with that when re-rendering in the context of middleware functions. Having spent way too much time attempting that approach, I switched gears to the simpler workaround of moving the translation strings into the Nunjucks template instead.
<!-- Describe the changes in detail - the "what"-->

### Error before
<img width="1271" alt="Screenshot 2024-04-30 at 09 24 40" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/3b1c37ef-2981-4aa7-a781-60b66ad8072f">

### Error after
<img width="1365" alt="Screenshot 2024-04-30 at 09 23 20" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/4f0d91ab-a63c-46eb-96df-c7d1ecadfe8d">

### Why did it change
Content disappears from the enter password page when the "required" check fails.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Manual local testing 
<!-- Provide a summary of any manual testing you've done -->

## How to review
Test that the content on the page: 
1. persists when the state of the page changes (there has been an error e.g the password field is missing or the password that was entered does not match the user's password)
2. reflects the journey that the password is entered as part of: for instance when the password is entered before changing the email address associated with the account, the content on the page should say "We need to make sure it's you before you can change your email address"
<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
