### PR TITLE
OLH-1875 - Update webchat accessibility copy to include link to ancho…

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -525,7 +525,7 @@
           "accessibility-statement": {
             "insetText": {
               "paragraphs": [
-                "Nid yw ein gwe-sgwrs yn gwbl hygyrch eto - rydym yn gweithio i’w wella. Gallwch ddarganfod <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=cy\">mwy am y cyfyngiadau a sut rydym yn eu cywiro.</a>"
+                "Nid yw ein gwe-sgwrs yn gwbl hygyrch eto - rydym yn gweithio i’w wella. Gallwch ddarganfod <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=cy#webchat-accessibility\">mwy am y cyfyngiadau a sut rydym yn eu cywiro.</a>"
               ]
             }
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -618,7 +618,7 @@
           "accessibility-statement": {
             "insetText": {
               "paragraphs": [
-                "Our webchat is not fully accessible yet - we’re working to improve it. You can find out <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=en\">more about the limitations and how we’re fixing them.</a>"
+                "Our webchat is not fully accessible yet - we’re working to improve it. You can find out <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=en#webchat-accessibility\">more about the limitations and how we’re fixing them.</a>"
               ]
             }
           }


### PR DESCRIPTION

## Proposed changes
OLH-1875 - Update webchat accessibility wording - This adds the missing anchor link

### What changed
Add missing anchor to the link

### Why did it change

To ensure when accessibility link is selected, it pans to the correct section.

### Related links

https://govukverify.atlassian.net/browse/OLH-1875

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed


## Testing

Deploy to dev and test

## How to review

