### PR TITLE
OLH-2046-enable-canary-deployment-in-all-environments-stage-2

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -375,11 +375,6 @@ Resources:
           Subnets:
             - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
             - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
-      TaskDefinition: !Ref TaskDefinition
-      # TaskDefinition: !If
-      #   - UseCanaryDeployment
-      #   - !Ref AWS::NoValue
-      #   - !Ref TaskDefinition
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2046] Enabled required canary deployment resources in all environments and defaulted canary deployment to all at once

### What changed
<!-- Describe the changes in detail - the "what"-->
- Enabled canary deployment in all environments so resources are available
- Defaulted to all at once deployments
- Maintained 10% every 3 mins canary deployment strategy in prod and integration

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Current implementation uses useCanaryDeployment to set which environment's use canary deployment.
If the environment's are changed the 2 stage canary enablement process is required to make it work.
If an environment with canary deployment's enabled is disabled, it causes confusion between target groups which could cause pipeline's to fail and 503's on the frontend.

To resolve this I am repurposing the conditional to use 10% every 3 mins instead which can be updated without risk of breaking pipeline's/ target groups.

This is stage 2 of 2 deployments required.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing
Deployed stage 2 to dev successfully.

[OLH-2046]: https://govukverify.atlassian.net/browse/OLH-2046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ