### PR TITLE
BAU: Use the correct parameter for container memory

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -896,7 +896,7 @@ Resources:
                   LANGUAGETOGGLE,
                 ]
       Cpu: !FindInMap [Container, !Ref Environment, CPU]
-      Memory: !FindInMap [Container, !Ref Environment, CPU]
+      Memory: !FindInMap [Container, !Ref Environment, Memory]
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       TaskRoleArn: !GetAtt TaskRole.Arn
       Family: !Sub "${AWS::StackName}-server"


### PR DESCRIPTION
## Proposed changes

### What changed

Use the correct parameter for container memory
### Why did it change

I used the wrong value in #1539 which is failing to deploy. 

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
