### PR TITLE
Olh 1953 set up canary deployments for the frontend deploy pipeline second stage

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -372,14 +372,10 @@ Resources:
           Subnets:
             - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
             - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
-      # TODO: Required due to 2 stage deployment of Canary Deployment, switch to step 2 after successful deployment and remove step 1.
-      # Step 1
-      TaskDefinition: !Ref TaskDefinition
-      # Step 2
-      # TaskDefinition: !If
-      #   - UseCanaryDeployment
-      #   - !Ref AWS::NoValue
-      #   - !Ref TaskDefinition
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref TaskDefinition
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-1953] Remove Task Definition for Canary Deployment  - Can only be deployed after OLH-1893.

### What changed
<!-- Describe the changes in detail - the "what"-->
Removed Task Definition when Canary Deployment is enabled. 

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Code Pipeline fails if Task Definition is present.

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing
<!-- Provide a summary of any manual testing you've done -->
- Deployed to Dev and validated works.

## How to review
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
On,y lines changewd compared to OLH 1893 is line 374-377.


[OLH-1953]: https://govukverify.atlassian.net/browse/OLH-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ