### PR TITLE
OLH-1958-fix-code-pipeline-failing-tests-on-frontend-pipeline

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1345,7 +1345,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 10.0.0.0/16
+      CidrIp: 0.0.0.0/0
       Description: Allows HTTP traffic from anyone on port 80
       IpProtocol: tcp
       FromPort: 80
@@ -1355,7 +1355,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 10.0.0.0/16
+      CidrIp: 0.0.0.0/0
       Description: Allows HTTPS traffic from anyone on port 443
       IpProtocol: tcp
       FromPort: 443

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1345,7 +1345,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 0.0.0.0/0
+      CidrIp: 10.0.0.0/16
       Description: Allows HTTP traffic from anyone on port 80
       IpProtocol: tcp
       FromPort: 80
@@ -1355,7 +1355,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 0.0.0.0/0
+      CidrIp: 10.0.0.0/16
       Description: Allows HTTPS traffic from anyone on port 443
       IpProtocol: tcp
       FromPort: 443
@@ -2138,7 +2138,6 @@ Resources:
   CloudFrontLogsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      # checkov:skip=CKV_AWS_18:This is the access logs bucket. It should not log itself.
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
@@ -2162,6 +2161,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      LoggingConfiguration:
+        DestinationBucketName: !Ref AccessLogsBucket
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -2233,7 +2234,7 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 5
-      Threshold: 0.05
+      Threshold: 5
       TreatMissingData: missing
       Metrics:
         - Id: errorThreshold

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1345,7 +1345,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 0.0.0.0/0
+      CidrIp: 10.0.0.0/16
       Description: Allows HTTP traffic from anyone on port 80
       IpProtocol: tcp
       FromPort: 80
@@ -1355,7 +1355,7 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt ApplicationLoadBalancerSecurityGroup.GroupId
-      CidrIp: 0.0.0.0/0
+      CidrIp: 10.0.0.0/16
       Description: Allows HTTPS traffic from anyone on port 443
       IpProtocol: tcp
       FromPort: 443


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-1958] Security group update to only VPC, Added cloudfront log to access logs, corrected api gateway alarm to 5%

### What changed
<!-- Describe the changes in detail - the "what"-->
1. Security group ingress rule was configured for all internet. Has been changed to 10.0.0.0/16 which is the VPC.
2. Changed CloudFront Logs to use the access logs bucket
3. ApiGateway4xxStatusAlarm false triggers as it is configured for 0.05% instead of 5%

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To resolve pipeline failing tests.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done -->

Left in Dev for ~ a week to validate no issues.


[OLH-1958]: https://govukverify.atlassian.net/browse/OLH-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ