### PR TITLE
OLH-1706 - Stop am cookie being used to sign in to deleted  or changed password account 

### DIFF
--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -5,7 +5,7 @@ import { deleteAccountService } from "./delete-account-service";
 import { PATH_DATA } from "../../app.constants";
 import { getNextState } from "../../utils/state-machine";
 import { getAppEnv, getBaseUrl, getSNSDeleteTopic } from "../../config";
-import { destroyUserSessions } from "../../utils/session-store";
+import { clearCookies, destroyUserSessions } from "../../utils/session-store";
 import {
   containsGovUkPublishingService,
   getAllowedListServices,
@@ -86,6 +86,8 @@ export function deleteAccountPost(
     });
 
     await destroyUserSessions(req, subjectId, req.app.locals.sessionStore);
+
+    clearCookies(req, res, ["am"]);
 
     return res.redirect(logoutUrl);
   };

--- a/src/components/delete-account/tests/delete-account-controller.test.ts
+++ b/src/components/delete-account/tests/delete-account-controller.test.ts
@@ -41,7 +41,6 @@ describe("delete account controller", () => {
       },
       log: { error: sandbox.fake() },
       headers: { "txma-audit-encoded": TXMA_AUDIT_ENCODED },
-      cookies: { _csrf: "dasdasdas", lo: "false", lng: "en", am: "dsadasdasd" },
     };
   }
 
@@ -52,7 +51,6 @@ describe("delete account controller", () => {
       render: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
       locals: {},
-      clearCookie: sandbox.fake(() => {}),
     };
   });
 
@@ -164,9 +162,11 @@ describe("delete account controller", () => {
         req.oidc = {
           endSessionUrl: sandbox.fake.returns("logout-url"),
         } as any;
+        const sessionStore = require("../../../utils/session-store");
+        sandbox.stub(sessionStore, "clearCookies").callsFake(() => {});
 
         await deleteAccountPost(fakeService)(req as Request, res as Response);
-        expect(res.clearCookie).to.have.calledWith("am");
+        expect(sessionStore.clearCookies).to.have.calledWith(req, res, ["am"]);
       });
     });
   });

--- a/src/components/delete-account/tests/delete-account-controller.test.ts
+++ b/src/components/delete-account/tests/delete-account-controller.test.ts
@@ -14,7 +14,7 @@ import { TXMA_AUDIT_ENCODED } from "../../../../test/utils/builders";
 describe("delete account controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
-  let res: Partial<Response>;
+  let res: any;
   const TEST_SUBJECT_ID = "testSubjectId";
 
   function validRequest(): any {
@@ -41,6 +41,7 @@ describe("delete account controller", () => {
       },
       log: { error: sandbox.fake() },
       headers: { "txma-audit-encoded": TXMA_AUDIT_ENCODED },
+      cookies: { _csrf: "dasdasdas", lo: "false", lng: "en", am: "dsadasdasd" },
     };
   }
 
@@ -51,6 +52,7 @@ describe("delete account controller", () => {
       render: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
       locals: {},
+      clearCookie: sandbox.fake(() => {}),
     };
   });
 
@@ -151,6 +153,20 @@ describe("delete account controller", () => {
           req,
           "public-subject-id"
         );
+      });
+      it("should clear am cookie", async () => {
+        req = validRequest();
+        const fakeService: DeleteAccountServiceInterface = {
+          deleteAccount: sandbox.fake.resolves(true),
+          publishToDeleteTopic: sandbox.fake(),
+        };
+        req.session.user.tokens = { accessToken: "token" } as any;
+        req.oidc = {
+          endSessionUrl: sandbox.fake.returns("logout-url"),
+        } as any;
+
+        await deleteAccountPost(fakeService)(req as Request, res as Response);
+        expect(res.clearCookie).to.have.calledWith("am");
       });
     });
   });

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -16,13 +16,14 @@ import { PATH_DATA } from "../../../app.constants";
 describe("update confirmation controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
-  let res: Partial<Response>;
+  let res: any;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
     req = {
       body: {},
+      cookies: { _csrf: "dasdasdas", lo: "false", lng: "en", am: "dsadasdasd" },
       session: { user: { state: {} }, destroy: sandbox.fake() } as any,
       t: sandbox.fake.returns("translated-string"),
     };
@@ -30,6 +31,7 @@ describe("update confirmation controller", () => {
       render: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
       locals: {},
+      clearCookie: sandbox.fake(() => {}),
     };
   });
 
@@ -48,7 +50,8 @@ describe("update confirmation controller", () => {
   describe("updatePasswordConfirmationGet", () => {
     it("should render update password confirmation page", () => {
       updatePasswordConfirmationGet(req as Request, res as Response);
-
+      expect(res.clearCookie).to.have.calledWith("am");
+      expect(req.session.destroy).called;
       expect(res.render).to.have.calledWith("update-confirmation/index.njk");
     });
   });

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -23,7 +23,6 @@ describe("update confirmation controller", () => {
 
     req = {
       body: {},
-      cookies: { _csrf: "dasdasdas", lo: "false", lng: "en", am: "dsadasdasd" },
       session: { user: { state: {} }, destroy: sandbox.fake() } as any,
       t: sandbox.fake.returns("translated-string"),
     };
@@ -31,7 +30,6 @@ describe("update confirmation controller", () => {
       render: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
       locals: {},
-      clearCookie: sandbox.fake(() => {}),
     };
   });
 
@@ -49,10 +47,12 @@ describe("update confirmation controller", () => {
 
   describe("updatePasswordConfirmationGet", () => {
     it("should render update password confirmation page", () => {
+      const sessionStore = require("../../../utils/session-store");
+      sandbox.stub(sessionStore, "clearCookies").callsFake(() => {});
       updatePasswordConfirmationGet(req as Request, res as Response);
-      expect(res.clearCookie).to.have.calledWith("am");
       expect(req.session.destroy).called;
       expect(res.render).to.have.calledWith("update-confirmation/index.njk");
+      expect(sessionStore.clearCookies).to.have.calledWith(req, res, ["am"]);
     });
   });
 

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from "express";
 import { redactPhoneNumber } from "../../utils/strings";
-import { PATH_DATA } from "../../app.constants";
+import { ERROR_MESSAGES, PATH_DATA } from "../../app.constants";
+import { clearCookies } from "../../utils/session-store";
+import { logger } from "../../utils/logger";
 
 const oplValues = {
   updateEmailConfirmation: {
@@ -40,6 +42,15 @@ export function updatePasswordConfirmationGet(
   res: Response
 ): void {
   delete req.session.user.state.changePassword;
+  clearCookies(req, res, ["am"]);
+
+  if (req.session) {
+    req.session.destroy((error) => {
+      if (error) {
+        logger.error(ERROR_MESSAGES.FAILED_TO_DESTROY_SESSION(error));
+      }
+    });
+  }
 
   res.render("update-confirmation/index.njk", {
     contentId: oplValues.updatePasswordConfirmation.contentId,

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -1,4 +1,4 @@
-import { Request } from "express";
+import { Request, Response } from "express";
 import {
   DynamoDBClient,
   QueryCommand,
@@ -99,5 +99,19 @@ export async function destroyUserSessions(
     );
   } finally {
     await deleteExpressSession(req);
+  }
+}
+
+export function clearCookies(
+  req: Request,
+  res: Response,
+  cookieNames: string[]
+): void {
+  if (req.cookies) {
+    for (const cookieName of Object.keys(req.cookies)) {
+      if (cookieNames.includes(cookieName)) {
+        res.clearCookie(cookieName);
+      }
+    }
   }
 }

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -108,9 +108,11 @@ export function clearCookies(
   cookieNames: string[]
 ): void {
   if (req.cookies) {
-    for (const cookieName of Object.keys(req.cookies)) {
-      if (cookieNames.includes(cookieName)) {
-        res.clearCookie(cookieName);
+    if (cookieNames) {
+      for (const cookieName of Object.keys(req.cookies)) {
+        if (cookieNames.includes(cookieName)) {
+          res.clearCookie(cookieName);
+        }
       }
     }
   }

--- a/src/utils/test/session-store.test.ts
+++ b/src/utils/test/session-store.test.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from "express";
+import { describe } from "mocha";
+import sinon from "sinon";
+import { clearCookies } from "../session-store";
+import { expect } from "chai";
+
+describe("Session Store Util Tests", () => {
+  describe("Clear cookies", () => {
+    let sandbox: sinon.SinonSandbox;
+    let req: Partial<Request>;
+    let res: any;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+
+      req = {
+        body: {},
+        cookies: {
+          _csrf: "dasdasdas",
+          lo: "false",
+          lng: "en",
+          am: "dsadasdasd",
+        },
+        session: { user: { state: {} }, destroy: sandbox.fake() } as any,
+        t: sandbox.fake.returns("translated-string"),
+      };
+      res = {
+        render: sandbox.fake(),
+        redirect: sandbox.fake(() => {}),
+        locals: {},
+        clearCookie: sandbox.fake(() => {}),
+      };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("clear cookie where matching single cookies exist", () => {
+      clearCookies(req as Request, res as Response, ["am"]);
+      expect(res.clearCookie.calledOnce).to.be.true;
+      expect(res.clearCookie.calledWith("am")).to.be.true;
+    });
+
+    it("clear cookie where matching multiple cookies exist", () => {
+      clearCookies(req as Request, res as Response, ["am", "lng"]);
+      expect(res.clearCookie.calledTwice).to.be.true;
+      expect(res.clearCookie.calledWith("am")).to.be.true;
+      expect(res.clearCookie.calledWith("lng")).to.be.true;
+    });
+
+    it("should not clear cookie where no matching cookies exist", () => {
+      clearCookies(req as Request, res as Response, ["another"]);
+      expect(res.clearCookie.notCalled).to.be.true;
+    });
+
+    it("should not fail if cookie names is null", () => {
+      let errorOccurred = false;
+      try {
+        clearCookies(req as Request, res as Response, null);
+      } catch (error) {
+        errorOccurred = true;
+      }
+      expect(errorOccurred).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes
OLH-1706 - Stop am cookie being used to sign in to deleted  or account where password has changed
https://govukverify.atlassian.net/browse/OLH-1706

### What changed

Expire am cookie when account deleted or password changed.

### Why did it change

As recommended by remediation action on Purple Teaming exercise.

### Related links

https://docs.google.com/presentation/d/1PCdEJzY0XlS8nY9UjNnvRoMs73qyZLcI_AE9BAuR3nQ/edit#slide=id.g2c25a21a9b4_0_0

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing

Deploy to dev and after accoutn deletion and/or password is changed, the am cookie expiry time is set to a date in the past.

## How to review
Test and code completeness