### PR TITLE
OLH-1804: Update contact hours

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -7,13 +7,6 @@
 {% set webchatLang = "welsh" if language == "cy" else "hgsgds" %}
 {% set hideTitleProductName = true %}
 
-{% macro openingHoursBlock(openingHours) %}
-  <ul class="govuk-list govuk-list--bullet">
-    <li>{{openingHours[0]}}</li>
-    <li>{{openingHours[1]}}</li>
-  </ul>
-{% endmacro %}
-
 {% block head %}
   {{ super() }}
   <meta name="description" content="{{'pages.contact.metaDescription' | translate }}">
@@ -77,7 +70,9 @@
     }) }}
 
     <p class="govuk-body">{{'pages.contact.section3.phone.paragraph2' | translate }}</p>
-    {{ openingHoursBlock('pages.contact.section3.phone.openingHours' | translate({ returnObjects: true })) }}
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{'pages.contact.section3.phone.openingHours' | translate }}</li>
+    </ul>
     <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/call-charges">{{'pages.contact.section3.phone.callChargesLinkText' | translate }}</a></p>
 
     <p class="govuk-body"></p>
@@ -134,8 +129,9 @@
           <p class="govuk-body">{{ paragraph | safe  }}</p>
         {% endfor %}
 
-        {{ openingHoursBlock('pages.contact.section3.webchat.openingHours' | translate({ returnObjects: true })) }}
-
+        <ul class="govuk-list govuk-list--bullet">
+          <li>{{'pages.contact.section3.webchat.openingHours' | translate }}</li>
+        </ul>
         <p class="govuk-body">{{'pages.contact.section3.webchat.paragraph2' | translate}}</p>
         <p class="govuk-body"><button type="button" class="launch-webchat-link" data-launch-webchat hidden>{{ 'pages.contact.section3.webchat.linkText' | translate }}</button></p>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -520,10 +520,7 @@
             "Efallai y gofynnir i chi am eich cod cyfeirio pan fyddwch yn siarad â ni.",
             "Gallwch sgwrsio'n fyw gyda chynghorydd ar:"
           ],
-          "openingHours": [
-            "Dydd Llun i ddydd Gwener, 8am i 8pm",
-            "penwythnosau a gwyliau cyhoeddus, 9am i 5.30pm"
-          ],
+          "openingHours": "Dydd Llun i ddydd Gwener, 8am i 8pm",
           "paragraph2": "Mae'r cynorthwyydd digidol bob amser ar gael",
           "linkText": "Defnyddio gwesgwrs",
           "accessibility-statement": {
@@ -546,10 +543,7 @@
             ]
           },
           "paragraph2": "You can call us on:",
-          "openingHours": [
-            "Dydd Llun i ddydd Gwener, 8am i 8pm",
-            "Penwythnosau a gwyliau cyhoeddus, 9am i 5:30pm"
-          ],
+          "openingHours": "Dydd Llun i ddydd Gwener, 8am i 8pm",
           "callChargesLinkText": "Darganfyddwch fwy am gostau galwadau",
           "waitingTimeWarning": "Mae amseroedd aros hir ar y ffôn ar hyn o bryd. Os nad yw'ch galwad yn un brys, rhowch gynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">cwblhewch y ffurflen gyswllt</a>."
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -582,10 +582,7 @@
             "You might be asked for your reference code when you chat to us.",
             "You can chat live with an advisor on:"
           ],
-          "openingHours": [
-            "Monday to Friday, 8am to 8pm",
-            "weekends and public holidays, 9am to 5.30pm"
-          ],
+          "openingHours": "Monday to Friday, 8am to 8pm",
           "paragraph2": "The digital assistant is always available.",
           "linkText": "Use webchat",
           "accessibility-statement": {
@@ -606,10 +603,7 @@
             ]
           },
           "paragraph2": "You can call us on:",
-          "openingHours": [
-            "Monday to Friday, 8am to 8pm",
-            "weekends and public holidays, 9am to 5.30pm"
-          ],
+          "openingHours": "Monday to Friday, 8am to 8pm",
           "callChargesLinkText": "Find out about call charges",
           "waitingTimeWarning": "There are currently long waiting times on the phone. If your call is not urgent, try again later or <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">fill in the contact form</a>."
         },


### PR DESCRIPTION
## Proposed changes

Remove the option to contact GOVUK OL on the weekend as this will no longer be available.

For the time being we are simply removing the weekend bullet point. 
This is only until we get back Welsh translations for the paragraph version which is when the content can be updated from

> You can call us on: 
• Monday to Friday, 8am to 8pm

to

> You can call us Monday to Friday, 8am to 8pm


The decision to proceed like this is because it's fairly urgent that the content is updated asap as users will no longer be able to get in touch with contact centre starting this weekend.


<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

Check that the opening hours have been updated on the webchat and phone contact options on the triage page. 