### PR TITLE
OLH-1745: Update content on update phone journey

### DIFF
--- a/src/components/change-phone-number/index.njk
+++ b/src/components/change-phone-number/index.njk
@@ -6,52 +6,51 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.changePhoneNumber.title' | translate %}
 {% block content %}
+  {% include "common/errors/errorSummary.njk" %}
 
-{% include "common/errors/errorSummary.njk" %}
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.changePhoneNumber.header' |
+    translate}}</h1>
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.changePhoneNumber.header' |
-  translate}}</h1>
+  <form action="/change-phone-number" method="post" novalidate>
 
-<form action="/change-phone-number" method="post" novalidate>
+    <input type="hidden" name="_csrf" value="{{csrfToken}}" />
 
-  <input type="hidden" name="_csrf" value="{{csrfToken}}" />
+    <p class="govuk-body">{{'pages.changePhoneNumber.info.paragraph1' | translate }}</p>
 
-  <p class="govuk-body">{{'pages.changePhoneNumber.info.paragraph1' | translate}}</p>
-
-  {{ govukInput({
-  label: {
-  text: 'pages.changePhoneNumber.ukPhoneNumber.label' | translate
-  },
-  classes: "govuk-!-width-two-thirds",
-  id: "phoneNumber",
-  name: "phoneNumber",
-  type: "tel",
-  autocomplete: "tel",
-  errorMessage: {
-    attributes: { "data-test-id": "phoneNumber-error"},
-    text: errors['phoneNumber'].text
-  } if (errors['phoneNumber'])})
-  }}
-
-  {% set internationalNumberHtml %}
     {{ govukInput({
-      id: "internationalPhoneNumber",
-      name: "internationalPhoneNumber",
+      label: {
+      text: 'pages.changePhoneNumber.ukPhoneNumber.label' | translate
+      },
+      classes: "govuk-!-width-two-thirds",
+      id: "phoneNumber",
+      name: "phoneNumber",
       type: "tel",
       autocomplete: "tel",
-      classes: "govuk-!-width-two-thirds",
-      label: {
-        text: 'pages.changePhoneNumber.internationalPhoneNumber.label' | translate
-      },
-      hint: {
-        text: 'pages.changePhoneNumber.internationalPhoneNumber.hint' | translate
-      },
       errorMessage: {
-        attributes: { "data-test-id": "internationalPhoneNumber-error"},
-        text: errors['internationalPhoneNumber'].text
-      } if (errors['internationalPhoneNumber'])
-    }) }}
-  {% endset -%}
+        attributes: { "data-test-id": "phoneNumber-error"},
+        text: errors['phoneNumber'].text
+      } if (errors['phoneNumber'])})
+    }}
+
+    {% set internationalNumberHtml %}
+      {{ govukInput({
+        id: "internationalPhoneNumber",
+        name: "internationalPhoneNumber",
+        type: "tel",
+        autocomplete: "tel",
+        classes: "govuk-!-width-two-thirds",
+        label: {
+          text: 'pages.changePhoneNumber.internationalPhoneNumber.label' | translate
+        },
+        hint: {
+          text: 'pages.changePhoneNumber.internationalPhoneNumber.hint' | translate
+        },
+        errorMessage: {
+          attributes: { "data-test-id": "internationalPhoneNumber-error"},
+          text: errors['internationalPhoneNumber'].text
+        } if (errors['internationalPhoneNumber'])
+      }) }}
+    {% endset -%}
 
     {{ govukCheckboxes({
       items: [
@@ -68,18 +67,15 @@
       ]
     }) }}
 
+    {{ govukButton({
+      "text": button_text|default('general.continue.label' | translate, true),
+      "type": "Submit",
+      "preventDoubleClick": true
+    }) }}
+  </form>
 
-
-  {{ govukButton({
-  "text": button_text|default('general.continue.label' | translate, true),
-  "type": "Submit",
-  "preventDoubleClick": true
-  }) }}
-
-</form>
-
-<a href="/manage-your-account" class="govuk-link govuk-body">
+  <a href="/manage-your-account" class="govuk-link govuk-body">
     {{'pages.changePhoneNumber.info.backLink' | translate}}
-</a>
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change phone number", contentId:"39a31338-cadc-4e09-a74d-bd9f0dd68d2f",loggedInStatus:true,dynamic:true})}}
+  </a>
+  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change phone number", contentId:"39a31338-cadc-4e09-a74d-bd9f0dd68d2f",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -51,15 +51,15 @@
     </p>
 {% endset %}
 
-{{ govukDetails({
-    summaryText: 'pages.checkYourEmail.details.summaryText' | translate,
-    html: detailsHTML
-}) }}
-
 {{ govukButton({
     "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
+}) }}
+
+{{ govukDetails({
+    summaryText: 'pages.checkYourEmail.details.summaryText' | translate,
+    html: detailsHTML
 }) }}
 
 </form>

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -8,7 +8,7 @@ import {
   formatValidationError,
   renderBadRequest,
 } from "../../utils/validation";
-import { redactPhoneNumber } from "../../utils/strings";
+import { getLastNDigits } from "../../utils/phone-number";
 import xss from "xss";
 import {
   UpdateInformationInput,
@@ -22,7 +22,7 @@ const TEMPLATE_NAME = "check-your-phone/index.njk";
 
 export function checkYourPhoneGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
-    phoneNumber: redactPhoneNumber(req.session.user.newPhoneNumber),
+    phoneNumber: getLastNDigits(req.session.user.newPhoneNumber, 4),
     resendCodeLink: PATH_DATA.RESEND_PHONE_CODE.url,
     changePhoneNumberLink: PATH_DATA.CHANGE_PHONE_NUMBER.url,
   });

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -13,7 +13,7 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate}}</h1>
     {{ govukInsetText({
-        text: 'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber)
+        text: 'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber) | safe
     })}}
 
     <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph' | translate}}</p>
@@ -43,15 +43,15 @@
             <p class="govuk-body">{{'pages.checkYourPhone.details.text' | translate | replace("[resendCodeLink]", resendCodeLink) | replace("[changePhoneNumberLink]", changePhoneNumberLink) | safe }}</p>
         {% endset %}
 
-        {{ govukDetails({
-            summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
-            html: detailsHTML
-        }) }}
-
         {{ govukButton({
             "text": button_text|default("general.continue.label" | translate, true),
             "type": "Submit",
             "preventDoubleClick": true
+        }) }}
+
+        {{ govukDetails({
+            summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
+            html: detailsHTML
         }) }}
     </form>
     {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change phone number", contentId:"fb69b162-9ddb-41db-a8fa-3cca7fea2fa9",loggedInStatus:true,dynamic:true})}}

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set paragraph = ['pages.enterPassword.', requestType, '.paragraph'] | join | translate %}
-{% set backLinkText = ['pages.enterPassword.', requestType, '.backLink'] | join | translate %}
+{% set cancelText = 'pages.enterPassword.cancelText' | translate %}
 {% set header = ['pages.enterPassword.', requestType, '.header'] | join | translate %}
 
 {% if requestType == 'changePassword' %}
@@ -46,10 +46,7 @@
         "preventDoubleClick": true
         }) }}
 
-        <p class="govuk-body">
-            <a href="/manage-your-account" class="govuk-link" rel="noreferrer noopener">{{backlinkText}}</a>
-        </p>
-
+        <p class="govuk-body"> <a href="/manage-your-account" class="govuk-link" rel="noreferrer noopener">{{cancelText}}</a></p>
     </form>
 
 {% endblock %}

--- a/src/components/resend-phone-code/index.njk
+++ b/src/components/resend-phone-code/index.njk
@@ -12,7 +12,7 @@
       <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate}}</h1>
 
       {{ govukInsetText({
-          text: 'pages.resendMfaCode.phoneNumber.insetText' | translate | replace("[mobile]", phoneNumberRedacted )
+          text: 'pages.resendMfaCode.phoneNumber.insetText' | translate | replace("[mobile]", phoneNumberRedacted) | safe
       }) }}
 
       <p class="govuk-body">{{'pages.resendMfaCode.phoneNumber.paragraph' | translate}}</p>

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from "express";
 import { ERROR_CODES, PATH_DATA } from "../../app.constants";
-import { redactPhoneNumber } from "../../utils/strings";
 import { ExpressRouteFunc } from "../../types";
 import { ChangePhoneNumberServiceInterface } from "../change-phone-number/types";
 import { changePhoneNumberService } from "../change-phone-number/change-phone-number-service";
 import { BadRequestError } from "../../utils/errors";
+import { getLastNDigits } from "../../utils/phone-number";
 import { getNextState } from "../../utils/state-machine";
 import xss from "xss";
 import {
@@ -17,7 +17,7 @@ const TEMPLATE_NAME = "resend-phone-code/index.njk";
 
 export function resendPhoneCodeGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
-    phoneNumberRedacted: redactPhoneNumber(req.session.user.newPhoneNumber),
+    phoneNumberRedacted: getLastNDigits(req.session.user.newPhoneNumber, 4),
     phoneNumber: req.session.user.newPhoneNumber,
   });
 }

--- a/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
@@ -47,7 +47,7 @@ describe("resend phone code controller", () => {
       resendPhoneCodeGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("resend-phone-code/index.njk", {
-        phoneNumberRedacted: "*******1111",
+        phoneNumberRedacted: "1111",
         phoneNumber: "07111111111",
       });
     });

--- a/src/components/update-confirmation/index.njk
+++ b/src/components/update-confirmation/index.njk
@@ -13,7 +13,7 @@
 }) }}
 
 {% if summaryText %}
-<p class="govuk-body">{{summaryText}}</p>
+<p class="govuk-body">{{summaryText | safe }}</p>
 {% endif %}
 
 {% if showGovUKButton %}

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from "express";
-import { redactPhoneNumber } from "../../utils/strings";
 import { ERROR_MESSAGES, PATH_DATA } from "../../app.constants";
 import { clearCookies } from "../../utils/session-store";
 import { logger } from "../../utils/logger";
+import { getLastNDigits } from "../../utils/phone-number";
 
 const oplValues = {
   updateEmailConfirmation: {
@@ -73,7 +73,7 @@ export function updatePhoneNumberConfirmationGet(
     panelText: req.t("pages.updatePhoneNumberConfirmation.panelText"),
     summaryText: req
       .t("pages.updatePhoneNumberConfirmation.summaryText")
-      .replace("[mobile]", redactPhoneNumber(req.session.user.phoneNumber)),
+      .replace("[mobile]", getLastNDigits(req.session.user.phoneNumber, 4)),
   });
 }
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -14,7 +14,7 @@
     },
     "yes": "Yes",
     "no": "Na",
-    "backToAccountButtonText": "Yn ôl i’r dudalen ddiogelwch",
+    "backToAccountButtonText": "Yn ôl i’r dudalen Ddiogelwch",
     "backToGovUKButtonText": "Ewch i hafan GOV.UK",
     "cookie": {
       "cookieBanner": {
@@ -257,24 +257,20 @@
       "title": "Rhowch eich cyfrinair",
       "changeEmail": {
         "header": "Rhowch eich cyfrinair",
-        "paragraph": "Mae angen i ni wneud yn siwr mai chi yw chi cyn y gallwch newid eich cyfeiriad e-bost.",
-        "backLink": "Nid wyf eisiau newid fy nghyfeiriad e-bost"
+        "paragraph": "Mae angen i ni wneud yn siwr mai chi yw chi cyn y gallwch newid eich cyfeiriad e-bost."
       },
       "changePassword": {
         "title": "Rhowch eich cyfrinair presennol",
         "header": "Rhowch eich cyfrinair presennol",
-        "paragraph": "Mae angen i ni wneud yn siwr mai chi yw chi cyn y gallwch newid eich cyfrinair.",
-        "backLink": "Nid wyf eisiau newid fy nghyfrinair"
+        "paragraph": "Mae angen i ni wneud yn siwr mai chi yw chi cyn y gallwch newid eich cyfrinair."
       },
       "changePhoneNumber": {
         "header": "Rhowch eich cyfrinair",
-        "paragraph": "Mae angen i ni wneud yn siwr mai chi yw chi cyn y gallwch newid eich rhif ffôn.",
-        "backLink": "Nid wyf eisiau newid fy rhif ffôn"
+        "paragraph": "Mae angen i ni sicrhau mai chi sydd yna cyn y gallwch reoli sut rydych yn cael codau diogelwch."
       },
       "deleteAccount": {
         "header": "Rhowch eich cyfrinair",
-        "paragraph": "Rydym angen sicrhau mai chi yw chi cyn y gallwch ddileu eich GOV.UK One Login.",
-        "backLink": "Nid wyf eisiau dileu fy GOV.UK One Login"
+        "paragraph": "Rydym angen sicrhau mai chi yw chi cyn y gallwch ddileu eich GOV.UK One Login."
       },
       "password": {
         "label": "Rhowch eich cyfrinair",
@@ -282,7 +278,8 @@
           "required": "Rhowch eich cyfrinair",
           "incorrectPassword": "Rhowch y cyfrinair cywir"
         }
-      }
+      },
+      "cancelText": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
     },
     "changeEmail": {
       "title": "Rhowch eich cyfeiriad e-bost newydd",
@@ -298,7 +295,7 @@
         }
       },
       "dontWantTo": {
-        "changeEmailLinkText": "Nid wyf eisiau newid fy nghyfeiriad e-bost"
+        "changeEmailLinkText": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
       }
     },
     "updateEmailConfirmation": {
@@ -313,7 +310,7 @@
     "updatePhoneNumberConfirmation": {
       "title": "Rydych wedi newid eich rhif ffôn",
       "panelText": "Rydych wedi newid eich rhif ffôn",
-      "summaryText": "Mae eich rhif ffôn wedi cael ei newid i [mobile]."
+      "summaryText": "Byddwn yn anfon codau diogelwch i'ch rhif ffôn sy'n gorffen gyda <strong>[mobile]</strong>."
     },
     "deleteAccountConfirmation": {
       "title": "Rydych wedi dileu eich GOV.UK One Login",
@@ -351,7 +348,7 @@
         "summary": "Sut i greu cyfrinair diogel",
         "text": "Ffordd dda o greu cyfrinair diogel a chofiadwy yw defnyddio 3 gair ar hap. Gallwch ddefnyddio rhifau, symbolau a gofodau."
       },
-      "backLink": "Nid wyf eisiau newid fy nghyfrinair"
+      "backLink": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
     },
     "checkYourEmail": {
       "title": "Gwiriwch eich e-bost",
@@ -385,7 +382,7 @@
     "checkYourPhone": {
       "title": "Gwiriwch eich ffôn",
       "header": "Gwiriwch eich ffôn",
-      "text": "Rydym wedi anfon cod i [mobile].",
+      "text": "Rydym wedi anfon cod i'ch rhif ffôn sy'n gorffen gyda <strong>[mobile]</strong>.",
       "info": {
         "paragraph": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
       },
@@ -415,14 +412,14 @@
       "paragraph5": "Os byddwch angen GOV.UK One Login yn y dyfodol, bydd yn rhaid i chi greu un newydd.",
       "details": "Ni fydd dileu eich GOV.UK One Login yn effeithio ar unrhyw gyfrifon eraill y llywodraeth sydd gennych, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
       "deleteAccount": "Dileu eich GOV.UK One Login",
-      "doNotDeleteAccount": "Canslo a mynd yn ôl i’r dudalen ddiogelwch"
+      "doNotDeleteAccount": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
     },
     "changePhoneNumber": {
       "title": "Rhowch eich rhif ffôn symudol newydd",
       "header": "Rhowch eich rhif ffôn symudol newydd",
       "info": {
         "paragraph1": "Byddwn yn anfon cod diogelwch 6 digid i’r rhif rydych yn ei roi i ni.",
-        "backLink": "Nid wyf eisiau newid fy rhif ffôn"
+        "backLink": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
       },
       "ukPhoneNumber": {
         "label": "Rhif ffôn symudol y DU",
@@ -460,7 +457,7 @@
       "continue": "Cael cod diogelwch",
       "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
       "phoneNumber": {
-        "insetText": "Byddwn yn anfon cod i: [mobile].",
+        "insetText": "Byddwn yn anfon cod i'ch rhif ffôn sy'n gorffen gyda <strong>[mobile]</strong>.",
         "paragraph": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd."
       },
       "email": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,7 +14,7 @@
     },
     "yes": "Yes",
     "no": "No",
-    "backToAccountButtonText": "Back to security",
+    "backToAccountButtonText": "Back to Security",
     "backToGovUKButtonText": "Go to the GOV.UK homepage",
     "cookie": {
       "cookieBanner": {
@@ -306,7 +306,6 @@
       "informationBox": {
         "heading": "Services you can use with GOV.UK One Login",
         "paragraph1": "GOV.UK One Login is new. At the moment you can only use it to access some government services.",
-
         "paragraph2": "In the future, you'll be able to use GOV.UK One Login to access all services on GOV.UK.",
         "paragraph3": "See the <a class=\"govuk-link\" href=\"[serviceListLink]\">services you can use with GOV.UK One Login</a>.",
         "link": "https://www.gov.uk/using-your-gov-uk-one-login/services"
@@ -316,24 +315,20 @@
       "title": "Enter your password",
       "changeEmail": {
         "header": "Enter your password",
-        "paragraph": "We need to make sure it’s you before you can change your email address.",
-        "backLink": "I do not want to change my email address"
+        "paragraph": "We need to make sure it’s you before you can change your email address."
       },
       "changePassword": {
         "title": "Enter your current password",
         "header": "Enter your current password",
-        "paragraph": "We need to make sure it’s you before you can change your password.",
-        "backLink": "I do not want to change my password"
+        "paragraph": "We need to make sure it’s you before you can change your password."
       },
       "changePhoneNumber": {
         "header": "Enter your password",
-        "paragraph": "We need to make sure it’s you before you can change your phone number.",
-        "backLink": "I do not want to change my phone number"
+        "paragraph": "We need to make sure it’s you before you can manage how you get security codes."
       },
       "deleteAccount": {
         "header": "Enter your password",
-        "paragraph": "We need to make sure it’s you before you can delete your GOV.UK One Login.",
-        "backLink": "I do not want to delete my GOV.UK One Login"
+        "paragraph": "We need to make sure it’s you before you can delete your GOV.UK One Login."
       },
       "password": {
         "label": "Enter your password",
@@ -344,9 +339,9 @@
       },
       "addMfaMethod": {
         "header": "Enter your password",
-        "paragraph": "We need to make sure it’s you before you can manage how you get your security codes",
-        "backLink": "Back"
-      }
+        "paragraph": "We need to make sure it’s you before you can manage how you get your security codes"
+      },
+      "cancelText" : "Cancel and go back to Security"
     },
     "changeEmail": {
       "title": "Enter your new email address",
@@ -362,7 +357,7 @@
         }
       },
       "dontWantTo": {
-        "changeEmailLinkText": "I do not want to change my email address"
+        "changeEmailLinkText": "Cancel and go back to Security"
       }
     },
     "updateEmailConfirmation": {
@@ -377,7 +372,7 @@
     "updatePhoneNumberConfirmation": {
       "title": "You’ve changed your phone number",
       "panelText": "You’ve changed your phone number",
-      "summaryText": "Your phone number has been changed to [mobile]."
+      "summaryText": "We’ll send security codes to your phone number ending with <strong>[mobile]</strong>."
     },
     "deleteAccountConfirmation": {
       "title": "You’ve deleted your GOV.UK One Login",
@@ -415,7 +410,7 @@
         "summary": "How to create a secure password",
         "text": "A good way to create a secure and memorable password is to use 3 random words. You can use numbers, symbols and spaces."
       },
-      "backLink": "I do not want to change my password"
+      "backLink": "Cancel and go back to Security"
     },
     "checkYourEmail": {
       "title": "Check your email",
@@ -449,9 +444,9 @@
     "checkYourPhone": {
       "title": "Check your phone",
       "header": "Check your phone",
-      "text": "We have sent a code to [mobile].",
+      "text": "We have sent a code to your phone number ending with <strong>[mobile]</strong>",
       "info": {
-        "paragraph": "It might take a few minutes to arrive. The code will expire after  15 minutes."
+        "paragraph": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
       "details": {
         "summaryText": "Problems with the code",
@@ -479,14 +474,14 @@
       "paragraph5": "If you need a GOV.UK One Login in the future, you’ll have to create a new one.",
       "details": "Deleting your GOV.UK One Login will not affect any other government accounts you may have, such as Government Gateway or Universal Credit.",
       "deleteAccount": "Delete your GOV.UK One Login",
-      "doNotDeleteAccount": "Cancel and go back to security"
+      "doNotDeleteAccount": "Cancel and go back to Security"
     },
     "changePhoneNumber": {
       "title": "Enter your new mobile phone number",
       "header": "Enter your new mobile phone number",
       "info": {
         "paragraph1": "We will send a 6 digit security code to the number you give us.",
-        "backLink": "I do not want to change my phone number"
+        "backLink": "Cancel and go back to Security"
       },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
@@ -524,7 +519,7 @@
       "continue": "Get security code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
       "phoneNumber": {
-        "insetText": "We will send a code to [mobile]",
+        "insetText": "We will send a code to your phone number ending with <strong>[mobile]</strong>",
         "paragraph": "Text messages can sometimes take a few minutes to arrive."
       },
       "email": {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -13,12 +13,6 @@ export function containsNumbersOnly(value: string): boolean {
   return value ? /^\d+$/.test(value) : false;
 }
 
-export function redactPhoneNumber(value: string): string | undefined {
-  return value
-    ? "*".repeat(value.length - 4) + value.trim().slice(value.length - 4)
-    : undefined;
-}
-
 export function generateNonce(): string {
   return randomBytes(16).toString("hex");
 }

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -5,7 +5,6 @@ import {
   containsNumbersOnly,
   isSafeString,
   isValidUrl,
-  redactPhoneNumber,
   zeroPad,
 } from "../../../src/utils/strings";
 import { sinon } from "../../utils/test-utils";
@@ -49,20 +48,6 @@ describe("string-helpers", () => {
 
     it("should return true when string contains numeric characters only", () => {
       expect(containsNumbersOnly("123456")).to.equal(true);
-    });
-  });
-
-  describe("obfuscatePhoneNumber", () => {
-    it("should return obfuscated phone number when valid uk phone number", () => {
-      expect(redactPhoneNumber("07700900796")).to.equal("*******0796");
-    });
-
-    it("should return obfuscated phone number when valid international phone number", () => {
-      expect(redactPhoneNumber("+330645453322")).to.equal("*********3322");
-    });
-
-    it("should return undefined when phone number is is empty", () => {
-      expect(redactPhoneNumber("")).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update some of the content on the update phone number journey (and a few bits in some other journeys) in light of bringing account management frontend more in line with auth. 

The content updates include:
-  moving the "Problems with the code" dropdown under the submit button on all versions of this page
- changing "I do not want to change my [thing]" to "Cancel and go back to Security"
- updating how we play back the new phone number in the update phone number journey:  changed the language and the way the phone number is displayed. Now we consistently display the last 4 digits, in bold, instead of the obfuscated "*******1111" format
- use uppercase "Security" across the journey when talking about the Security page 


<!-- Describe the changes in detail - the "what"-->

### Why did it change
More consistent language across the old and new journeys.

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing
Mel has checked this on dev 
<!-- Provide a summary of any manual testing you've done -->

## How to review
Double check the content matches the figma and that all the welsh content is there. 
Check that nothing's broken as a consequence of the removal of the old phone number obfuscation util func.

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
