### PR TITLE
OLH-1991: Disable interactive pager for test image

### DIFF
--- a/post-deploy-tests/Dockerfile
+++ b/post-deploy-tests/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install curl gnupg -y \
 
 # We don't need the standalone Chromium
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV AWS_PAGER=""
 
 COPY . .
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Disable the interactive pager so AWS commands can run in the headless test container.

### Why did it change

By default the AWS CLI uses `less` to display an interactive pager on commands that have a long expected runtime (eg. uploading a file to S3).

This Docker image doesn't have `less` installed, so the tests were failing when the pipeline ran the AWS command to get the frontend stack outputs.

### Related links

Merge this before https://github.com/govuk-one-login/di-account-management-frontend/pull/1565 

## Checklists


### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I've built this image locally, pushed it to ECR and verified it runs in the pipeline:

![image](https://github.com/user-attachments/assets/e8bbb0e3-a77c-4dae-afa3-739883f92e3e)
