### PR TITLE
OLH-2034 - Add the new header params to the cache policy.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2120,7 +2120,6 @@ Resources:
             HeaderBehavior: whitelist
             Headers:
               - CloudFront-Viewer-Country
-              - CloudFront-Viewer-JA3-Fingerprint
           QueryStringsConfig:
             QueryStringBehavior: none
           EnableAcceptEncodingBrotli: true

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2097,7 +2097,10 @@ Resources:
         CookiesConfig:
           CookieBehavior: all
         HeadersConfig:
-          HeaderBehavior: allViewer
+          HeaderBehavior: allViewerAndWhitelistCloudFront
+          Headers:
+            - CloudFront-Viewer-Country
+            - CloudFront-Viewer-JA3-Fingerprint
         Name: !Sub "${AWS::StackName}-OriginRequestPolicy"
         QueryStringsConfig:
           QueryStringBehavior: all
@@ -2117,7 +2120,7 @@ Resources:
             HeaderBehavior: whitelist
             Headers:
               - CloudFront-Viewer-Country
-              - Cloudfront-viewer-ja3-fingerprint
+              - CloudFront-Viewer-JA3-Fingerprint
           QueryStringsConfig:
             QueryStringBehavior: none
           EnableAcceptEncodingBrotli: true

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2114,7 +2114,10 @@ Resources:
           CookiesConfig:
             CookieBehavior: none
           HeadersConfig:
-            HeaderBehavior: none
+            HeaderBehavior: whitelist
+            Headers:
+              - CloudFront-Viewer-Country
+              - Cloudfront-viewer-ja3-fingerprint
           QueryStringsConfig:
             QueryStringBehavior: none
           EnableAcceptEncodingBrotli: true


### PR DESCRIPTION
## Proposed changes

OLH-2034 - Add the new header params to the cache policy.
To ensure Missing country code / ja3_fingerprint values in Cloudfront Headers are available.

### What changed

In cloudformation template, update the cache policy to include the headers

### Why did it change

To ensure Missing country code / ja3_fingerprint values in Cloudfront Headers are available as part of data sent to TICF using the TICFFraudHeadersFunction cloudfront function
**EDIT** - Guidance from TxMA QA for testing suggests this testing the TxMA event contains the value can only be done in a higher environment like Staging which means we would need this approved on the basis on yes it didn' t break dev and on dev environment, we can visibly see the new parameters

### Related links

https://govukverify.atlassian.net/browse/TT2-2015

<!-- List any related ADRs or RFCs -->

## Checklists


### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

## Testing

Deploy to dev and manually check the new headers are added to the cloudfront cache policy
Run as a user and ensure additional requested data is sent to TICF

## How to review
