### PR TITLE
OLH-1991: Add dependabot config for post deploy tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,45 @@ updates:
       - dependency-name: "node"
         update-types:
           - "version-update:semver-major"
+
+  - package-ecosystem: "npm"
+    directory: "/post-deploy-tests"
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    ignore:
+      - dependency-name: "node"
+        versions: ["17.x", "18.x", "19.x"]
+    commit-message:
+      prefix: BAU
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: docker
+    directory: "/post-deploy-tests"
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    commit-message:
+      prefix: BAU
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Proposed changes

### What changed

Add dependabot config for post deploy tests.

This uses the same options as we have for our application code, most notably the Node major version restrictions to keep us on Node 20.


## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed