### PR TITLE
OLH-1883 - Point integration webchat to their prod env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -246,7 +246,7 @@ Mappings:
       SERVICEDOMAIN: "integration.account.gov.uk"
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "1"
-      WEBCHATSOURCEURL: "https://uat-chat-loader.smartagent.app"
+      WEBCHATSOURCEURL: "https://chat-loader.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"


### PR DESCRIPTION
## Proposed changes
OLH-1883 - Point integration webchat to their prod env

### What changed
template.yml WEBCHATSOURCEURL for integration now points to: https://chat-loader.smartagent.app


### Why did it change

Support testing their live environment in our integration env

### Related links

[<!-- List any related PRs -->](https://govukverify.atlassian.net/browse/OLH-1883)

## Checklists

### Environment variables or secrets
template.yml WEBCHATSOURCEURL for integration now points to: https://chat-loader.smartagent.app

## Testing
Once deployed, check integration env is loading live webchat

## How to review
