### PR TITLE
OLH-2028-create-a-success-rate-alarm-for-the-fe-canary-deployment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2398,9 +2398,9 @@ Resources:
         DeploymentStrategy: !Ref DeploymentStrategy
         ContainerName: !Sub "${AWS::StackName}-TaskDefinition"
         ContainerPort: !Ref ContainerPort
-        CloudWatchAlarms:
-          - !Sub "${ELB5XX10PercentAlarm}"
-          - ELB5XX10PercentAlarm
+        CloudWatchAlarms: !Sub
+          - "${ELB5XX10PercentAlarm}"
+          - ELB5XX10PercentAlarm: !Ref ELB5XX10PercentAlarm
 
 Outputs:
   ApiGatewayEndpoint:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2398,10 +2398,9 @@ Resources:
         DeploymentStrategy: !Ref DeploymentStrategy
         ContainerName: !Sub "${AWS::StackName}-TaskDefinition"
         ContainerPort: !Ref ContainerPort
-        CloudWatchAlarms: !Sub
-          - "${ELB5XXAlarm},${ELB4XXAnomalyAlarm}"
-          - ELB5XXAlarm: !Ref ELB5XXAlarm
-            ELB4XXAnomalyAlarm: !Ref ELB4XXAnomalyAlarm
+        CloudWatchAlarms:
+          - !Sub "${ELB5XX10PercentAlarm}"
+          - ELB5XX10PercentAlarm
 
 Outputs:
   ApiGatewayEndpoint:


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2028] - Update cloudwatch alarm for canary deployment
### What changed
<!-- Describe the changes in detail - the "what"-->
Replaced cloudwatch alarms that would trigger canary rollback with a ELB 5XX 10% alarm which would trigger if more than 10% of requests return a 5XX.

### Why did it change

Reduces the chances of false positives.

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[OLH-2028]: https://govukverify.atlassian.net/browse/OLH-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ