### PR TITLE
BAU: Update our alarm targets to use the new topic 

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,7 +59,7 @@ Parameters:
   AlertingStackName:
     Description: The name of the stack that defines the Alerting resources
     Type: String
-    Default: platform-alerting
+    Default: build-notifications
   BackendStackName:
     Description: The name of the backend stack
     Type: String
@@ -1862,7 +1862,8 @@ Resources:
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
       ActionsEnabled: false
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
@@ -1911,7 +1912,8 @@ Resources:
       AlarmDescription: "Activate when 5 5xx events detected in the last 24 hours.  The Alarm will be raised within 300 seconds of the 5xx being raised."
       ActionsEnabled: true
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 288
       DatapointsToAlarm: 288
@@ -1957,7 +1959,8 @@ Resources:
       AlarmDescription: "Trigger the alarm if response latency exceeds 2.5 seconds with the minimum of 10 invocations in 2 out of the last 5 minutes"
       ActionsEnabled: false
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 2

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -56,10 +56,6 @@ Parameters:
   VpcStackName:
     Description: The name of the stack that defines the VPC in which this container will run.
     Type: String
-  AlertingStackName:
-    Description: The name of the stack that defines the Alerting resources
-    Type: String
-    Default: build-notifications
   BackendStackName:
     Description: The name of the backend stack
     Type: String
@@ -1862,8 +1858,7 @@ Resources:
       AlarmDescription: "Trigger the alarm if errorThreshold exceeds 1% with the minimum of 10 invocations in 2 out of the last 5 minutes"
       ActionsEnabled: false
       AlarmActions:
-        - !ImportValue
-          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
@@ -1912,8 +1907,7 @@ Resources:
       AlarmDescription: "Activate when 5 5xx events detected in the last 24 hours.  The Alarm will be raised within 300 seconds of the 5xx being raised."
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue
-          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 288
       DatapointsToAlarm: 288
@@ -1959,8 +1953,7 @@ Resources:
       AlarmDescription: "Trigger the alarm if response latency exceeds 2.5 seconds with the minimum of 10 invocations in 2 out of the last 5 minutes"
       ActionsEnabled: false
       AlarmActions:
-        - !ImportValue
-          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 2


### PR DESCRIPTION
## Proposed changes

### What changed

Update our alarms to use the topic created by the new stack.

DO NOT MERGE this until all accounts have the new `build-notifications` stack set up.

### Why did it change

We've changed our alerting topic to use the dev platform's `build-notifications` stack instead of our own custom one. See also https://github.com/govuk-one-login/di-account-management-backend/pull/276

## Checklists
<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed


## Testing

I'll deploy this branch to dev once that's in a clean state with the new topic & stack. 