### PR TITLE
OLH-1991: Add a Github action to build the test image

### DIFF
--- a/.github/workflows/merge-post-deploy-tests-to-main.yml
+++ b/.github/workflows/merge-post-deploy-tests-to-main.yml
@@ -1,0 +1,42 @@
+---
+name: "Publish Feature Tests to Build"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "post-deploy-tests/**"
+      - ".github/workflows/merge-post-deploy-tests-to-main.yml"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish_artifacts:
+    name: "Publish post-deploy tests image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4.0.2
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # pin@v2.0.1
+
+      - name: Build & Publish Docker image
+        working-directory: post-deploy-tests/
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.POST_DEPLOY_TESTS_IMAGE_REPOSITORY }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push -a $ECR_REGISTRY/$ECR_REPOSITORY


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add a new Github action that builds and pushes the post-deploy tests image to ECR in our build environment. I've already set up the ECR repository as described in the documentation[^1].

This action is triggered when a PR is merged to main that includes changes to the post-deploy tests folder or the action itself. I've set this up as a separate action rather than a new step in the existing post-merge actions so it doesn't add to the time between merging code and it getting deployed to production.

The image needs to be pushed to ECR before the pipeline starts running the test step, but I think we should be safe to do this as a parallel step. The only slow part in this action is building the image, most of which is network time downloading Chrome. It takes well under 5 minutes on my laptop and the Github action runners have faster internet connections than me.

This is comfortably under the ~7 minutes it takes for Github actions to test, build and push the main frontend image plus ~7 minutes for the stack to update in Codebuild.

[^1]: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3107258369/How+to+deploy+a+container+to+Fargate+with+secure+pipelines#Step-9%3A-Configure-pipelines-for-running-tests-against-infrastructure-(Optional)

### Related links

Don't merge before #1544 

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

