### PR TITLE
OLH-1488 Update 404 page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -69,6 +69,7 @@ import { safeTranslate } from "./utils/safeTranslate";
 import { addMfaMethodSmsRouter } from "./components/add-mfa-method-sms/add-mfa-method-sms-routes";
 import { deleteMfaMethodRouter } from "./components/delete-mfa-method/delete-mfa-method-routes";
 import { changeDefaultMethodRouter } from "./components/change-default-method/change-default-method-routes";
+import { isUserLoggedInMiddleware } from "./middleware/is-user-logged-in-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -167,6 +168,7 @@ async function createApp(): Promise<express.Application> {
   app.use(startRouter);
   app.use(logoutRouter);
   app.use(enterPasswordRouter);
+  app.use(isUserLoggedInMiddleware);
   app.use(changeEmailRouter);
   app.use(updateConfirmationRouter);
   app.use(changePasswordRouter);

--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -1,6 +1,12 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% set activeNav = '404' %}
 {% set pageTitleName = 'error.error404.title' | translate %}
+{% if isUserLoggedIn %}
+  {% set buttonText = button_text | default('error.error404.content.signInUserButtonText' | translate, true) %}
+{% else %}
+  {% set buttonText = button_text | default('error.error404.content.signOutUserButtonText' | translate, true) %}
+{% endif %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -9,9 +15,9 @@
       <p class="govuk-body">{{'error.error404.content.paragraph1' | translate }}</p>
       <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
       {{ govukButton({
-          "text": button_text|default('error.error404.content.govUKHomepageButtonText' | translate, true),
+          "text": buttonText,
           "type": "Submit",
-          "href": 'error.error404.content.govUKHomepageButtonHref' | translate
+          "href": accountHome
           }) }}
     </div>
   </div>

--- a/src/components/common/errors/500.njk
+++ b/src/components/common/errors/500.njk
@@ -1,5 +1,5 @@
 {% extends "common/layout/base.njk" %}
-
+{% set activeNav = '500' %}
 {% set pageTitleName = 'error.error500.title' | translate %}
 
 {% block content %}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -36,7 +36,7 @@
 
 {% block header %}
     {% include 'common/layout/header.njk' %}
-    {% if not hideAccountNavigation %}
+    {% if not hideAccountNavigation and isUserLoggedIn %}
       {% include 'common/layout/navigation.njk' %}
     {% endif %}
 {% endblock %}

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -11,6 +11,7 @@ import {
   getAccessibilityStatementUrl,
 } from "../../config";
 import { EVENT_NAME, PATH_DATA } from "../../app.constants";
+import isUserLoggedIn from "../../utils/isUserLoggedIn";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 
@@ -45,11 +46,6 @@ const logUserVisitsContactPage = (event: AuditEvent, trace: string) => {
 const render = (req: Request, res: Response): void => {
   const { language, protocol, hostname } = req;
   const baseUrl = protocol + "://" + hostname;
-  const isAuthenticated = req.session.user?.isAuthenticated;
-  let isLoggedOut = req.cookies?.lo;
-  if (typeof isLoggedOut === "string") {
-    isLoggedOut = JSON.parse(isLoggedOut);
-  }
   const referenceCode = req.session.referenceCode;
 
   const data = {
@@ -57,7 +53,7 @@ const render = (req: Request, res: Response): void => {
     contactPhoneEnabled: supportPhoneContact(),
     showContactGuidance: showContactGuidance(),
     showContactEmergencyMessage: showContactEmergencyMessage(),
-    showSignOut: isAuthenticated && !isLoggedOut,
+    showSignOut: isUserLoggedIn(req),
     referenceCode,
     contactEmailServiceUrl: PATH_DATA.TRACK_AND_REDIRECT.url,
     accessibilityStatementUrl: getAccessibilityStatementUrl(),

--- a/src/config/nunjucks.ts
+++ b/src/config/nunjucks.ts
@@ -2,7 +2,7 @@ import express from "express";
 import * as nunjucks from "nunjucks";
 import { Environment } from "nunjucks";
 import i18next, { TFunction } from "i18next";
-import { PATH_DATA } from "../app.constants";
+import { LOCALE, PATH_DATA } from "../app.constants";
 import addLanguageParam from "@govuk-one-login/frontend-language-toggle";
 import { safeTranslate } from "../utils/safeTranslate";
 
@@ -17,10 +17,12 @@ export function configureNunjucks(
   });
 
   nunjucksEnv.addFilter("translate", function (key: string, options?: any) {
-    const translate: TFunction<"translation", undefined> = i18next.getFixedT(
-      this.ctx.i18n.language
-    );
-    return safeTranslate(translate, key, this.ctx.i18n.language, options);
+    const currentLanguage = this.ctx.i18n.language
+      ? this.ctx.i18n.language
+      : LOCALE.EN;
+    const translate: TFunction<"translation", undefined> =
+      i18next.getFixedT(currentLanguage);
+    return safeTranslate(translate, key, currentLanguage, options);
   });
 
   nunjucksEnv.addGlobal("addLanguageParam", addLanguageParam);

--- a/src/config/nunjucks.ts
+++ b/src/config/nunjucks.ts
@@ -17,7 +17,7 @@ export function configureNunjucks(
   });
 
   nunjucksEnv.addFilter("translate", function (key: string, options?: any) {
-    const currentLanguage = this.ctx.i18n.language
+    const currentLanguage = this.ctx?.i18n?.language
       ? this.ctx.i18n.language
       : LOCALE.EN;
     const translate: TFunction<"translation", undefined> =

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -101,8 +101,8 @@
       "content": {
         "paragraph1": "Os ydych wedi teipio’r cyfeiriad gwe, edrychwch i weld ei fod yn gywir.",
         "paragraph2": "Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan.",
-        "govUKHomepageButtonHref": "https://www.gov.uk/",
-        "govUKHomepageButtonText": "Ewch i hafan GOV.UK"
+        "signInUserButtonText": "Ewch i'ch GOV.UK One Login",
+        "signOutUserButtonText": "Mewngofnodi i GOV.UK One Login"
       }
     },
     "error500": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -101,8 +101,8 @@
       "content": {
         "paragraph1": "If you typed the web address, check it is correct.",
         "paragraph2": "If you pasted the web address, check you copied the entire address.",
-        "govUKHomepageButtonHref": "https://www.gov.uk/",
-        "govUKHomepageButtonText": "Go to the GOV.UK homepage"
+        "signInUserButtonText": "Go to your GOV.UK One Login",
+        "signOutUserButtonText": "Sign in to GOV.UK One Login"
       }
     },
     "error500": {

--- a/src/middleware/is-user-logged-in-middleware.ts
+++ b/src/middleware/is-user-logged-in-middleware.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from "express";
+import isUserLoggedIn from "../utils/isUserLoggedIn";
+
+export const isUserLoggedInMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  res.locals.isUserLoggedIn = isUserLoggedIn(req);
+  next();
+};

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -13,7 +13,6 @@ import { generateNonce } from "../utils/strings";
 import { PATH_DATA } from "../app.constants";
 import { getSessionIdsFrom } from "../utils/session-ids";
 import { getCurrentUrl } from "../utils/language-toggle";
-import isUserLoggedIn from "../utils/isUserLoggedIn";
 
 export function setLocalVarsMiddleware(
   req: Request,
@@ -33,7 +32,6 @@ export function setLocalVarsMiddleware(
   res.locals.isGa4Disabled = googleAnalytics4Disabled();
   res.locals.isUaDisabled = universalAnalyticsDisabled();
   res.locals.currentUrl = getCurrentUrl(req);
-  res.locals.isUserLoggedIn = isUserLoggedIn(req);
 
   const sessionIds = getSessionIdsFrom(req);
   res.locals.sessionId = sessionIds.sessionId;

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -13,6 +13,7 @@ import { generateNonce } from "../utils/strings";
 import { PATH_DATA } from "../app.constants";
 import { getSessionIdsFrom } from "../utils/session-ids";
 import { getCurrentUrl } from "../utils/language-toggle";
+import isUserLoggedIn from "../utils/isUserLoggedIn";
 
 export function setLocalVarsMiddleware(
   req: Request,
@@ -32,6 +33,7 @@ export function setLocalVarsMiddleware(
   res.locals.isGa4Disabled = googleAnalytics4Disabled();
   res.locals.isUaDisabled = universalAnalyticsDisabled();
   res.locals.currentUrl = getCurrentUrl(req);
+  res.locals.isUserLoggedIn = isUserLoggedIn(req);
 
   const sessionIds = getSessionIdsFrom(req);
   res.locals.sessionId = sessionIds.sessionId;

--- a/src/utils/isUserLoggedIn.ts
+++ b/src/utils/isUserLoggedIn.ts
@@ -1,0 +1,14 @@
+import { Request } from "express";
+
+const isUserLoggedIn = (req: Request): boolean => {
+  const isAuthenticated = req.session?.user?.isAuthenticated ?? false;
+  let isLoggedOut = false;
+
+  if (req.cookies?.lo) {
+    isLoggedOut = JSON.parse(req.cookies.lo);
+  }
+
+  return isAuthenticated && !isLoggedOut;
+};
+
+export default isUserLoggedIn;

--- a/src/utils/test/isUserLoggedIn.test.ts
+++ b/src/utils/test/isUserLoggedIn.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { Request } from "express";
+import isUserLoggedIn from "../isUserLoggedIn";
+
+describe("isUserLoggedIn", () => {
+  let req: Partial<Request>;
+
+  beforeEach(() => {
+    req = {
+      session: {
+        user: {
+          isAuthenticated: false,
+        },
+      } as any,
+      cookies: {},
+    };
+  });
+
+  it("should return false if the user is not authenticated", () => {
+    req.session!.user!.isAuthenticated = false;
+    expect(isUserLoggedIn(req as Request)).to.be.false;
+  });
+
+  it("should return true if the user is authenticated and not logged out", () => {
+    req.session!.user!.isAuthenticated = true;
+    expect(isUserLoggedIn(req as Request)).to.be.true;
+  });
+
+  it("should return false if the user is authenticated but logged out", () => {
+    req.session!.user!.isAuthenticated = true;
+    req.cookies!.lo = JSON.stringify(true);
+    expect(isUserLoggedIn(req as Request)).to.be.false;
+  });
+
+  it("should return true if the user is authenticated and lo cookie is false", () => {
+    req.session!.user!.isAuthenticated = true;
+    req.cookies!.lo = JSON.stringify(false);
+    expect(isUserLoggedIn(req as Request)).to.be.true;
+  });
+
+  it("should return false if there is no session", () => {
+    req.session = undefined;
+    expect(isUserLoggedIn(req as Request)).to.be.false;
+  });
+
+  it("should return false if there is no user in session", () => {
+    req.session!.user = undefined;
+    expect(isUserLoggedIn(req as Request)).to.be.false;
+  });
+});

--- a/test/unit/config/nunjucks.test.ts
+++ b/test/unit/config/nunjucks.test.ts
@@ -36,6 +36,18 @@ describe("configureNunjucks", () => {
       expect(result).to.equal("translated_value");
       expect(fixedTStub.calledWith("test_key")).to.be.true;
     });
+    it("should translate based on default language", () => {
+      const fixedTStub = sinon
+        .stub()
+        .returns("translated_value") as unknown as MyStubType;
+      sinon.stub(i18next, "getFixedT").returns(fixedTStub);
+
+      const translateFilter = nunjucksEnv.getFilter("translate");
+      const result = translateFilter.call({}, "test_key");
+
+      expect(result).to.equal("translated_value");
+      expect(fixedTStub.calledWith("test_key")).to.be.true;
+    });
     it("should throw an error if translation key does no exist", () => {
       const fixedTStub = sinon
         .stub()

--- a/test/unit/middleware/is-user-logged-in-middleware.test.ts
+++ b/test/unit/middleware/is-user-logged-in-middleware.test.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { NextFunction } from "express";
+import { sinon } from "../../utils/test-utils";
+import { isUserLoggedInMiddleware } from "../../../src/middleware/is-user-logged-in-middleware";
+
+describe("isUserLoggedInMiddleware", () => {
+  let req: any;
+  const res: any = { locals: {}, redirect: sinon.fake() };
+  const nextFunction: NextFunction = sinon.fake(() => {});
+
+  beforeEach(() => {
+    req = {
+      session: {
+        user: {
+          isAuthenticated: false,
+        } as any,
+      },
+      cookies: {
+        lo: "true",
+      },
+    };
+  });
+
+  it("should set isUserLoggedIn in res.locals", () => {
+    isUserLoggedInMiddleware(req, res, nextFunction);
+    expect(res.locals).to.have.property("isUserLoggedIn");
+  });
+
+  it("should call next function", () => {
+    isUserLoggedInMiddleware(req, res, nextFunction);
+    expect(nextFunction).to.have.been.called;
+  });
+});


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Changed the way 404 page behaves depending on whether a user is logged in or not.
For logged in users, navigation is displayed and the main CTA button goes to `your-services` page
For not logged in users, navigation is not shown and the main CTA button goes to sign in page.

### Why did it change

Because that’s the more appropriate place to send users who get a “not found” while navigating their One Login home, and less confusing when we don't show the navigation

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added a local variable `res.locals.isUserLoggedIn`

## Testing

Local testing for both logged in and not logged in users

<img width="953" alt="image" src="https://github.com/user-attachments/assets/55bf1ced-449f-4af9-953a-b0b56ab444b2">
<img width="948" alt="image" src="https://github.com/user-attachments/assets/9c21746b-cefb-430e-bac1-ef498a921da9">


## How to review

Navigate to any non-existent page to see the 404 page. Check both navigation and CTA  button copy
