### PR TITLE
OLH-1906: enter password and delete journey tweaks

### DIFF
--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -6,7 +6,7 @@
 {% set pageTitleName = 'pages.deleteAccount.title' | translate %}
 {% set contentId = "0768fa94-3a7a-4f19-8bf5-a1d5afa49023" if services.length else "7c0ae794-46ba-4abd-bf23-ebd70782a96b" %}
 
-{% block pageContent%}
+{% block pageContent %}
 
 {% include "common/errors/errorSummary.njk" %}
 
@@ -18,10 +18,8 @@
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph2' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">
     {% for service in services %}
-
       {% set locale = ['clientRegistry.', env, '.', service.client_id, '.'] | join %}
         <li data-test-id="service-list-item">{{ [locale, 'header'] | join | translate }}</li>
-
     {% endfor %}
     </ul>
     {% if hasGovUkEmailSubscription %}
@@ -35,25 +33,26 @@
   {% endif %}
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph5' | translate }}</p>
 
-{{ govukInsetText({
-  text: 'pages.deleteAccount.details' | translate
-}) }}
+  {{ govukInsetText({
+    text: 'pages.deleteAccount.details' | translate
+  }) }}
 
-<form action="/delete-account" method="post" novalidate>
+<form action="{{'DELETE_ACCOUNT' | getPath }}" method="post" novalidate>
+  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+  <input type="hidden" name="fromSecurity" value="{{fromSecurity}}"/>
 
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-
-{{ govukButton({
-  text: 'pages.deleteAccount.deleteAccount' | translate,
-  classes: "govuk-button--warning",
-  "type": "Submit",
-  "preventDoubleClick": true
-}) }}
-
+  {{ govukButton({
+    text: 'pages.deleteAccount.deleteAccount' | translate,
+    classes: "govuk-button--warning",
+    "type": "Submit",
+    "preventDoubleClick": true
+  }) }}
 </form>
 
-<a href="/manage-your-account" class="govuk-link govuk-body">
+{% if fromSecurity %}
+  <a href="/manage-your-account" class="govuk-link govuk-body">
     {{ 'pages.deleteAccount.doNotDeleteAccount' | translate }}
-</a>
+  </a>
+{% endif %}
 {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"delete account", contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -76,6 +76,7 @@ export function enterPasswordGet(req: Request, res: Response): void {
 
   res.render(`enter-password/index.njk`, {
     requestType,
+    fromSecurity: req.query.from == "security",
     oplValues: OPL_VALUES[requestType] || {},
   });
 }

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -7,22 +7,24 @@
 {% set header = ['pages.enterPassword.', requestType, '.header'] | join | translate %}
 
 {% if requestType == 'changePassword' %}
-    {% set pageTitleName = 'pages.enterPassword.changePassword.title' | translate %}
+  {% set pageTitleName = 'pages.enterPassword.changePassword.title' | translate %}
 {% else %}
-    {% set pageTitleName = 'pages.enterPassword.title' | translate %}
+  {% set pageTitleName = 'pages.enterPassword.title' | translate %}
 {% endif %}
-
-{% set backLink = "/manage-your-account" %}
+{% if fromSecurity %}
+  {% set backLink = "/manage-your-account" %}
+{% endif %}
 
 {% block pageContent %}
 {% include "common/errors/errorSummary.njk" %}
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{header}}</h1>
 
-    <form action="/enter-password" method="post" novalidate>
+    <form action="{{'ENTER_PASSWORD' | getPath }}" method="post" novalidate>
 
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
         <input type="hidden" name="requestType" value="{{requestType}}"/>
+        <input type="hidden" name="fromSecurity" value="{{fromSecurity}}"/>
 
         <p class="govuk-body">{{paragraph}}</p>
 
@@ -45,8 +47,9 @@
         "type": "Submit",
         "preventDoubleClick": true
         }) }}
-
+        {% if fromSecurity %}
         <p class="govuk-body"> <a href="/manage-your-account" class="govuk-link" rel="noreferrer noopener">{{cancelText}}</a></p>
+        {% endif %}
     </form>
 
 {% endblock %}

--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -1,7 +1,6 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% set pageTitleName = 'pages.security.title' | translate %}
-
 {% set contentId = "06b3a091-8595-45b7-832a-1b5f3632ad2e" if isPhoneNumberVerified else "caaccf0a-1dd3-441c-af20-01925c8f9cba" %}
 
 {% set accountDetailsSummaryList = {
@@ -17,7 +16,7 @@
       actions: {
         items: [
           {
-            href: "/enter-password?type=changeEmail&edit=true",
+            href: enterPasswordUrl + "&type=changeEmail&edit=true",
             text: 'general.change' | translate,
             visuallyHiddenText: 'pages.security.accountDetails.summaryList.email' | translate
           }
@@ -35,7 +34,7 @@
       actions: {
         items: [
           {
-            href: "/enter-password?type=changePassword&edit=true",
+            href: enterPasswordUrl + "&type=changePassword&edit=true",
             text: 'general.change' | translate,
             visuallyHiddenText: 'pages.security.accountDetails.summaryList.password' | translate
           }
@@ -87,8 +86,8 @@
                   {% if (method.priorityIdentifier == "BACKUP") and not foundSecondary %}
                     {# 1: backup method exists => display backup method block with options to change backup method or switch primary and backup #}
                     <p class="govuk-body">{{ method.text }}</p>
-                    <p class="govuk-body"><a href="/enter-password?type=switchBackupMethod" class="govuk-link"> {{ 'pages.security.mfaSection.supportChangeMfa.backup.switchLink' | translate }}</a></p>
-                    <p class="govuk-body"><a href="/enter-password?type=removeMfaMethod" class="govuk-link"> {{ 'pages.security.mfaSection.supportChangeMfa.backup.removeLink' | translate }}</a></p>
+                    <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=switchBackupMethod" class="govuk-link"> {{ 'pages.security.mfaSection.supportChangeMfa.backup.switchLink' | translate }}</a></p>
+                    <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=removeMfaMethod" class="govuk-link"> {{ 'pages.security.mfaSection.supportChangeMfa.backup.removeLink' | translate }}</a></p>
                     {% set foundSecondary = true %}
                   {% endif %}
                 {% endfor %}
@@ -97,7 +96,7 @@
                   <p class="govuk-body">{{ 'pages.security.mfaSection.supportChangeMfa.backup.paragraph' | translate }}</p>
                   <p class="govuk-body">{{ 'pages.security.mfaSection.supportChangeMfa.backup.paragraph2' | translate }}</p>
                   <p class="govuk-body">
-                    <a href="/enter-password?type=addMfaMethod" class="govuk-link">{{ 'pages.security.mfaSection.supportChangeMfa.backup.link' | translate }}</a>
+                    <a href="{{enterPasswordUrl}}&type=addMfaMethod" class="govuk-link">{{ 'pages.security.mfaSection.supportChangeMfa.backup.link' | translate }}</a>
                   </p>
                 {% endif %}
               </div>
@@ -145,7 +144,7 @@
       <div class="summary-list-container">
         <h2 class="govuk-heading-m">{{ 'pages.security.deleteAccount.heading' | translate }}</h2>
         <p class="govuk-body">{{ 'pages.security.deleteAccount.info' | translate }}</p>
-        <p class="govuk-body"><a href="/enter-password?type=deleteAccount" class="govuk-link">{{ 'pages.security.deleteAccount.link' | translate }}</a></p>
+        <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=deleteAccount" class="govuk-link">{{ 'pages.security.deleteAccount.link' | translate }}</a></p>
       </div>
     </div>
   </div>

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -10,7 +10,7 @@ import { getLastNDigits } from "../../utils/phone-number";
 
 export async function securityGet(req: Request, res: Response): Promise<void> {
   const { email } = req.session.user;
-
+  const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=security`;
   const supportActivityLogFlag = supportActivityLog();
 
   const hasHmrc = await hasAllowedRSAServices(req, res);
@@ -34,7 +34,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
             linkText = req.t(
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change"
             );
-            linkHref = `${PATH_DATA.ENTER_PASSWORD.url}?type=changePhoneNumber`;
+            linkHref = `${enterPasswordUrl}&type=changePhoneNumber`;
           } else if (mfaMethod.method.mfaMethodType === "AUTH_APP") {
             text = req.t(
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.app.title"
@@ -42,7 +42,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
             linkText = req.t(
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.app.change"
             );
-            linkHref = `${PATH_DATA.ENTER_PASSWORD.url}?type=changeAuthenticatorApp`;
+            linkHref = `${enterPasswordUrl}&type=changeAuthenticatorApp`;
           } else {
             throw new Error(
               `Unexpected mfaMethodType: ${mfaMethod.method.mfaMethodType}`
@@ -75,7 +75,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
               items: [
                 {
                   attributes: { "data-test-id": "change-phone-number" },
-                  href: `${PATH_DATA.ENTER_PASSWORD.url}?type=changePhoneNumber`,
+                  href: `${enterPasswordUrl}&type=changePhoneNumber`,
                   text: req.t("general.change"),
                   visuallyHiddenText: req.t(
                     "pages.security.mfaSection.summaryList.app.hiddenText"
@@ -125,6 +125,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
     email,
     supportActivityLog: supportActivityLogFlag && hasHmrc,
     activityLogUrl,
+    enterPasswordUrl,
     mfaMethods,
     supportChangeMfa: supportChangeMfa(),
     supportAddBackupMfa: supportAddBackupMfa(),

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -63,10 +63,11 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: true,
         activityLogUrl: "/activity-history",
+        enterPasswordUrl: "/enter-password?from=security",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?type=changePhoneNumber",
+            linkHref: "/enter-password?from=security&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",
@@ -113,10 +114,11 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: false,
         activityLogUrl: "/activity-history",
+        enterPasswordUrl: "/enter-password?from=security",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?type=changePhoneNumber",
+            linkHref: "/enter-password?from=security&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",
@@ -165,10 +167,11 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: false,
         activityLogUrl: "/activity-history",
+        enterPasswordUrl: "/enter-password?from=security",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?type=changePhoneNumber",
+            linkHref: "/enter-password?from=security&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",
@@ -284,10 +287,11 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: true,
         activityLogUrl: "/activity-history",
+        enterPasswordUrl: "/enter-password?from=security",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?type=changePhoneNumber",
+            linkHref: "/enter-password?from=security&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Users now have some options for changing their identity information when using an identity RP. However they can only change one part of their name. If they want to change multiple parts of their name they must delete their account and create a new one again.

Identity would like to link straight to the delete journey in account management for this purpose.

A requirement has come through to remove the home specific navigation items from the delete account journey when users arrive to this journey from this route as it was deemed that these elements might cause some confusion.

The way I've gone about this has been to append a query parameter when linking to this journey from the security page.
This seemed most logical as those elements should only be visible the Security page was part of the journey.

When the query parameter is present, the navigational elements should be visible, and when it's not present they should be hidden. 
We'll give the identity team the version of the link without the query string parameter.


### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## Testing
Manual verification that the security page adjacent links appear when clicking  through the journey from the Security page, and not present when the `from=security` parameter is removed. 
<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
