### PR TITLE
OLH-1920 Resolve payloads between legacy & new API calls [MFA]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,4 @@
 
 ## How to review
 
-<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
+<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->

--- a/src/components/check-your-email/types.ts
+++ b/src/components/check-your-email/types.ts
@@ -9,3 +9,10 @@ export interface CheckYourEmailServiceInterface {
     sessionDetails: UpdateInformationSessionValues
   ) => Promise<boolean>;
 }
+
+export const INTENT_CHANGE_PHONE_NUMBER = "changePhoneNumber";
+export const INTENT_ADD_MFA_METHOD = "addMfaMethod";
+
+export type Intent =
+  | typeof INTENT_CHANGE_PHONE_NUMBER
+  | typeof INTENT_ADD_MFA_METHOD;

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -10,18 +10,26 @@ import {
 import { CheckYourPhoneServiceInterface } from "../types";
 import { PATH_DATA } from "../../../app.constants";
 import { TXMA_AUDIT_ENCODED } from "../../../../test/utils/builders";
+import {
+  INTENT_ADD_MFA_METHOD,
+  INTENT_CHANGE_PHONE_NUMBER,
+} from "../../check-your-email/types";
+import { logger } from "../../../utils/logger";
 
 describe("check your phone controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
+  let fakeService: CheckYourPhoneServiceInterface;
+  let errorLoggerSpy: sinon.SinonSpy;
 
   beforeEach(() => {
     delete process.env.SUPPORT_CHANGE_MFA;
     sandbox = sinon.createSandbox();
-
+    errorLoggerSpy = sinon.spy(logger, "error");
     req = {
       body: {},
+      t: sandbox.fake(),
       session: {
         user: { state: { changePhoneNumber: { value: "CHANGE_VALUE" } } },
         mfaMethods: [
@@ -39,17 +47,25 @@ describe("check your phone controller", () => {
       cookies: { lng: "en" },
       i18n: { language: "en" },
       headers: { "txma-audit-encoded": TXMA_AUDIT_ENCODED },
-      query: { intent: "changePhoneNumber" },
+      query: { intent: INTENT_CHANGE_PHONE_NUMBER },
     };
     res = {
       render: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
       status: sandbox.fake(),
-      locals: {},
+      locals: {
+        trace: "trace-id",
+      },
+    };
+    fakeService = {
+      updatePhoneNumber: sandbox.stub().resolves(true),
+      updatePhoneNumberWithMfaApi: sandbox.stub().resolves(true),
+      addMfaMethodService: sandbox.stub().resolves(true),
     };
   });
 
   afterEach(() => {
+    errorLoggerSpy.restore();
     sandbox.restore();
   });
 
@@ -63,12 +79,6 @@ describe("check your phone controller", () => {
 
   describe("checkYourPhonePost", () => {
     it("should redirect to /phone-number-updated-confirmation when valid code entered", async () => {
-      const fakeService: CheckYourPhoneServiceInterface = {
-        updatePhoneNumber: sandbox.fake.resolves(true),
-        updatePhoneNumberWithMfaApi: sandbox.fake.resolves(true),
-        addMfaMethodService: sandbox.fake.resolves(true),
-      };
-
       req.session.user.tokens = { accessToken: "token" } as any;
       req.body.code = "123456";
       req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
@@ -82,7 +92,7 @@ describe("check your phone controller", () => {
     });
 
     it("should return error when invalid code entered", async () => {
-      const fakeService: CheckYourPhoneServiceInterface = {
+      fakeService = {
         updatePhoneNumber: sandbox.fake.resolves(false),
         updatePhoneNumberWithMfaApi: sandbox.fake.resolves(false),
         addMfaMethodService: sandbox.fake.resolves(false),
@@ -98,21 +108,59 @@ describe("check your phone controller", () => {
       expect(fakeService.updatePhoneNumber).to.have.been.calledOnce;
       expect(res.render).to.have.been.calledWith("check-your-phone/index.njk");
     });
-  });
 
-  describe("checkYourPhonePost with mfa method management API", () => {
-    it("should redirect to /phone-number-updated-confirmation when valid code entered", async () => {
+    it("should log an error when MFA method is invalid", async () => {
       process.env.SUPPORT_CHANGE_MFA = "1";
-      const fakeService: CheckYourPhoneServiceInterface = {
-        updatePhoneNumber: sandbox.fake.resolves(true),
-        updatePhoneNumberWithMfaApi: sandbox.fake.resolves(true),
-        addMfaMethodService: sandbox.fake.resolves(true),
-      };
 
       req.session.user.tokens = { accessToken: "token" } as any;
       req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
       req.body.code = "123456";
-      req.body.intent = "changePhoneNumber";
+      req.body.intent = INTENT_CHANGE_PHONE_NUMBER;
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
+      req.session.mfaMethods[0].method.mfaMethodType = "UNKNOWN" as any;
+      const errorMessage = "No existing MFA method in handleChangePhoneNumber";
+      try {
+        await checkYourPhonePost(fakeService)(req as Request, res as Response);
+      } catch (e) {
+        expect(errorLoggerSpy).to.have.been.calledWith(errorMessage);
+      }
+    });
+
+    it("should redirect to /phone-number-updated-confirmation when valid code entered for legacy API", async () => {
+      process.env.SUPPORT_CHANGE_MFA = "0";
+
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
+      req.body.code = "123456";
+      req.body.intent = INTENT_CHANGE_PHONE_NUMBER;
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
+
+      await checkYourPhonePost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.updatePhoneNumberWithMfaApi).not.to.have.been.called;
+      expect(fakeService.updatePhoneNumber).to.have.been.calledOnce;
+      expect(fakeService.updatePhoneNumber).to.have.calledWith({
+        email: "test@test.com",
+        updatedValue: "07111111111",
+        otp: "123456",
+      });
+      expect(res.redirect).to.have.calledWith(
+        PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url
+      );
+      delete process.env.SUPPORT_CHANGE_MFA;
+    });
+  });
+
+  describe("checkYourPhonePost with mfa method management API", () => {
+    it("should redirect to /phone-number-updated-confirmation when valid code entered for change phone number journey", async () => {
+      process.env.SUPPORT_CHANGE_MFA = "1";
+
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
+      req.body.code = "123456";
+      req.body.intent = INTENT_CHANGE_PHONE_NUMBER;
       req.session.user.newPhoneNumber = "07111111111";
       req.session.user.email = "test@test.com";
 
@@ -121,7 +169,6 @@ describe("check your phone controller", () => {
       expect(fakeService.updatePhoneNumberWithMfaApi).to.have.been.calledOnce;
       expect(fakeService.updatePhoneNumberWithMfaApi).to.have.calledWith({
         email: "test@test.com",
-        updatedValue: "07111111111",
         otp: "123456",
         mfaMethod: {
           mfaIdentifier: 111111,
@@ -136,6 +183,116 @@ describe("check your phone controller", () => {
       expect(res.redirect).to.have.calledWith(
         PATH_DATA.PHONE_NUMBER_UPDATED_CONFIRMATION.url
       );
+      delete process.env.SUPPORT_CHANGE_MFA;
+    });
+
+    it("should redirect to /phone-number-updated-confirmation when valid code entered for add MFA method journey", async () => {
+      process.env.SUPPORT_CHANGE_MFA = "1";
+
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
+      req.body.code = "123456";
+      req.body.intent = INTENT_ADD_MFA_METHOD;
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
+
+      await checkYourPhonePost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.addMfaMethodService).to.have.been.calledOnce;
+      expect(fakeService.addMfaMethodService).to.have.calledWith({
+        email: "test@test.com",
+        otp: "123456",
+        credential: "no-credentials",
+        mfaMethod: {
+          mfaIdentifier: 111112,
+          methodVerified: true,
+          method: {
+            endPoint: "07111111111",
+            mfaMethodType: "AUTH_APP",
+          },
+          priorityIdentifier: "BACKUP",
+        },
+      });
+      expect(res.redirect).to.have.calledWith(
+        PATH_DATA.ADD_MFA_METHOD_SMS_CONFIRMATION.url
+      );
+      delete process.env.SUPPORT_CHANGE_MFA;
+    });
+
+    it("should log an error when priorityIdentifier is not valid", async () => {
+      process.env.SUPPORT_CHANGE_MFA = "1";
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
+      req.body.code = "123456";
+      req.body.intent = INTENT_ADD_MFA_METHOD;
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
+      req.session.mfaMethods[0].priorityIdentifier =
+        "INVALID-PRIORITY-IDENTIFIER" as any;
+
+      const errorMessage =
+        "No existing DEFAULT MFA method in handleAddMfaMethod";
+      (fakeService.updatePhoneNumber as sinon.SinonStub).throws(
+        new Error(errorMessage)
+      );
+
+      try {
+        await checkYourPhonePost(fakeService)(req as Request, res as Response);
+        expect(fakeService.updatePhoneNumber).not.to.have.been.called;
+        expect(fakeService.updatePhoneNumberWithMfaApi).not.to.have.been.called;
+        expect(fakeService.addMfaMethodService).not.to.have.been.called;
+      } catch (e) {
+        expect(errorLoggerSpy).to.have.been.calledWith(errorMessage);
+      }
+      delete process.env.SUPPORT_CHANGE_MFA;
+    });
+
+    it("should log an error when intent is not valid", async () => {
+      process.env.SUPPORT_CHANGE_MFA = "1";
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
+      req.body.code = "123456";
+      req.body.intent = "invalid-intent";
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
+
+      const errorMessage = "Unknown phone verification intent invalid-intent";
+      (fakeService.updatePhoneNumber as sinon.SinonStub).throws(
+        new Error(errorMessage)
+      );
+
+      try {
+        await checkYourPhonePost(fakeService)(req as Request, res as Response);
+        expect(fakeService.updatePhoneNumber).not.to.have.been.called;
+        expect(fakeService.updatePhoneNumberWithMfaApi).not.to.have.been.called;
+        expect(fakeService.addMfaMethodService).not.to.have.been.called;
+      } catch (e) {
+        expect(errorLoggerSpy).to.have.been.calledWith(errorMessage);
+      }
+      delete process.env.SUPPORT_CHANGE_MFA;
+    });
+
+    it("should log an error when addMfaMethodService fails", async () => {
+      process.env.SUPPORT_CHANGE_MFA = "1";
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";
+      req.body.code = "123456";
+      req.body.intent = INTENT_ADD_MFA_METHOD;
+      req.session.user.newPhoneNumber = "07111111111";
+      req.session.user.email = "test@test.com";
+
+      const errorMessage = "error message";
+      (fakeService.addMfaMethodService as sinon.SinonStub).throws(
+        new Error(errorMessage)
+      );
+
+      try {
+        await checkYourPhonePost(fakeService)(req as Request, res as Response);
+        expect(fakeService.updatePhoneNumber).not.to.have.been.called;
+        expect(fakeService.updatePhoneNumberWithMfaApi).not.to.have.been.called;
+      } catch (e) {
+        expect(errorLoggerSpy).to.have.been.calledWith(errorMessage);
+      }
       delete process.env.SUPPORT_CHANGE_MFA;
     });
   });

--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -43,7 +43,7 @@
       }
     }
 ]} %}
-{% 
+{%
 set mfaSummaryList = {
   classes:"govuk-summary-list--security",
   attributes: {"data-test-id": "mfa-summary-list"},
@@ -71,10 +71,10 @@ set mfaSummaryList = {
           {% if mfaMethods | length > 0 %}
             {% set foundPrimary = false %}
             {% set foundSecondary = false %}
-            {% for method in mfaMethods %} 
+            {% for method in mfaMethods %}
               {% if (method.priorityIdentifier == "DEFAULT") and not foundPrimary %}
                 {# display existing primary method with options to change the method or use a different type #}
-                <div class="summary-list-container__content">
+                <div class="summary-list-container__content" data-test-id="mfa-summary-list">
                   <h2 class="govuk-heading-s">{{'pages.security.mfaSection.supportChangeMfa.defaultMethod.heading' | translate }}</h2>
                   <p class="govuk-body">{{ method.text }}</p>
                   <p class="govuk-body"><a href="{{ method.linkHref }}" class="govuk-link"> {{ method.linkText }}</a></p>
@@ -90,7 +90,7 @@ set mfaSummaryList = {
               {# backup mfa block has two states #}
               <div class="summary-list-container__content">
                 <h3 class='govuk-heading-s'>{{ 'pages.security.mfaSection.supportChangeMfa.backup.heading' | translate }}</h3>
-                {% for method in mfaMethods %} 
+                {% for method in mfaMethods %}
                   {% if (method.priorityIdentifier == "BACKUP") and not foundSecondary %}
                     {# 1: backup method exists => display backup method block with options to change backup method or switch primary and backup #}
                     <p class="govuk-body">{{ method.text }}</p>


### PR DESCRIPTION
## Proposed changes
[OLH-1920]

### What changed

Add additional check to handle both legacy and MFA API calls

### Why did it change

To address what was fixed in https://github.com/govuk-one-login/di-account-management-frontend/pull/1481

### Related links

https://github.com/govuk-one-login/di-account-management-frontend/pull/1481

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed


## Testing

Unit tests

## How to review

Is easier to review by commits. The first one has the original code, the last one is a code refactor.


[OLH-1920]: https://govukverify.atlassian.net/browse/OLH-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ