### PR TITLE
Olh 2029 enable canary deployment in prod integration for fe

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -84,17 +84,6 @@ Parameters:
   ActivityLogTableName:
     Type: String
     Default: activity_log
-  DeploymentStrategy:
-    Description: "Predefined deployment configuration for ECS application"
-    Type: String
-    Default: "None"
-    AllowedValues:
-      - None
-      - CodeDeployDefault.ECSCanary10Percent5Minutes
-      - CodeDeployDefault.ECSCanary10Percent15Minutes
-      - CodeDeployDefault.ECSAllAtOnce
-      - CodeDeployDefault.ECSLinear10PercentEvery1Minutes
-      - CodeDeployDefault.ECSLinear10PercentEvery3Minutes
 
 Conditions:
   UseCodeSigning:
@@ -131,8 +120,7 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
-  UseCanaryDeployment:
-    !Or # TODO: Replace with Prod and Integration when tests in Dev complete
+  UseCanaryDeployment: !Or
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, dev]
 
@@ -2395,7 +2383,7 @@ Resources:
         GreenTargetGroupName: !GetAtt ApplicationLoadBalancerTargetGroupGreen.TargetGroupName
         LoadBalancerListenerARN: !Ref ApplicationLoadBalancerListenerHTTPS
         ECSServiceTaskDefinition: !Ref TaskDefinition
-        DeploymentStrategy: !Ref DeploymentStrategy
+        DeploymentStrategy: ECSLinear10PercentEvery3Minutes
         ContainerName: !Sub "${AWS::StackName}-TaskDefinition"
         ContainerPort: !Ref ContainerPort
         CloudWatchAlarms: !Sub

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -121,8 +121,8 @@ Conditions:
       - !Equals [!Ref Environment, production]
 
   UseCanaryDeployment: !Or
-    - !Equals [!Ref Environment, dev]
-    - !Equals [!Ref Environment, dev]
+    - !Equals [!Ref Environment, production]
+    - !Equals [!Ref Environment, integration]
 
 Mappings:
   ElasticLoadBalancerAccountIds:
@@ -2383,7 +2383,7 @@ Resources:
         GreenTargetGroupName: !GetAtt ApplicationLoadBalancerTargetGroupGreen.TargetGroupName
         LoadBalancerListenerARN: !Ref ApplicationLoadBalancerListenerHTTPS
         ECSServiceTaskDefinition: !Ref TaskDefinition
-        DeploymentStrategy: ECSLinear10PercentEvery3Minutes
+        DeploymentStrategy: CodeDeployDefault.ECSLinear10PercentEvery3Minutes
         ContainerName: !Sub "${AWS::StackName}-TaskDefinition"
         ContainerPort: !Ref ContainerPort
         CloudWatchAlarms: !Sub


### PR DESCRIPTION
## Proposed changes
[OLH-2029] Enable canary Deployment in production and integration

### What changed
<!-- Describe the changes in detail - the "what"-->
Conditional change. Removed extra config.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Enabling as part of Canary Initiative.

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

Deployed to dev.
<img width="1329" alt="image" src="https://github.com/user-attachments/assets/e04348c4-1b7d-45ca-8908-a657611b978e">



[OLH-2029]: https://govukverify.atlassian.net/browse/OLH-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ