### PR TITLE
OLH-1717 Set nvmrc version based on Dockerfile

### DIFF
--- a/.github/workflows/update-dependabot-nvmrc.yml
+++ b/.github/workflows/update-dependabot-nvmrc.yml
@@ -1,0 +1,53 @@
+name: Update Dependabot PRs
+
+on:
+  pull_request:
+    branches:
+      - 'dependabot/docker/**'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4.1.7
+      - name: Set up git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Extract Node.js version from Dockerfile
+        id: extract_version
+        run: |
+          VERSION=$(grep -m 1 -oP 'FROM node:\K[0-9]+\.[0-9]+\.[0-9]+' Dockerfile)
+          VERSION=$(echo $VERSION | tr -d '\n\r')
+          echo "NODE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Read current .nvmrc version
+        id: read_nvmrc
+        run: |
+          if [ -f .nvmrc ]; then
+            CURRENT_VERSION=$(cat .nvmrc | tr -d '\n\r')
+            echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          else
+            echo "CURRENT_VERSION=" >> $GITHUB_ENV
+          fi
+
+      - name: Check if versions are different
+        id: check_diff
+        run: |
+          if [ "$NODE_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "Versions are the same. No update needed."
+            echo "create_pr=false" >> $GITHUB_ENV
+          else
+            echo "Versions are different. Update needed."
+            echo "create_pr=true" >> $GITHUB_ENV
+          fi
+
+      - name: Update .nvmrc if update is needed
+        if: env.create_pr == 'true'
+        run: |
+          echo "$NODE_VERSION" > .nvmrc
+          git add .nvmrc
+          git commit -m "Updated .nvmrc"
+          git push

--- a/.github/workflows/update-dependabot-nvmrc.yml
+++ b/.github/workflows/update-dependabot-nvmrc.yml
@@ -3,7 +3,7 @@ name: Update Dependabot PRs
 on:
   pull_request:
     branches:
-      - 'dependabot/docker/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed changes
[OLH-1717] Set nvmrc version based on Dockerfile

### What changed

Added a new workflow to run everytime dependabot updates the Dockerfile

### Why did it change

Since Dependabot only updates node versions in our Dockerfiles, it is easier to keep .nvmrc file up to date once dependabot creates a PR that updates node
The workflow would only update .nvmrc if both node versions are different, making it easier to maintain rather than having build environment variables in our dockerfile and github actions. (See previous PR)

### Related links

https://github.com/govuk-one-login/di-account-management-frontend/pull/1417

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->


## Testing

I have modified the Dockerfile on a separate draft PR and how checked the workflow updates the .nvmrc file and creates a new PR

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


[OLH-1717]: https://govukverify.atlassian.net/browse/OLH-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ