### PR TITLE
BAU: Allow tests to be run in a merge queue

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -2,6 +2,9 @@
 name: "Validation & Verification checks against Dev instance"
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - main


### PR DESCRIPTION


## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Allow tests to be run in a merge queue. This change won't have any impact on its own. Once it's merged I'll set up the merge queue in the repository settings.

[^1]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#about-merge-queues
### Why did it change

We're going to try out merge queues[^1] as a solution for constantly needing to rebase our PRs when another PR is merged.

Some of the steps in this workflow are required before a PR is merged. The same restriction applies to Github merging a PR from a merge queue, so before we can set up the queue we need to allow the workflow to be triggered by the queue.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

