### PR TITLE
BAU: a11y statement inset text tweak

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -35,7 +35,7 @@
   {% endfor %}
 
   <p class="govuk-body contact-reference">
-    {{'pages.contact.refCodeBlock.refCode' | translate}}
+    {{ 'pages.contact.refCodeBlock.refCode' | translate }}
     <strong class="contact-reference__code">{{ referenceCode }}</strong>
   </p>
 {% endset %}
@@ -127,10 +127,7 @@
         <p class="govuk-body"><button type="button" class="launch-webchat-link" data-launch-webchat hidden>{{ 'pages.contact.section3.webchat.linkText' | translate }}</button></p>
 
         {% set accessibilityTextHtml %}
-          {% set insetTextParagraphs =  'pages.contact.section3.webchat.accessibility-statement.insetText.paragraphs'  | translate({ returnObjects: true }) %}
-          {% for paragraph in insetTextParagraphs %}
-            <p class="govuk-body">{{ paragraph | safe | replace('[accessibilityStatementLinkHref]', accessibilityStatementUrl )  }}</p>
-          {% endfor %}
+          <p class="govuk-body">{{ 'pages.contact.section3.webchat.accessibilityStatementParagraph' | translate | safe | replace('[accessibilityStatementLinkHref]', accessibilityStatementUrl )  }}</p>
         {% endset %}
 
         {{ govukInsetText({

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -522,13 +522,7 @@
             "Mae'r cynorthwyydd digidol bob amser ar gael."
           ],
           "linkText": "Defnyddio gwe-sgwrs",
-          "accessibility-statement": {
-            "insetText": {
-              "paragraphs": [
-                "Nid yw ein gwe-sgwrs yn gwbl hygyrch eto - rydym yn gweithio i’w wella. Gallwch ddarganfod <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=cy#webchat-accessibility\">mwy am y cyfyngiadau a sut rydym yn eu cywiro.</a>"
-              ]
-            }
-          }
+          "accessibilityStatementParagraph": "Nid yw ein gwe-sgwrs yn gwbl hygyrch eto — rydym yn gweithio i’w wella. Gallwch ddarganfod <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=cy#webchat-accessibility\">mwy am y cyfyngiadau a sut rydym yn eu cywiro</a>."
         },
         "phone": {
           "heading": "Ffôn",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -638,13 +638,7 @@
             "The digital assistant is always available."
           ],
           "linkText": "Use webchat",
-          "accessibility-statement": {
-            "insetText": {
-              "paragraphs": [
-                "Our webchat is not fully accessible yet - we’re working to improve it. You can find out <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=en#webchat-accessibility\">more about the limitations and how we’re fixing them.</a>"
-              ]
-            }
-          }
+          "accessibilityStatementParagraph": "Our webchat is not fully accessible yet — we’re working to improve it. You can find out <a class=\"govuk-link\" href=\"[accessibilityStatementLinkHref]?lng=en#webchat-accessibility\">more about the limitations and how we’re fixing them</a>."
         },
         "phone": {
           "heading": "Phone",


### PR DESCRIPTION
## Proposed changes

### What changed

Tweak the way the webchat accessibility statement paragraph is displayed on the contact triage page.

The inset text used to have several paragraphs which were stored as an array in the translation files. This has since been updated so there is one paragraph only, which means the current solution is a bit overengineered. 

Some additional small style updates: use em dash instead of a regular hyphen and move the full stop outside of the anchor tag. The differences are pretty subtle:

### Before

<img width="979" alt="Screenshot 2024-06-19 at 12 58 43" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/4cf47250-3cb2-4bde-b370-bc5e38716647">

### After

<img width="997" alt="Screenshot 2024-06-19 at 12 57 26" src="https://github.com/govuk-one-login/di-account-management-frontend/assets/7116819/4a1fd076-a7c2-4647-8d21-117d6972419c">




### Why did it change

There is no need to store the a11y statement related content as an array of paragraphs anymore (it is only one paragraph now). And em dash is technically the correct character for this use case. 

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
Tested that the content on the inset text displays as expected in the en and cy versions
<!-- Provide a summary of any manual testing you've done -->

## How to review
Verify the above
<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
