### PR TITLE
OLH-1874 Turn on GA4 in production.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -262,7 +262,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "TBD"
       GOOGLEANALYTICS4GTMCONTAINERID: "TBD"
-      GA4DISABLED: "true"
+      GA4DISABLED: "false"
       UADISABLED: "true"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"
@@ -294,7 +294,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "GTM-TT5HDKV"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-K4PBJH3"
-      GA4DISABLED: "true"
+      GA4DISABLED: "false"
       UADISABLED: "false"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -262,7 +262,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "TBD"
       GOOGLEANALYTICS4GTMCONTAINERID: "TBD"
-      GA4DISABLED: "false"
+      GA4DISABLED: "true"
       UADISABLED: "true"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"


### PR DESCRIPTION
## Proposed changes
OLH-1874 Turn on GA4 in production.

### What changed

Enable GA4 in prod

### Why did it change

GA4 is planned for Go Live tomorrow morning 10am

### Related links

https://govukverify.atlassian.net/browse/OLH-1874

## Checklists


### Environment variables or secrets
Changed the flag GA4_DISABLED to false.


## Testing
Replicate same config in dev and check the GA4 is being shown.

## How to review

