### PR TITLE
OLH-1994: Increase container resources in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -147,10 +147,10 @@ Mappings:
       MinCapacity: 3
       MaxCapacity: 6
     build:
-      CPU: 1024
+      CPU: 2048
       Memory: 4096
-      MinCapacity: 3
-      MaxCapacity: 6
+      MinCapacity: 8
+      MaxCapacity: 12
     staging:
       CPU: 1024
       Memory: 4096


### PR DESCRIPTION
## Proposed changes

### What changed

Increase the container CPU in build to 2048 (2 vCPU) and change the autoscaling configuration so we're running 8 containers by default, scaling up to 16.

Once this is rolled out we'll re-run the performance tests and see how we do. I'm hopeful this many containers is more than we need, but I'd prefer to start with too many then gradually reduce it (and the cost) once we're sure.

### Why did it change

In our performance tests there’s two main causes of problems:

1. Our containers run out of CPU
2. Our containers don’t scale up fast enough

We can solve both of these fairly easily by throwing more resources at the traffic.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## How to review

Please check the CPU / memory configuration against the allowed combinations for Fargate tasks[^1].

[^1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
