### PR TITLE
[DFC-644]: Add tracking to activity report pages

### DIFF
--- a/src/components/report-suspicious-activity/index.njk
+++ b/src/components/report-suspicious-activity/index.njk
@@ -17,7 +17,9 @@
       {# account for the possibility of users re-visiting the report page soon after reporting an event, before a report number is known #}
       <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.alreadyReported.noReportNo' | translate }}</p>
     {% endif %}
+    {%set contentId = "5f83e2b4-6c9d-4b98-b68e-43d4f6892b56"%}
   {% else %}
+   {% set contentId = "0252c1d4-c233-48c1-bf4b-a5b124ed8ec2"%}
     {# The event has not been reported yet – show report form #}
     <h1 class="govuk-heading-l">{{ 'pages.reportSuspiciousActivity.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.intro' | translate }}</p>
@@ -42,5 +44,5 @@
       }) }}
     </form>
   {% endif %}
-  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"activity", contentId:"0252c1d4-c233-48c1-bf4b-a5b124ed8ec2",loggedInStatus:true,dynamic:true})}}
+  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"activity", contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/report-suspicious-activity/index.njk
+++ b/src/components/report-suspicious-activity/index.njk
@@ -41,5 +41,6 @@
         "preventDoubleClick": true
       }) }}
     </form>
-{% endif %}
+  {% endif %}
+  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"activity", contentId:"0252c1d4-c233-48c1-bf4b-a5b124ed8ec2",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/report-suspicious-activity/success.njk
+++ b/src/components/report-suspicious-activity/success.njk
@@ -23,4 +23,6 @@
   <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.success.section2.paragraph2' | translate }}</p>
   <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.success.section2.paragraph3' | translate }}</p>
 
+{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"activity", contentId:"e047725a-f19a-448a-9f8d-1e9e08f5c21f",loggedInStatus:true,dynamic:true})}}
+
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

<!-- Describe the changes in detail - the "what"-->

- Implement the Page View Tracker for the` /activity-history/report-activity?` and `/activity-history/report-activity/done `pages.
- Set contentId and taxonomy values dynamically for the activity-history/report-activity?



### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
As part of GA4 CI work

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
(DFC-644)[https://govukverify.atlassian.net/browse/DFC-644]

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

## Testing

<!-- Provide a summary of any manual testing you've done -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
