### PR TITLE
OLH-1766: Enable the Cloudfront header in all environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -129,9 +129,6 @@ Conditions:
       - !Equals [!Ref Environment, staging]
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
-  AddFraudHeader: !Or
-    - !Equals [!Ref Environment, dev]
-    - !Equals [!Ref Environment, staging]
 
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
@@ -1697,11 +1694,8 @@ Resources:
             !FindInMap [EnvironmentVariables, !Ref Environment, BASEURL]
           ViewerProtocolPolicy: redirect-to-https
           FunctionAssociations:
-            - !If
-              - AddFraudHeader
-              - EventType: viewer-request
-                FunctionARN: !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersFunction"
-              - !Ref "AWS::NoValue"
+            - EventType: viewer-request
+              FunctionARN: !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersFunction"
         Enabled: true
         HttpVersion: "http2"
         Logging:


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Enable the Cloudfront header in all environments by removing the condition.

### Why did it change

We've confirmed with TxMA that they're ready to receive events with this new field in production, and with our service transition lead that this is a minor change for us since we're not doing any of the DNS changes.

That means we're ready to call the function in production and start setting the new header for requests to our frontend.

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

I've deployed this to dev to check my template changes are valid. 
