### PR TITLE
Remove pre deploy jobs from publish to Dev on frontend repo

### DIFF
--- a/.github/workflows/on-manual-publish-to-dev.yml
+++ b/.github/workflows/on-manual-publish-to-dev.yml
@@ -23,13 +23,6 @@ permissions:
   contents: read
 
 jobs:
-  validate_application:
-    name: Acceptance Checks
-    uses: ./.github/workflows/build-test-application.yml
-    secrets: inherit
-    with:
-      gitRef: ${{ inputs.gitRef }}
-
   validate_deployment:
     name: Deployment Template Checks
     uses: ./.github/workflows/validate-sam-template-dev.yml
@@ -42,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs:
-      - validate_application
       - validate_deployment
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
@@ -95,7 +87,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.DEV_ECR_REPOSITORY }}
         run: |
-          
+
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_REF_SHA .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_REF_SHA
 

--- a/.github/workflows/on-manual-publish-to-dev.yml
+++ b/.github/workflows/on-manual-publish-to-dev.yml
@@ -23,19 +23,10 @@ permissions:
   contents: read
 
 jobs:
-  validate_deployment:
-    name: Deployment Template Checks
-    uses: ./.github/workflows/validate-sam-template-dev.yml
-    secrets: inherit
-    with:
-      gitRef: ${{ inputs.gitRef }}
-
   publish_artifacts:
     name: "Publish Image & Template to Dev"
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs:
-      - validate_deployment
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:


### PR DESCRIPTION
## Proposed changes
[OLH-1952] Remove pre deploy job from publish to Dev on frontend repo

### What changed
Removal of validate application and validate deployment  from publish to dev workflow.

### Why did it change
Jobs run before merge to main and on pull request. Not necessary before deploying to dev and will save ~4 minutes of dev time.

## Checklists
### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
- I have run the publish to dev flow and validated it is still working.


[OLH-1952]: https://govukverify.atlassian.net/browse/OLH-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ