### PR TITLE
OLH-1895 - Set up the feature to skip canary deployments for the frontend

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -107,6 +107,18 @@ Parameters:
     Description: >
       The ARN of the Code Signing Config to use, provided by the deployment pipeline
     Default: "none"
+  DeploymentStrategy:
+    Description: "Predefined deployment configuration for ECS application"
+    Type: String
+    Default: "None"
+    # Allowed values: See https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html
+    AllowedValues:
+      - None
+      - CodeDeployDefault.ECSCanary10Percent5Minutes
+      - CodeDeployDefault.ECSCanary10Percent15Minutes
+      - CodeDeployDefault.ECSAllAtOnce
+      - CodeDeployDefault.ECSLinear10PercentEvery1Minutes
+      - CodeDeployDefault.ECSLinear10PercentEvery3Minutes
 
 Conditions:
   IsProduction: !Equals [!Ref Environment, production]


### PR DESCRIPTION
## Proposed changes
OLH-1895 - Set up the feature to skip canary deployments for the frontend

### What changed

As per: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3836051600/Rollback+Recovery+Guidance#Escape-Hatch%3A-how-to-skip-canary-deployments-when-needed

Config in on-merge.main.yml is already using latest commit sha for 1.3.0
Added config in template.yml, includes all the deployment configuration available as per AWS
Reference paremeter in the ecs canary deployment stack

### Why did it change
So we can skip canary deployment where required

### Related links
https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3836051600/Rollback+Recovery+Guidance#Escape-Hatch%3A-how-to-skip-canary-deployments-when-needed


## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed


## Testing

Test deploying with and without [skip canary], [canary skip], or [no canary]
## How to review
