### PR TITLE
OLH-1976: Add new guidance link on the triage page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -478,6 +478,10 @@
             "text": "Defnyddio'r ap GOV.UK ID Check app"
           },
           {
+            "href": "https://www.gov.uk/guidance/linking-the-govuk-id-check-app-to-govuk.cy",
+            "text": "Cysylltu'r ap GOV.UK  ID Check i GOV.UK"
+          },
+          {
             "href": "https://www.gov.uk/guidance/proving-your-identity-with-govuk-one-login-by-answering-security-questions.cy",
             "text": "Profi eich hunaniaeth gyda GOV.UK One Login drwy ateb cwestiynau diogelwch"
           },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -593,6 +593,10 @@
             "text": "Using the GOV.UK ID Check app"
           },
           {
+            "href": "https://www.gov.uk/guidance/linking-the-govuk-id-check-app-to-govuk",
+            "text": "Linking the GOV.UK ID Check app to GOV.UK"
+          },
+          {
             "href": "https://www.gov.uk/guidance/proving-your-identity-with-govuk-one-login-by-answering-security-questions",
             "text": "Proving your identity with GOV.UK One Login by answering security questions"
           },


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
New guidance has been published on linking the ID check app to GOV.UK.

We've received a request to add a link to this guidance on the contact triage page, following the "Using the GOV.UK ID Check app" link.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Help users to connect the app to the website if they need to prove their identity with GOV.UK One Login.


<!-- Describe the reason these changes were made - the "why" -->

### Related links
https://govukverify.atlassian.net/browse/OLH-1976
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing
Tested that the links work locally. Sent screen recording to Tom Hughes who confirmed that the update looks correct.
<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
