### PR TITLE
OLH-1991: Downgrade image upload action versions

### DIFF
--- a/.github/workflows/merge-post-deploy-tests-to-main.yml
+++ b/.github/workflows/merge-post-deploy-tests-to-main.yml
@@ -22,14 +22,14 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4.0.2
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # pin@v2.0.1
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # pin@v1
 
       - name: Build & Publish Docker image
         working-directory: post-deploy-tests/


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Downgrade the AWS action versions in the `merge-post-deploy-tests-to-main.yml` to match those in the action which deploys a branch to dev.

**Don't merge this** before https://github.com/govuk-one-login/di-account-management-frontend/pull/1565

### Why did it change

This action is currently failing with a permissions error:

```
denied: User: arn:aws:sts::301577035144:assumed-role/account-mgmt-frontend-pipeline-GitHubActionsRole-AHD0ZJ9UGXU4/GitHubActions is not authorized to perform: ecr:InitiateLayerUpload on resource: arn:aws:ecr:eu-west-2:301577035144:repository/*** because no identity-based policy allows the ecr:InitiateLayerUpload action

```

I think this is because the newer version of one of these actions is a breaking change and slightly changes the role ARN that we end up using (`assumed-role` in the ARN instead of just `role`).

The action to upload the image to our dev environment does almost exactly the same steps and that works, so downgrade the versions in this action to match it.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

