### PR TITLE
OLH-1868: Update wording around "security codes"

### DIFF
--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -114,7 +114,7 @@ describe("Integration:: check your email", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($("#code-error").text()).to.contains("Enter the code");
       })
       .expect(400);
   });
@@ -131,7 +131,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400);
@@ -149,7 +149,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400);
@@ -167,7 +167,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400);
@@ -219,7 +219,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
+          "The code you entered is not correct, or may have expired, try entering it again or request a new code."
         );
       })
       .expect(400);

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -146,7 +146,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($(testComponent("code-error")).text()).to.contains(
-          "Enter the security code"
+          "Enter the code"
         );
       })
       .expect(400);
@@ -164,7 +164,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($(testComponent("code-error")).text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400);
@@ -182,7 +182,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($(testComponent("code-error")).text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400);
@@ -200,7 +200,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($(testComponent("code-error")).text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400);

--- a/src/components/common/mfa/add-auth-app.njk
+++ b/src/components/common/mfa/add-auth-app.njk
@@ -12,7 +12,7 @@
   <h1 class="govuk-heading-xl">{{ 'pages.addMfaMethodApp.title' | translate }}</h1>
   <ol class="govuk-list">
     <li>
-      <p>{{ 'pages.addMfaMethodApp.step1.text' | translate }}</p>
+      <p class="govuk-body">{{ 'pages.addMfaMethodApp.step1.text' | translate }}</p>
       {% set detailsHtml %}
         {% set paragraphs =  "pages.addMfaMethodApp.step1.hintText" | translate({ returnObjects: true }) %}
           {% for paragraph in paragraphs %}
@@ -25,7 +25,7 @@
       })}}
     </li>
     <li>
-      <p>{{ 'pages.addMfaMethodApp.step2.text' | translate }}</p>
+      <p class="govuk-body">{{ 'pages.addMfaMethodApp.step2.text' | translate }}</p>
       <img id="qr-code" src="{{qrCode}}" alt="QR Code Image">
       {{ govukDetails({
           summaryText: "pages.addMfaMethodApp.step2.hintTitle" | translate,
@@ -33,20 +33,19 @@
       }) }}
     </li>
     <li>
-      {{ 'pages.addMfaMethodApp.step3.text' | translate }}
+      <p class="govuk-body">{{ 'pages.addMfaMethodApp.step3.text' | translate }}</p>
     </li>
     <li>
-      <p>{{ 'pages.addMfaMethodApp.step4.text' | translate }}</p>
       <form method="post" action="{{ formAction }}">
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
         <input type="hidden" name="authAppSecret" value="{{authAppSecret}}"/>
 
         {{ govukInput({
           label: {
-          text: 'pages.addMfaMethodApp.step4.label' | translate
+            text: 'pages.addMfaMethodApp.step4.text' | translate
           },
           hint: {
-              text: 'pages.addMfaMethodApp.step4.hint' | translate
+            text: 'pages.addMfaMethodApp.step4.hint' | translate
           },
           classes: "govuk-input--width-10 govuk-!-font-weight-bold",
           id: "code",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -369,13 +369,13 @@
         "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi i mewn yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god diogelwch newydd."
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd."
         }
       }
     },
@@ -391,13 +391,13 @@
         "text": "Gallwn <a class=\"govuk-link\" href=\"[resendCodeLink]\">anfon y cod eto</a> neu gallwch <a class=\"govuk-link\" href=\"[changePhoneNumberLink]\">ddefnyddio rhif ffôn gwahanol</a>."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi i mewn yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god diogelwch newydd."
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd."
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -243,15 +243,14 @@
         "text": "3. The authenticator app will show a security code."
       },
       "step4": {
-        "text": "4. Enter the security code.",
-        "label": "Security code",
+        "text": "4. Enter the code.",
         "hint": "This is the 6-digit code shown in your authenticator app"
       },
       "errors": {
-        "invalidCode": "The security code you entered is not correct. Try entering it again or wait for your authenticator app to give you a new code",
-        "required": "Enter the security code shown in your authenticator app",
-        "maxLength": "Enter the security code using only 6 digits",
-        "invalidFormat": "Enter the security code using only numbers"
+        "invalidCode": "The code you entered is not correct, check your authenticator app and try again",
+        "required": "Enter the code shown in your authenticator app",
+        "maxLength": "Enter the code using only 6 digits",
+        "invalidFormat": "Enter the code using only numbers"
       },
       "cancel": "Cancel and go back to Security"
     },
@@ -485,13 +484,13 @@
         "paragraph3": "The code will expire after 15 minutes."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code."
         }
       }
     },
@@ -507,13 +506,13 @@
         "text": "We can <a class=\"govuk-link\" href=\"[resendCodeLink]\">send the code again</a> or you can <a class=\"govuk-link\" href=\"[changePhoneNumberLink]\">use a different phone number</a>."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new security code."
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code."
         }
       }
     },


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

This update is to reflect Auth's content changes, removing the phrase "security code" from input field labels (and the error messages associated with them), and replacing it with simply "code".

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The reason behind this update is that some mobile browsers interpret input fields labelled "security code" as being credit card related, and therefore prompt users to enter their card security code which is obviously not correct.

<!-- Describe the reason these changes were made - the "why" -->

### Related links

https://govukverify.atlassian.net/browse/OLH-1868
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

A UCD check of the content updates has been done in the dev environment 

<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
