### PR TITLE
INCIDEN-867: Display auth app as read-only in prod

### DIFF
--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -43,13 +43,6 @@
       }
     }
 ]} %}
-{%
-set mfaSummaryList = {
-  classes:"govuk-summary-list--security",
-  attributes: {"data-test-id": "mfa-summary-list"},
-  rows: mfaMethods
-}
-%}
 
 {% block content %}
   <div class="govuk-grid-row" id="your-account">
@@ -120,8 +113,25 @@ set mfaSummaryList = {
             <p class="govuk-body">{{ 'pages.security.mfaSection.paragraph' | translate }}</p>
           </div>
           {% if mfaMethods | length > 0 %}
-            {{ govukSummaryList(mfaSummaryList) }}
+            {% for method in mfaMethods %}
+              {% if method.type == "SMS" %}
+                {%
+                  set mfaSummaryList = {
+                    classes:"govuk-summary-list--security",
+                    attributes: {"data-test-id": "mfa-summary-list"},
+                    rows: [method]
+                  }
+                %}
+                {{ govukSummaryList(mfaSummaryList)}}
+              {% elif method.type == "AUTH_APP" %}
+                <div class="summary-list-container__content">
+                  {# if mfa method management is not supported, the auth app method is READ ONLY #}
+                  <p class="govuk-body"><strong>{{ method.key.text }}</strong></p>
+                </div>
+              {% endif %}
+            {% endfor %}
           {% endif %}
+
         </div>
       {% endif %}
 

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -63,7 +63,6 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
           let key: string,
             value: string,
             actions = {};
-
           if (method.method.mfaMethodType === "SMS") {
             const phoneNumber = getLastNDigits(method.method.endPoint, 4);
             key = req.t(
@@ -86,20 +85,6 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
             };
           } else if (method.method.mfaMethodType === "AUTH_APP") {
             key = req.t("pages.security.mfaSection.summaryList.app.title");
-            value = req.t("pages.security.mfaSection.summaryList.app.value");
-
-            actions = {
-              items: [
-                {
-                  attributes: { "data-test-id": "change-authenticator-app" },
-                  href: `${PATH_DATA.ENTER_PASSWORD.url}?type=changeAuthenticatorApp`,
-                  text: req.t("general.change"),
-                  visuallyHiddenText: req.t(
-                    "pages.security.mfaSection.summaryList.app.hiddenText"
-                  ),
-                },
-              ],
-            };
           } else {
             throw new Error(
               `Unexpected mfaMethodType: ${method.method.mfaMethodType}`
@@ -107,6 +92,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
           }
 
           return {
+            type: method.method.mfaMethodType,
             classes: "govuk-summary-list__row--no-border",
             key: {
               text: key,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -147,9 +147,7 @@
             "hiddenText": "Phone number"
           },
           "app": {
-            "title": "Authenticator app",
-            "value": "Change authenticator app",
-            "hiddenText": "Authenticator app"
+            "title": "Authenticator app"
           }
         },
         "supportChangeMfa": {


### PR DESCRIPTION
# Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Display the authenticator app MFA method as read-only in prod (so when the `supportChangeMfa()` flag is off) as MFA method management is not supported yet.


<!-- Describe the changes in detail - the "what"-->

### Why did it change
A bug was discovered where we are accidentally displaying the option to change authenticator app in production. This is not good as changing authenticator app would not work yet. So when users would have tried to change their auth app to a different one, they would have seen an error.

| Before  | After |
| ------------- | ------------- |
| <img width="723" alt="Screenshot 2024-07-17 at 15 47 39" src="https://github.com/user-attachments/assets/91430e92-5fb5-459d-8633-ddef36d35ae2"> | <img width="691" alt="Screenshot 2024-07-17 at 15 47 05" src="https://github.com/user-attachments/assets/6487e556-2b81-4a5d-9c4f-50a97cf7655d"> |
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## Testing

Tested manually on local using the stub profiles, with the support MFA flag on and off.
<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
