### PR TITLE
OLH-2052 Add new DWP integration client service card and update existing one

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -863,9 +863,15 @@
       },
       "sqae3L7gOdizeRqFMw_KCDlhcyg": {
         "header": "Repay and manage benefit money you owe",
-        "description": "Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych.",
+        "description": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych.",
         "link_text": "Go to your repay and manage benefit money you owe account",
-        "link_href": "https://idt-rmd-stub.idt.pdu-dev.hcs-eks.dwpcloud.uk/landing?source=your-services"
+        "link_href": "https://repay-my-debt.services.aks-test-ext.np.az.dwpcloud.uk/oidv-sign-in"
+      },
+      "RtE7mP5yzCrdthst1kuVHS1SsSw": {
+        "header": "Repay and manage benefit money you owe",
+        "description": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych.",
+        "link_text": "Go to your repay and manage benefit money you owe account",
+        "link_href": "https://repay-my-debt.services.aks-test-ext.np.az.dwpcloud.uk/oidv-sign-in"
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1020,7 +1020,14 @@
         "header": "Repay and manage benefit money you owe",
         "description": "Use this service if you need to repay money to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your repay and manage benefit money you owe account",
-        "link_href": "https://idt-rmd-stub.idt.pdu-dev.hcs-eks.dwpcloud.uk/landing?source=your-services"
+        "link_href": "https://repay-my-debt.services.aks-test-ext.np.az.dwpcloud.uk/oidv-sign-in"
+      },
+      "RtE7mP5yzCrdthst1kuVHS1SsSw": {
+        "header": "Repay and manage benefit money you owe",
+        "description": "Use this service if you need to repay money to the Department for Work and Pensions (DWP).",
+        "link_text": "Go to your repay and manage benefit money you owe account",
+        "link_text": "Go to your repay and manage benefit money you owe account",
+        "link_href": "https://repay-my-debt.services.aks-test-ext.np.az.dwpcloud.uk/oidv-sign-in"
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Find and use an API from the Department for Education",


### PR DESCRIPTION

## Proposed changes
OLH-2052 Add new DWP integration client service card and update existing one
https://govukverify.atlassian.net/browse/OLH-2052

### What changed
Add new entry and update URL for existing entry in translation files for DWP to test new RP in integration environment only. 


### Why did it change

So that DWP can test their new service cards before releasing to production.

### Related links

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

## Testing

As it is integration environment only, there is no point deploying this to dev environment to check. i confirmed with Ben this is OK and matches what was done before by @alex9smith  as this is not the same as adding a new RP to prod.

## How to review
Code completeness and invalid JSON.