### PR TITLE
OLH-1844 - Enable GA4 in staging.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -227,7 +227,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "GTM-TK92W68"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-KD86CMZ"
-      GA4DISABLED: "true"
+      GA4DISABLED: "false"
       UADISABLED: "false"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"


### PR DESCRIPTION
## Proposed changes
OLH-1844 - Enable GA4 in staging.
### What changed

What: Enable GA4 in staging

Why: So that performance analysts can test report suspicious activity pages with GA4

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links


## Checklists

### Environment variables or secrets
- Set GA4DISABLED to false

## Testing

## How to review
