### PR TITLE
OLH-1895-set-up-the-feature-to-skip-canary-deployments-for-the-frontend [skip canary]

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -93,8 +93,8 @@ Parameters:
       - CodeDeployDefault.ECSCanary10Percent5Minutes
       - CodeDeployDefault.ECSCanary10Percent15Minutes
       - CodeDeployDefault.ECSAllAtOnce
-      - ECSCanary50Percent5Minutes
-      - ECSLinear10PercentEvery3Minutes
+      - CodeDeployDefault.ECSLinear10PercentEvery1Minutes
+      - CodeDeployDefault.ECSLinear10PercentEvery3Minutes
 
 Conditions:
   UseCodeSigning:


### PR DESCRIPTION
## Proposed changes
[OLH-1895] Skip Canary deployment for the frontend 

### What changed
Addition of latest deployment strategy options

### Why did it change
To update to latest pipeline version which enables canary deployments.

## Checklists
## Testing
Manually configured template.zip to have skip canary enabled which skipped canary deployment.

[OLH-1895]: https://govukverify.atlassian.net/browse/OLH-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ