### PR TITLE
OLH-1863 - Bug Fix to ensure correctly structured post is sent to create MFA method

### DIFF
--- a/src/utils/mfa/index.ts
+++ b/src/utils/mfa/index.ts
@@ -9,6 +9,7 @@ import { MfaMethod, ProblemDetail, ValidationProblem } from "./types";
 import { getAppEnv, getMfaServiceUrl } from "../../config";
 import { authenticator } from "otplib";
 import {
+  AddMFAMethodInput,
   UpdateInformationInput,
   UpdateInformationSessionValues,
 } from "../types";
@@ -44,18 +45,19 @@ export function addMfaMethod(
   const http = new Http(getMfaServiceUrl());
   const { accessToken, sourceIp, persistentSessionId, sessionId } =
     sessionDetails;
+  const addInput: AddMFAMethodInput = {
+    email: updateInput.email,
+    credential: updateInput.credential,
+    otp: updateInput.otp,
+    mfaMethod: {
+      priorityIdentifier: updateInput.mfaMethod.priorityIdentifier,
+      mfaMethodType: updateInput.mfaMethod.method.mfaMethodType,
+    },
+    methodVerified: updateInput.mfaMethod.methodVerified,
+  };
   return http.client.post<MfaMethod>(
     METHOD_MANAGEMENT_API.MFA_METHODS_ADD,
-    {
-      email: updateInput.email,
-      credential: updateInput.credential,
-      otp: updateInput.otp,
-      mfaMethod: {
-        priorityIdentifier: updateInput.mfaMethod.priorityIdentifier,
-        mfaMethodType: updateInput.mfaMethod.method.mfaMethodType,
-      },
-      methodVerified: updateInput.mfaMethod.methodVerified,
-    },
+    addInput,
     getRequestConfig({
       token: accessToken,
       sourceIp,

--- a/src/utils/mfa/index.ts
+++ b/src/utils/mfa/index.ts
@@ -46,7 +46,16 @@ export function addMfaMethod(
     sessionDetails;
   return http.client.post<MfaMethod>(
     METHOD_MANAGEMENT_API.MFA_METHODS_ADD,
-    updateInput,
+    {
+      email: updateInput.email,
+      credential: updateInput.credential,
+      otp: updateInput.otp,
+      mfaMethod: {
+        priorityIdentifier: updateInput.mfaMethod.priorityIdentifier,
+        mfaMethodType: updateInput.mfaMethod.method.mfaMethodType,
+      },
+      methodVerified: updateInput.mfaMethod.methodVerified,
+    },
     getRequestConfig({
       token: accessToken,
       sourceIp,

--- a/src/utils/mfa/types.d.ts
+++ b/src/utils/mfa/types.d.ts
@@ -12,6 +12,12 @@ export interface MfaMethod {
   smsPhoneNumber?: string;
 }
 
+export interface AddMfaMethod {
+  mfaIdentifier?: number;
+  priorityIdentifier: PriorityIdentifier;
+  mfaMethodType: MfaMethodType;
+}
+
 export interface ProblemDetail {
   type?: string;
   /** @example MFA Method could not be updated. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,7 +6,7 @@ import {
 
 import { SignCommandOutput } from "@aws-sdk/client-kms";
 import { PublishCommandOutput } from "@aws-sdk/client-sns";
-import { MfaMethod } from "./mfa/types";
+import { AddMfaMethod, MfaMethod } from "./mfa/types";
 import { GetCommandOutput } from "@aws-sdk/lib-dynamodb";
 
 type ClientId = string;
@@ -117,6 +117,14 @@ export interface UpdateInformationInput {
   updatedValue?: string;
   otp: string;
   mfaMethod?: MfaMethod;
+}
+
+export interface AddMFAMethodInput {
+  email: string;
+  credential?: string;
+  otp: string;
+  mfaMethod?: AddMfaMethod;
+  methodVerified?: boolean;
 }
 
 export interface UpdateInformationSessionValues {


### PR DESCRIPTION

## Proposed changes
OLH-1863 - Bug Fix to ensure correctly structured post is sent to create MFA method


### What changed
Ensures correctly structured post is sent to create MFA method, to match expected input as per the open-api spec
here: https://github.com/govuk-one-login/openapi-specs/blob/main/auth/method-management-api.yaml

### Why did it change
Previously sending as
`{
	"email": "xxxxx",
	"otp": "111111",
	"credential": "xxxxx",
	"mfaMethod": {
		"mfaIdentifier": 2,
		"priorityIdentifier": "BACKUP",
		"method": {
			"mfaMethodType": "SMS",
			"endPoint": "xxxxx"
		},
		"methodVerified": true
	}
}`

Whereas actual method management API expects as

`{
	"email": "xxxx",
	"credential": "xxxx",
	"otp": "111111",
	"mfaMethod": {
		"priorityIdentifier": "BACKUP",
		"mfaMethodType": "xxxxx"
	},
	"methodVerified": true
}`


### Related links

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

## Testing

Deploy to dev and test

## How to review