### PR TITLE
OLH-1828 - Upgrade the frontend to AWS SDK v3

### DIFF
--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -1,13 +1,11 @@
-import { Client, custom, generators, Issuer } from "openid-client";
+import { Issuer, Client, custom, generators } from "openid-client";
 import { OIDCConfig } from "../types";
 import memoize from "fast-memoize";
 import { ClientAssertionServiceInterface, KmsService } from "./types";
 import { kmsService } from "./kms";
 import base64url from "base64url";
-import { createRemoteJWKSet, decodeJwt } from "jose";
 import random = generators.random;
-
-const { toBase64 } = require("@aws-sdk/util-base64-browser");
+import { decodeJwt, createRemoteJWKSet } from "jose";
 
 custom.setHttpOptionsDefaults({
   timeout: 20000,
@@ -63,6 +61,7 @@ function clientAssertionGenerator(
       alg: "RS512",
       typ: "JWT",
     };
+
     const payload = {
       iss: clientId,
       sub: clientId,
@@ -83,12 +82,13 @@ function clientAssertionGenerator(
 
     const sig = await kms.sign(message);
 
+    const base64Signature = Buffer.from(sig.Signature).toString('base64');
     return (
       token_components.header +
       "." +
       token_components.payload +
       "." +
-      toBase64(sig.Signature.toString())
+      base64Signature
         .replace(/\+/g, "-")
         .replace(/\//g, "_")
         .replace(/=/g, "")

--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -82,16 +82,13 @@ function clientAssertionGenerator(
 
     const sig = await kms.sign(message);
 
-    const base64Signature = Buffer.from(sig.Signature).toString('base64');
+    const base64Signature = Buffer.from(sig.Signature).toString("base64");
     return (
       token_components.header +
       "." +
       token_components.payload +
       "." +
-      base64Signature
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=/g, "")
+      base64Signature.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
     );
   };
 


### PR DESCRIPTION
## Proposed changes
OLH-1828 - Upgrade the frontend to AWS SDK v3

### What changed
Removed aws-sdk 2.0 dependency from package.json and use modular implementations of the individual components we use in OLH. Also some code changes to align with new implementations


### Why did it change

AWS SDK Version 2.x has reached end of support.

### Related links
https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/welcome.html
https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating.html
https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/
https://aws.amazon.com/blogs/developer/why-and-how-you-should-use-aws-sdk-for-javascript-v3-on-node-js-18/

## Checklists

Thorough testing specifically in the areas of KMS, OIDC, S3 etc.

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed



## Testing

Deploy to dev and carry out an end to end test of all key functionalities

## How to review

Code completeness and  to detect breaking fixes