### PR TITLE
OLH-1992: changeAuthenticatorAppRouter feature flag fix

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -191,8 +191,8 @@ async function createApp(): Promise<express.Application> {
     app.use(addMfaMethodSmsRouter);
     app.use(deleteMfaMethodRouter);
     app.use(changeDefaultMethodRouter);
+    app.use(changeAuthenticatorAppRouter);
   }
-  app.use(changeAuthenticatorAppRouter);
   app.use(trackAndRedirectRouter);
 
   // Router for all previously used URLs, that we want to redirect on

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { sinon, expect } from "../../../../test/utils/test-utils";
 import * as cheerio from "cheerio";
 import decache from "decache";
 import { PATH_DATA } from "../../../app.constants";
@@ -10,16 +10,81 @@ import { CLIENT_SESSION_ID, SESSION_ID } from "../../../../test/utils/builders";
 import * as mfaModule from "../../../utils/mfa";
 
 describe("Integration:: change authenticator app", () => {
-  let sandbox: sinon.SinonSandbox;
   let token: string | string[];
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let cookies: string;
-  let app: any;
+  const sandbox = sinon.createSandbox();
 
-  before(async () => {
+  after(() => {
+    sandbox.restore();
+  });
+
+  it("should return change authenticator app page if feature flag is on", async () => {
+    const app = await appWithMiddlewareSetup();
+    request(app)
+      .get(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
+      .expect((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"].concat(
+          `gs=${SESSION_ID}.${CLIENT_SESSION_ID}`
+        );
+        expect(res.status).to.equal(200);
+      });
+  });
+
+  it("should not return change authenticator app page if feature flag is off", async () => {
+    const app = await appWithMiddlewareSetup({ hideChangeMfa: true });
+
+    await request(app)
+      .get(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
+      .then((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"].concat(
+          `gs=${SESSION_ID}.${CLIENT_SESSION_ID}`
+        );
+        expect(res.status).to.equal(404);
+      });
+  });
+
+  it("should redirect to your services when csrf not present", async () => {
+    const app = await appWithMiddlewareSetup();
+    await checkFailedCSRFValidationBehaviour(
+      app,
+      PATH_DATA.CHANGE_AUTHENTICATOR_APP.url,
+      {
+        code: "123456",
+      }
+    );
+  });
+
+  it("should redirect to /update confirmation when valid code entered", async () => {
+    const app = await appWithMiddlewareSetup({ verifyMfaCode: true });
+
+    await request(app)
+      .post(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
+      .type("form")
+      .send({
+        _csrf: token,
+        code: "111111",
+        authAppSecret: "qwer42312345342",
+      })
+      .then((res) => {
+        expect(
+          "Location",
+          PATH_DATA.AUTHENTICATOR_APP_UPDATED_CONFIRMATION.url
+        );
+        expect(res.status).to.equal(302);
+      });
+  });
+
+  const appWithMiddlewareSetup = async (config: any = {}) => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
-    sandbox = sinon.createSandbox();
+    const sandbox = sinon.createSandbox();
+    const configFuncs = require("../../../config");
     sandbox
       .stub(sessionMiddleware, "requiresAuthMiddleware")
       .callsFake(function (req: any, res: any, next: any): void {
@@ -83,66 +148,21 @@ describe("Integration:: change authenticator app", () => {
     sandbox.replace(mfaModule, "generateMfaSecret", () => "A".repeat(20));
     sandbox.replace(mfaModule, "generateQRCodeValue", () => "qrcode");
 
-    app = await require("../../../app").createApp();
-
-    const configFuncs = require("../../../config");
+    if (config.verifyMfaCode) {
+      sandbox.replace(mfaModule, "verifyMfaCode", () => true);
+    }
 
     sandbox.stub(configFuncs, "getMfaServiceUrl").callsFake(() => {
       return "https://method-management-v1-stub.home.build.account.gov.uk";
     });
     sandbox.stub(configFuncs, "supportChangeMfa").callsFake(() => {
-      return true;
+      return !config.hideChangeMfa;
     });
+
     sandbox.stub(configFuncs, "supportMfaPage").callsFake(() => {
       return true;
     });
 
-    await request(app)
-      .get(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"].concat(
-          `gs=${SESSION_ID}.${CLIENT_SESSION_ID}`
-        );
-      });
-  });
-
-  beforeEach(() => {});
-
-  after(() => {
-    sandbox.restore();
-    app = undefined;
-  });
-
-  it("should return change authenticator app page", (done) => {
-    request(app).get(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url).expect(200, done);
-  });
-
-  it("should redirect to your services when csrf not present", async () => {
-    await checkFailedCSRFValidationBehaviour(
-      app,
-      PATH_DATA.CHANGE_AUTHENTICATOR_APP.url,
-      {
-        code: "123456",
-      }
-    );
-  });
-
-  it("should redirect to /update confirmation when valid code entered", () => {
-    sandbox.replace(mfaModule, "verifyMfaCode", () => true);
-
-    // Act
-    request(app)
-      .post(PATH_DATA.CHANGE_AUTHENTICATOR_APP.url)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "111111",
-        authAppSecret: "qwer42312345342",
-      })
-      .expect("Location", PATH_DATA.AUTHENTICATOR_APP_UPDATED_CONFIRMATION.url)
-      .expect(302);
-  });
+    return await require("../../../app").createApp();
+  };
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Move `changeAuthenticatorAppRouter` behind the `supportChangeMfa` flag so that the page cannot be accessed when the feature isn't live yet.
Update tests to verify that the update worked.

For some reason I could not fully understand, the tests weren't picking up on the value of `supportChangeMfa` when using `sandbox.stub` to update its value to false within the `it()` test functions.  
I refactored the test somewhat to work around this problem so all the tests seem to function correctly now (though I am not sure why it wasn't functioning correctly to begin with 🙃 )
<!-- Describe the changes in detail - the "what"-->

### Why did it change

The OL home team had an incident where the "change authenticator app" page was accessible in spite of the flag being off. 
<!-- Describe the reason these changes were made - the "why" -->

### Related links

https://govukverify.atlassian.net/browse/OLH-1992
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## Testing
Manual test: the change authenticator app route returns a 404 when the flag is off now, whereas previously it used to return status code 200.
Automated tests should pass. 
<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
