### PR TITLE
OLH-1983 Update robots.txt, and add a noindex meta tag

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1366,6 +1366,7 @@ Resources:
             MessageBody: >
               "user-agent: *"
               "disallow: /"
+              "allow: /contact-gov-uk-one-login"
             StatusCode: 200
       Conditions:
         - Field: path-pattern

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -19,6 +19,9 @@
 
     {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
     <!--[if lt IE 9]> <script src="/html5-shiv/html5shiv.js"></script> <![endif]-->
+    {% if not allowCrawl %}
+    <meta name="robots" content="noindex">
+    {% endif %}
 {% endblock %}
 
 {% block pageTitle %}

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -6,6 +6,7 @@
 {% set secondaryContactMethodEnabled = contactPhoneEnabled or contactWebchatEnabled %}
 {% set webchatLang = "welsh" if language == "cy" else "hgsgds" %}
 {% set hideTitleProductName = true %}
+{% set allowCrawl = true %}
 
 {% block head %}
   {{ super() }}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add a line to the robots.txt to allow the contact page to be crawled, this will display the icon in search results

Add a "noindex" meta tag to all pages, unless specifically opted in to crawling.

### Why did it change

The gov.uk icon wasn't displaying when our pages appeared in search results, we suspect that this was because it was disallowed in robots.txt, so it wasn't being crawled.

Robots.txt only stops a page from being crawled directly, but if a third party page links to a page, it can still get crawled. Adding a noindex meta tag stops a page from ever getting crawled.