### PR TITLE
OLH-1798 - Check the stub is validating the right things

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -185,8 +185,8 @@ async function createApp(): Promise<express.Application> {
   if (supportChangeMfa()) {
     app.use(addMfaMethodRouter);
     app.use(addMfaMethodAppRouter);
-    app.use(changeAuthenticatorAppRouter);
   }
+  app.use(changeAuthenticatorAppRouter);
   app.use(trackAndRedirectRouter);
 
   // Router for all previously used URLs, that we want to redirect on

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -132,6 +132,14 @@ var cookies = function () {
         "delete account",
         "end"
       ),
+      "/change-authenticator-app": generateJourneySession(
+        "change authenticator app",
+        "middle"
+      ),
+      "/authenticator-app-updated-confirmation": generateJourneySession(
+        "change authenticator app",
+        "end"
+      ),
     };
 
     return JOURNEY_DATA_LAYER_PATHS[url];

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -112,7 +112,6 @@ describe("change authenticator app controller", () => {
           mfaIdentifier: 2,
           priorityIdentifier: "SECONDARY",
           mfaMethodType: "AUTH_APP",
-          endPoint: "",
           methodVerified: true,
         },
       ];
@@ -155,7 +154,6 @@ describe("change authenticator app controller", () => {
           mfaIdentifier: 2,
           priorityIdentifier: "SECONDARY",
           mfaMethodType: "AUTH_APP",
-          endPoint: "",
           methodVerified: true,
         },
       ];

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
@@ -1,0 +1,148 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import * as cheerio from "cheerio";
+import decache from "decache";
+import { PATH_DATA } from "../../../app.constants";
+import { UnsecuredJWT } from "jose";
+import { checkFailedCSRFValidationBehaviour } from "../../../../test/utils/behaviours";
+import { CLIENT_SESSION_ID, SESSION_ID } from "../../../../test/utils/builders";
+import * as mfaModule from "../../../utils/mfa";
+
+describe("Integration:: change authenticator app", () => {
+  let sandbox: sinon.SinonSandbox;
+  let token: string | string[];
+  let cookies: string;
+  let app: any;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/requires-auth-middleware");
+    const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
+    sandbox = sinon.createSandbox();
+    sandbox
+      .stub(sessionMiddleware, "requiresAuthMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        req.session.user = {
+          email: "test@test.com",
+          state: {
+            changeAuthenticatorApp: {
+              value: "CHANGE_VALUE",
+              events: ["VALUE_UPDATED", "CONFIRMATION"],
+            },
+          },
+          isAuthenticated: true,
+          tokens: {
+            accessToken: new UnsecuredJWT({})
+              .setIssuedAt()
+              .setSubject("12345")
+              .setIssuer("urn:example:issuer")
+              .setAudience("urn:example:audience")
+              .setExpirationTime("2h")
+              .encode(),
+            idToken: "Idtoken",
+            refreshToken: "token",
+          },
+        };
+        req.body = {
+          code: "qrcode",
+          authAppSecret: "A".repeat(20),
+        };
+
+        (req.session.mfaMethods = [
+          {
+            mfaIdentifier: 111111,
+            methodVerified: true,
+            endPoint: "PHONE",
+            mfaMethodType: "SMS",
+            priorityIdentifier: "PRIMARY",
+          },
+          {
+            mfaIdentifier: 2,
+            priorityIdentifier: "SECONDARY",
+            mfaMethodType: "AUTH_APP",
+            methodVerified: true,
+          },
+        ]),
+          next();
+      });
+
+    const oidc = require("../../../utils/oidc");
+    sandbox.stub(oidc, "getOIDCClient").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
+    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    });
+
+    sandbox.replace(mfaModule, "generateMfaSecret", () => "A".repeat(20));
+    sandbox.replace(mfaModule, "generateQRCodeValue", () => "qrcode");
+
+    app = await require("../../../app").createApp();
+
+    const configFuncs = require("../../../config");
+
+    sandbox.stub(configFuncs, "getMfaServiceUrl").callsFake(() => {
+      return "https://method-management-v1-stub.home.build.account.gov.uk";
+    });
+    sandbox.stub(configFuncs, "supportChangeMfa").callsFake(() => {
+      return true;
+    });
+    sandbox.stub(configFuncs, "supportMfaPage").callsFake(() => {
+      return true;
+    });
+
+    await request(app)
+      .get(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
+      .then((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"].concat(
+          `gs=${SESSION_ID}.${CLIENT_SESSION_ID}`
+        );
+      });
+  });
+
+  beforeEach(() => {});
+
+  after(() => {
+    sandbox.restore();
+    app = undefined;
+  });
+
+  it("should return change authenticator app page", (done) => {
+    request(app).get(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url).expect(200, done);
+  });
+
+  it("should redirect to your services when csrf not present", async () => {
+    await checkFailedCSRFValidationBehaviour(
+      app,
+      PATH_DATA.CHANGE_AUTHENTICATOR_APP.url,
+      {
+        code: "123456",
+      }
+    );
+  });
+
+  it("should redirect to /update confirmation when valid code entered", () => {
+    sandbox.replace(mfaModule, "verifyMfaCode", () => true);
+
+    // Act
+    request(app)
+      .post(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "111111",
+        authAppSecret: "qwer42312345342",
+      })
+      .expect("Location", PATH_DATA.AUTHENTICATOR_APP_UPDATED_CONFIRMATION.url)
+      .expect(302);
+  });
+});

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -32,7 +32,6 @@ export function checkYourPhonePost(
 
     const updateInput: UpdateInformationInput = {
       email,
-      updatedValue: newPhoneNumber,
       otp: req.body["code"],
     };
 
@@ -44,6 +43,7 @@ export function checkYourPhonePost(
         (mfa) => mfa.mfaMethodType === "SMS"
       );
       if (smsMFAMethod) {
+        smsMFAMethod.endPoint = newPhoneNumber;
         updateInput.mfaMethod = smsMFAMethod;
         isPhoneNumberUpdated = await service.updatePhoneNumberWithMfaApi(
           updateInput,

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -104,10 +104,23 @@ describe("check your phone controller", () => {
 
       req.session.user.tokens = { accessToken: "token" } as any;
       req.body.code = "123456";
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
 
       await checkYourPhonePost(fakeService)(req as Request, res as Response);
 
       expect(fakeService.updatePhoneNumberWithMfaApi).to.have.been.calledOnce;
+      expect(fakeService.updatePhoneNumberWithMfaApi).to.have.calledWith({
+        email: "test@test.com",
+        otp: "123456",
+        mfaMethod: {
+          mfaIdentifier: 111111,
+          methodVerified: true,
+          endPoint: "07111111111",
+          mfaMethodType: "SMS",
+          priorityIdentifier: "PRIMARY",
+        },
+      });
       expect(res.redirect).to.have.calledWith(
         PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url
       );

--- a/src/components/common/mfa/index.ts
+++ b/src/components/common/mfa/index.ts
@@ -4,10 +4,7 @@ import assert from "node:assert";
 import { generateMfaSecret, generateQRCodeValue } from "../../../utils/mfa";
 import QRCode from "qrcode";
 import { splitSecretKeyIntoFragments } from "../../../utils/strings";
-import {
-  UpdateInformationInput,
-  UpdateInformationSessionValues,
-} from "../../../utils/types";
+import { UpdateInformationSessionValues } from "../../../utils/types";
 import xss from "xss";
 import { getTxmaHeader } from "../../../utils/txma-header";
 
@@ -61,17 +58,4 @@ export async function generateSessionDetails(
     txmaAuditEncoded: getTxmaHeader(req, res.locals.trace),
   };
   return sessionDetails;
-}
-
-export async function generateUpdateInformationInput(
-  email: string,
-  updatedValue: any,
-  otp: any
-): Promise<UpdateInformationInput> {
-  const updateInput: UpdateInformationInput = {
-    email,
-    updatedValue: updatedValue,
-    otp: otp,
-  };
-  return updateInput;
 }

--- a/src/utils/mfa/index.ts
+++ b/src/utils/mfa/index.ts
@@ -229,6 +229,12 @@ export async function updateMfaMethod(
 
     if (response.status === HTTP_STATUS_CODES.OK) {
       isUpdated = true;
+    } else {
+      errorHandler(
+        new Error("MFA Method Not Found"),
+        sessionDetails.sessionId,
+        "update"
+      );
     }
   } catch (err) {
     errorHandler(err, sessionDetails.sessionId, "update");

--- a/src/utils/mfa/types.d.ts
+++ b/src/utils/mfa/types.d.ts
@@ -5,7 +5,7 @@ export interface MfaMethod {
   mfaIdentifier: number;
   priorityIdentifier: PriorityIdentifier;
   mfaMethodType: MfaMethodType;
-  endPoint: string;
+  endPoint?: string;
   methodVerified: boolean;
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -109,7 +109,7 @@ export interface Error {
 
 export interface UpdateInformationInput {
   email: string;
-  updatedValue: string;
+  updatedValue?: string;
   otp: string;
   mfaMethod?: MfaMethod;
 }


### PR DESCRIPTION
## Proposed changes
OLH-1798 - Check the stub is validating the right things

### What changed
Update the change SMS mfa method to call as per agreed validations where 

- Endpoint field - empty when updating AUTH_APP mfa method and for SMS, it will be the phone number

- credential field - empty when updating SMS mfa method and for AUTH_APP, it will be the secret

### Why did it change

So that calling services can adhere to the method management api specification and validation rules.

### Related links

https://govukverify.atlassian.net/browse/OLH-1798

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

## Testing

Deploy to dev and confirm changing sms auth method works to completion.


## How to review
