### PR TITLE
OLH-1835: update phone/webchat opening hours (again)

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -42,7 +42,6 @@
 
 {% set phoneBlock %}
   {% set phoneParagraphs1 = 'pages.contact.section3.phone.paragraphs' | translate({ returnObjects: true }) %}
-  {% set phoneParagraphs2 = 'pages.contact.section3.phone.paragraphs2' | translate({ returnObjects: true }) %}
   {% set insetTextHtml %}
     {% set insetTextParagraphs =  'pages.contact.section3.phone.insetText.paragraphs' | translate({ returnObjects: true }) %}
     {% for paragraph in insetTextParagraphs %}
@@ -70,12 +69,8 @@
     }) }}
 
     <p class="govuk-body">{{'pages.contact.section3.phone.paragraph2' | translate }}</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>{{'pages.contact.section3.phone.openingHours' | translate }}</li>
-    </ul>
-    <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/call-charges">{{'pages.contact.section3.phone.callChargesLinkText' | translate }}</a></p>
 
-    <p class="govuk-body"></p>
+    <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/call-charges">{{'pages.contact.section3.phone.callChargesLinkText' | translate }}</a></p>
   </section>
 {% endset %}
 
@@ -123,16 +118,12 @@
       <section>
         {% set webchatParagraphs =  'pages.contact.section3.webchat.paragraphs1' | translate({ returnObjects: true }) %}
 
-        <h3 class="govuk-heading-m">{{'pages.contact.section3.webchat.heading' | translate}}</h3>
+        <h3 class="govuk-heading-m">{{'pages.contact.section3.webchat.heading' | translate }}</h3>
 
         {% for paragraph in webchatParagraphs %}
-          <p class="govuk-body">{{ paragraph | safe  }}</p>
+          <p class="govuk-body">{{ paragraph }}</p>
         {% endfor %}
 
-        <ul class="govuk-list govuk-list--bullet">
-          <li>{{'pages.contact.section3.webchat.openingHours' | translate }}</li>
-        </ul>
-        <p class="govuk-body">{{'pages.contact.section3.webchat.paragraph2' | translate}}</p>
         <p class="govuk-body"><button type="button" class="launch-webchat-link" data-launch-webchat hidden>{{ 'pages.contact.section3.webchat.linkText' | translate }}</button></p>
 
         {% set accessibilityTextHtml %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -518,10 +518,9 @@
           "paragraphs1": [
             "Cael help gan gynorthwyydd digidol GOV.UK One Login neu sgwrs gydag ymgynghorydd.",
             "Efallai y gofynnir i chi am eich cod cyfeirio pan fyddwch yn siarad â ni.",
-            "Gallwch sgwrsio'n fyw gyda chynghorydd ar:"
+            "Gallwch sgwrsio'n fyw gydag ymgynghorydd o ddydd Llun i ddydd Gwener, 8am i 8pm.",
+            "Mae'r cynorthwyydd digidol bob amser ar gael."
           ],
-          "openingHours": "Dydd Llun i ddydd Gwener, 8am i 8pm",
-          "paragraph2": "Mae'r cynorthwyydd digidol bob amser ar gael",
           "linkText": "Defnyddio gwesgwrs",
           "accessibility-statement": {
             "insetText": {
@@ -542,8 +541,7 @@
               "Y tu allan i'r DU:<br><strong>+44 208 629 0008</strong>"
             ]
           },
-          "paragraph2": "You can call us on:",
-          "openingHours": "Dydd Llun i ddydd Gwener, 8am i 8pm",
+          "paragraph2": "Gallwch ein ffonio o ddydd Llun i ddydd Gwener, 8am i 8pm.",
           "callChargesLinkText": "Darganfyddwch fwy am gostau galwadau",
           "waitingTimeWarning": "Mae amseroedd aros hir ar y ffôn ar hyn o bryd. Os nad yw'ch galwad yn un brys, rhowch gynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">cwblhewch y ffurflen gyswllt</a>."
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -616,10 +616,9 @@
           "paragraphs1": [
             "Get help from GOV.UK One Login’s digital assistant or chat with an advisor.",
             "You might be asked for your reference code when you chat to us.",
-            "You can chat live with an advisor on:"
+            "You can chat live with an advisor Monday to Friday, 8am to 8pm.",
+            "The digital assistant is always available."
           ],
-          "openingHours": "Monday to Friday, 8am to 8pm",
-          "paragraph2": "The digital assistant is always available.",
           "linkText": "Use webchat",
           "accessibility-statement": {
             "insetText": {
@@ -638,8 +637,7 @@
               "<strong>Outside the UK:</strong><br>+44 208 629 0008"
             ]
           },
-          "paragraph2": "You can call us on:",
-          "openingHours": "Monday to Friday, 8am to 8pm",
+          "paragraph2": "You can call us Monday to Friday, 8am to 8pm.",
           "callChargesLinkText": "Find out about call charges",
           "waitingTimeWarning": "There are currently long waiting times on the phone. If your call is not urgent, try again later or <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">fill in the contact form</a>."
         },


### PR DESCRIPTION
## Proposed changes

Change opening hours for phone and webchat from a bullet list format to a paragraph format.

The option to contact the contact centre on the weekend [has been removed](https://github.com/govuk-one-login/di-account-management-frontend/pull/1397). 
We have now received the Welsh translations so the content can be re-formatted as a sentence.

Also, remove random empty `<p>` tag.
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### Related links
https://govukverify.atlassian.net/browse/OLH-1835
https://github.com/govuk-one-login/di-account-management-frontend/pull/1397 

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review
Test the contact page in English and Welsh, checking that the content matches the content from the [JIRA ticket](https://govukverify.atlassian.net/browse/OLH-1835) (Welsh translations sheet in the comments)

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
