### PR TITLE
OLH-1875 - Update webchat accessibility wording

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -525,7 +525,7 @@
           "accessibility-statement": {
             "insetText": {
               "paragraphs": [
-                "Darllenwch ein <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=cy\">datganiad hygyrchedd</a> i gael gwybod am broblemau hygyrchedd hysbys gyda'n gwesgwrs. "
+                "Nid yw ein gwe-sgwrs yn gwbl hygyrch eto - rydym yn gweithio i’w wella. Gallwch ddarganfod <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=cy\">mwy am y cyfyngiadau a sut rydym yn eu cywiro.</a>"
               ]
             }
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -618,7 +618,7 @@
           "accessibility-statement": {
             "insetText": {
               "paragraphs": [
-                "Read our <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=en\">accessibility statement</a> to find out about known accessibility problems with our webchat."
+                "Our webchat is not fully accessible yet - we’re working to improve it. You can find out <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=en\">more about the limitations and how we’re fixing them.</a>"
               ]
             }
           }


### PR DESCRIPTION
## Proposed changes
OLH-1875 - Update webchat accessibility wording

### What changed

Translation files to change webchat wording for english and welsh.

### Why did it change

Align with latest from central UCD team

### Related links
https://govukverify.atlassian.net/browse/OLH-1875

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed


## Testing

Deploy to dev and confirm works as expected for welsh and english.

## How to review
