### PR TITLE
INCIDEN-834: Include new phone number in payload

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -34,6 +34,7 @@ export function checkYourPhonePost(
 
     const updateInput: UpdateInformationInput = {
       email,
+      updatedValue: newPhoneNumber,
       otp: req.body["code"],
     };
 

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -119,6 +119,7 @@ describe("check your phone controller", () => {
       expect(fakeService.updatePhoneNumberWithMfaApi).to.have.been.calledOnce;
       expect(fakeService.updatePhoneNumberWithMfaApi).to.have.calledWith({
         email: "test@test.com",
+        updatedValue: "07111111111",
         otp: "123456",
         mfaMethod: {
           mfaIdentifier: 111111,


### PR DESCRIPTION

## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Include new phone number in payload to calls to the Account Management API when a user is changing their phone number. 

### Why did it change

It looks like when we refactored this controller to switch between the new MFA method API or the old API based on the feature flag we set up a common type definition for both. In #1401 we removed the new phone number from the payload when we added new logic for the endpoint field, but this inadvertently also removed it for the old method which is still in use at the moment.

This means users cannot currently change their phone number. Add the new value back into the payload for all requests.

After this PR we'll need to remove this new field from the payload in the new-style API calls, but that can be done in a followup PR since it's not in use yet.

### Related links

#1401 

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
