### PR TITLE
OLH-1705 Change "advisor" to "member of the support team"

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -526,7 +526,7 @@
           "paragraphs1": [
             "Cael help gan gynorthwyydd digidol GOV.UK One Login neu sgwrsio gydag aelod o'r tîm cymorth.",
             "Efallai y gofynnir i chi am eich cod cyfeirio pan fyddwch yn siarad â ni.",
-            "Gallwch sgwrsio'n fyw gydag ymgynghorydd o ddydd Llun i ddydd Gwener, 8am i 8pm.",
+            "Gallwch sgwrsio'n fyw gyda'n tîm cymorth o ddydd Llun i ddydd Gwener, 8am i 8pm.",
             "Mae'r cynorthwyydd digidol bob amser ar gael."
           ],
           "linkText": "Defnyddio gwe-sgwrs",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -524,7 +524,7 @@
         "webchat": {
           "heading": "Gwe-sgwrs",
           "paragraphs1": [
-            "Cael help gan gynorthwyydd digidol GOV.UK One Login neu sgwrs gydag ymgynghorydd.",
+            "Cael help gan gynorthwyydd digidol GOV.UK One Login neu sgwrsio gydag aelod o'r tîm cymorth.",
             "Efallai y gofynnir i chi am eich cod cyfeirio pan fyddwch yn siarad â ni.",
             "Gallwch sgwrsio'n fyw gydag ymgynghorydd o ddydd Llun i ddydd Gwener, 8am i 8pm.",
             "Mae'r cynorthwyydd digidol bob amser ar gael."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -698,7 +698,7 @@
         "webchat": {
           "heading": "Webchat",
           "paragraphs1": [
-            "Get help from GOV.UK One Login’s digital assistant or chat with an advisor.",
+            "Get help from GOV.UK One Login’s digital assistant or chat with a member of the support team.",
             "You might be asked for your reference code when you chat to us.",
             "You can chat live with an advisor Monday to Friday, 8am to 8pm.",
             "The digital assistant is always available."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -700,7 +700,7 @@
           "paragraphs1": [
             "Get help from GOV.UK One Login’s digital assistant or chat with a member of the support team.",
             "You might be asked for your reference code when you chat to us.",
-            "You can chat live with an advisor Monday to Friday, 8am to 8pm.",
+            "You can chat live with our support team Monday to Friday, 8am to 8pm.",
             "The digital assistant is always available."
           ],
           "linkText": "Use webchat",


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Change translations of "advisor" to "member of the support team"

### Why did it change

On the contact triage page we talk about chatting to an 'advisor' via webchat, but in the webchat itself they're calling themselves a 'member of the support team'