### PR TITLE
OLH-1931-local-key-id-not-found-in-dev-environment

### DIFF
--- a/src/config/aws.ts
+++ b/src/config/aws.ts
@@ -9,7 +9,9 @@ import { SQSClient, SQSClientConfig } from "@aws-sdk/client-sqs";
 import { readEnvVar } from "../utils/read-envs";
 
 //refer to seed.yaml
-const LOCAL_KEY_ID = readEnvVar("LOCAL_KEY_ID");
+function getLocalKeyId() {
+  return readEnvVar("LOCAL_KEY_ID");
+}
 
 export interface KmsConfig {
   awsConfig: AwsConfig;
@@ -34,7 +36,7 @@ export interface AwsConfig {
 function getLocalStackKmsConfig() {
   return {
     awsConfig: { ...getLocalStackAWSConfig() },
-    kmsKeyId: LOCAL_KEY_ID,
+    kmsKeyId: getLocalKeyId(),
   };
 }
 


### PR DESCRIPTION
## Proposed changes
[OLH-1931 Bug fix for Local Key ID not found

### What changed
Changed from a constant to a function call.

### Why did it change
Constant was getting initialised during build and threw an error as the env var did not exist.


### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
