### PR TITLE
OLH-1805 Security Page breaks when lng cookie is not set

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,6 +64,8 @@ import { addMfaMethodRouter } from "./components/add-mfa-method/add-mfa-method-r
 import { addMfaMethodAppRouter } from "./components/add-mfa-method-app/add-mfa-method-app-routes";
 import { csrfErrorHandler } from "./handlers/csrf-error-handler";
 import { languageToggleMiddleware } from "./middleware/language-toggle-middleware";
+import { logger } from "./utils/logger";
+import { safeTranslate } from "./utils/safeTranslate";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -118,6 +120,14 @@ async function createApp(): Promise<express.Application> {
   } else {
     app.use(helmet(helmetConfiguration));
   }
+
+  app.use((req, res, next) => {
+    const translate = req.t.bind(req);
+    req.t = (key: string): string => {
+      return safeTranslate(translate, key, req.language, {}) as string;
+    };
+    next();
+  });
 
   app.use(languageToggleMiddleware);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -64,7 +64,6 @@ import { addMfaMethodRouter } from "./components/add-mfa-method/add-mfa-method-r
 import { addMfaMethodAppRouter } from "./components/add-mfa-method-app/add-mfa-method-app-routes";
 import { csrfErrorHandler } from "./handlers/csrf-error-handler";
 import { languageToggleMiddleware } from "./middleware/language-toggle-middleware";
-import { logger } from "./utils/logger";
 import { safeTranslate } from "./utils/safeTranslate";
 
 const APP_VIEWS = [


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Override the req.t function (provided by the i18n middleware), instead of calling it directly, call it using the `safeTranslate` function.

### Why did it change

We added a `safeTranslation` system in [this PR](https://github.com/govuk-one-login/di-account-management-frontend/pull/1347), so that we could log cases of missing Welsh translations.

As part of the change, the fallback translation key was [removed](https://github.com/govuk-one-login/di-account-management-frontend/pull/1347/files#diff-f85240b4ea55d79848a6c10ada2ee5a7c8a98322e7a473fd53a54f50f8057072R8).

Since the `safeTranslation` was only used in the nunjucks `translate` [filter](https://github.com/govuk-one-login/di-account-management-frontend/pull/1347/files#diff-56d484fb2dd4640edebe2d84825c06d6b2cfdcd75abbae7801a858ee4637467fL17), we don't translate strings correctly when the `lng` cookie isn't set AND we are translating in the code rather than the templates.