### PR TITLE
OLH-2053-endpoint-will-be-changed-to-phone-number-in-the-method-management-api

### DIFF
--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -118,7 +118,6 @@ describe("addMfaAppMethodPost", () => {
       Promise.resolve({
         status: 200,
         data: {
-          endPoint: "endPoint",
           mfaIdentifier: 1,
           methodVerified: true,
           method: {

--- a/src/components/add-mfa-method/tests/add-mfa-methods-controller.test.ts
+++ b/src/components/add-mfa-method/tests/add-mfa-methods-controller.test.ts
@@ -56,7 +56,7 @@ describe("addMfaMethodGet", () => {
         mfaIdentifier: 111111,
         methodVerified: true,
         method: {
-          endPoint: "PHONE",
+          credential: "ABC",
           mfaMethodType: "AUTH_APP",
         },
         priorityIdentifier: "DEFAULT",
@@ -75,7 +75,7 @@ describe("addMfaMethodGet", () => {
         mfaIdentifier: 111111,
         methodVerified: true,
         method: {
-          endPoint: "PHONE",
+          phoneNumber: "070",
           mfaMethodType: "SMS",
         },
         priorityIdentifier: "DEFAULT",
@@ -84,7 +84,7 @@ describe("addMfaMethodGet", () => {
         mfaIdentifier: 2222,
         methodVerified: true,
         method: {
-          endPoint: "PHONE",
+          phoneNumber: "070",
           mfaMethodType: "SMS",
         },
         priorityIdentifier: "BACKUP",
@@ -103,7 +103,7 @@ describe("addMfaMethodGet", () => {
         mfaIdentifier: 111111,
         methodVerified: true,
         method: {
-          endPoint: "PHONE",
+          phoneNumber: "070",
           mfaMethodType: "SMS",
         },
         priorityIdentifier: "DEFAULT",
@@ -112,7 +112,7 @@ describe("addMfaMethodGet", () => {
         mfaIdentifier: 22222,
         methodVerified: true,
         method: {
-          endPoint: "PHONE",
+          phoneNumber: "070",
           mfaMethodType: "SMS",
         },
         priorityIdentifier: "BACKUP",
@@ -121,7 +121,7 @@ describe("addMfaMethodGet", () => {
         mfaIdentifier: 33333,
         methodVerified: true,
         method: {
-          endPoint: "PHONE",
+          phoneNumber: "070",
           mfaMethodType: "SMS",
         },
         priorityIdentifier: "BACKUP",

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -107,7 +107,7 @@ describe("change authenticator app controller", () => {
           methodVerified: true,
           method: {
             mfaMethodType: "SMS",
-            endPoint: "PHONE",
+            phoneNumber: "070",
           },
           priorityIdentifier: "DEFAULT",
         },
@@ -116,6 +116,7 @@ describe("change authenticator app controller", () => {
           priorityIdentifier: "BACKUP",
           method: {
             mfaMethodType: "AUTH_APP",
+            credential: "ABC",
           },
           methodVerified: true,
         },
@@ -153,8 +154,8 @@ describe("change authenticator app controller", () => {
           mfaIdentifier: 111111,
           methodVerified: true,
           method: {
-            endPoint: "PHONE",
             mfaMethodType: "SMS",
+            phoneNumber: "070",
           },
           priorityIdentifier: "DEFAULT",
         },
@@ -163,6 +164,7 @@ describe("change authenticator app controller", () => {
           priorityIdentifier: "BACKUP",
           method: {
             mfaMethodType: "AUTH_APP",
+            credential: "ABC",
           },
           methodVerified: true,
         },

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
@@ -118,7 +118,7 @@ describe("Integration:: change authenticator app", () => {
           {
             mfaIdentifier: 111111,
             methodVerified: true,
-            endPoint: "PHONE",
+            phoneNumber: "070",
             mfaMethodType: "SMS",
             priorityIdentifier: "DEFAULT",
           },

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-service.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-service.test.ts
@@ -41,7 +41,7 @@ describe("changeAuthenticatorAppService", () => {
       priorityIdentifier: "BACKUP",
       method: {
         mfaMethodType: "AUTH_APP",
-        endPoint: "1Password",
+        credential: "ABC",
       },
       methodVerified: true,
     };

--- a/src/components/change-default-method/change-default-method-controllers.ts
+++ b/src/components/change-default-method/change-default-method-controllers.ts
@@ -29,7 +29,7 @@ export async function changeDefaultMethodGet(
     currentMethodType: defaultMethod.method.mfaMethodType,
     phoneNumber:
       defaultMethod.method.mfaMethodType === "SMS"
-        ? getLastNDigits(defaultMethod.method.endPoint, 4)
+        ? getLastNDigits(defaultMethod.method.phoneNumber, 4)
         : null,
   };
 

--- a/src/components/change-default-method/tests/change-default-method-controller.test.ts
+++ b/src/components/change-default-method/tests/change-default-method-controller.test.ts
@@ -51,7 +51,7 @@ describe("change default method controller", () => {
             priorityIdentifier: "DEFAULT",
             method: {
               mfaMethodType: "SMS",
-              endPoint: "12345678",
+              phoneNumber: "12345678",
             },
           },
         ],

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -153,24 +153,22 @@ async function handleAddMfaMethod(
     return false;
   }
 
-  if (defaultMfaMethod.method.mfaMethodType !== "SMS") {
-    return false;
-  }
-
   try {
-    defaultMfaMethod.method.phoneNumber = newPhoneNumber;
-    updateInput.credential = "no-credentials";
-    updateInput.mfaMethod = {
-      ...defaultMfaMethod,
-      mfaIdentifier: defaultMfaMethod.mfaIdentifier + 1,
-      priorityIdentifier: "BACKUP",
-      method: {
-        mfaMethodType: defaultMfaMethod.method.mfaMethodType,
-        phoneNumber: newPhoneNumber,
-      },
-      methodVerified: true,
-    };
-    return await service.addMfaMethodService(updateInput, sessionDetails);
+    if (defaultMfaMethod.method.mfaMethodType === "SMS") {
+      defaultMfaMethod.method.phoneNumber = newPhoneNumber;
+      updateInput.credential = "no-credentials";
+      updateInput.mfaMethod = {
+        ...defaultMfaMethod,
+        mfaIdentifier: defaultMfaMethod.mfaIdentifier + 1,
+        priorityIdentifier: "BACKUP",
+        method: {
+          mfaMethodType: defaultMfaMethod.method.mfaMethodType,
+          phoneNumber: newPhoneNumber,
+        },
+        methodVerified: true,
+      };
+      return await service.addMfaMethodService(updateInput, sessionDetails);
+    }
   } catch (error) {
     logger.error({
       err: `No existing MFA method in handleAddMfaMethod: ${error.message} `,
@@ -201,6 +199,5 @@ export function requestNewOTPCodeGet(req: Request, res: Response): void {
     req.session.user.state.changePhoneNumber.value,
     EventType.ResendCode
   );
-
   return res.redirect(PATH_DATA.CHANGE_PHONE_NUMBER.url);
 }

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -37,7 +37,7 @@ describe("check your phone controller", () => {
             mfaIdentifier: 111111,
             methodVerified: true,
             method: {
-              endPoint: "PHONE",
+              phoneNumber: "070",
               mfaMethodType: "SMS",
             },
             priorityIdentifier: "DEFAULT",
@@ -174,8 +174,8 @@ describe("check your phone controller", () => {
           mfaIdentifier: 111111,
           methodVerified: true,
           method: {
-            endPoint: "07111111111",
             mfaMethodType: "SMS",
+            phoneNumber: "07111111111",
           },
           priorityIdentifier: "DEFAULT",
         },
@@ -207,8 +207,8 @@ describe("check your phone controller", () => {
           mfaIdentifier: 111112,
           methodVerified: true,
           method: {
-            endPoint: "07111111111",
-            mfaMethodType: "AUTH_APP",
+            mfaMethodType: "SMS",
+            phoneNumber: "07111111111",
           },
           priorityIdentifier: "BACKUP",
         },

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -53,7 +53,7 @@ describe("Integration:: check your phone", () => {
             mfaIdentifier: 111111,
             methodVerified: true,
             method: {
-              endPoint: "PHONE",
+              phoneNumber: "070",
               mfaMethodType: "SMS",
             },
             priorityIdentifier: "DEFAULT",
@@ -94,7 +94,7 @@ describe("Integration:: check your phone", () => {
       {
         mfaIdentifier: 111111,
         methodVerified: true,
-        endPoint: "PHONE",
+        phoneNumber: "070",
         mfaMethodType: "SMS",
         priorityIdentifier: "DEFAULT",
       },

--- a/src/components/check-your-phone/tests/check-your-phone-service.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-service.test.ts
@@ -95,8 +95,8 @@ describe("checkYourPhoneService", () => {
       mfaIdentifier: 111111,
       methodVerified: true,
       method: {
-        endPoint: "PHONE",
         mfaMethodType: "SMS",
+        phoneNumber: "PHONE",
       },
       priorityIdentifier: "DEFAULT",
     };

--- a/src/components/delete-mfa-method/delete-mfa-method-controller.ts
+++ b/src/components/delete-mfa-method/delete-mfa-method-controller.ts
@@ -20,7 +20,7 @@ export async function deleteMfaMethodGet(
   }
 
   if (backupMethod.method.mfaMethodType === "SMS") {
-    phoneNumber = getLastNDigits(backupMethod.method.endPoint, 4);
+    phoneNumber = getLastNDigits(backupMethod.method.phoneNumber, 4);
   }
 
   res.render("delete-mfa-method/index.njk", { ...backupMethod, phoneNumber });

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -25,7 +25,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
           let text: string, linkText: string, linkHref: string;
 
           if (mfaMethod.method.mfaMethodType === "SMS") {
-            const phoneNumber = getLastNDigits(mfaMethod.method.endPoint, 4);
+            const phoneNumber = getLastNDigits(mfaMethod.method.phoneNumber, 4);
             text = req
               .t(
                 "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title"
@@ -44,9 +44,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
             );
             linkHref = `${enterPasswordUrl}&type=changeAuthenticatorApp`;
           } else {
-            throw new Error(
-              `Unexpected mfaMethodType: ${mfaMethod.method.mfaMethodType}`
-            );
+            throw new Error(`Unexpected mfaMethodType: ${mfaMethod.method}`);
           }
 
           return {
@@ -64,7 +62,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
             value: string,
             actions = {};
           if (method.method.mfaMethodType === "SMS") {
-            const phoneNumber = getLastNDigits(method.method.endPoint, 4);
+            const phoneNumber = getLastNDigits(method.method.phoneNumber, 4);
             key = req.t(
               "pages.security.mfaSection.summaryList.phoneNumber.title"
             );
@@ -86,9 +84,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
           } else if (method.method.mfaMethodType === "AUTH_APP") {
             key = req.t("pages.security.mfaSection.summaryList.app.title");
           } else {
-            throw new Error(
-              `Unexpected mfaMethodType: ${method.method.mfaMethodType}`
-            );
+            throw new Error(`Unexpected mfaMethodType: ${method.method}`);
           }
 
           return {

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -51,7 +51,7 @@ describe("security controller", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "SMS",
-            endPoint: "xxxxxxx7898",
+            PhoneNumber: "xxxxxxx7898",
           },
           methodVerified: true,
         },
@@ -102,7 +102,7 @@ describe("security controller", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "SMS",
-            endPoint: "xxxxxxx7898",
+            phoneNumber: "xxxxxxx7898",
           },
           methodVerified: true,
         },
@@ -155,7 +155,7 @@ describe("security controller", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "SMS",
-            endPoint: "xxxxxxx7898",
+            PhoneNumber: "xxxxxxx7898",
           },
           methodVerified: true,
         },
@@ -205,7 +205,7 @@ describe("security controller", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "SMS",
-            endPoint: "xxxxxxx7898",
+            PhoneNumber: "xxxxxxx7898",
           },
           methodVerified: true,
         },
@@ -238,7 +238,7 @@ describe("security controller", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "INVALID",
-            endPoint: "xxxxxxx7898",
+            PhoneNumber: "xxxxxxx7898",
           },
           methodVerified: true,
         },
@@ -275,7 +275,7 @@ describe("security controller", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "SMS",
-            endPoint: "xxxxxxx7898",
+            PhoneNumber: "xxxxxxx7898",
           },
           methodVerified: true,
         },

--- a/src/components/security/tests/security-integration.test.ts
+++ b/src/components/security/tests/security-integration.test.ts
@@ -122,7 +122,7 @@ const appWithMiddlewareSetup = async (config: any = {}) => {
       priorityIdentifier: "DEFAULT",
       method: {
         mfaMethodType: "SMS",
-        endPoint: TEST_USER_PHONE_NUMBER,
+        phoneNumber: TEST_USER_PHONE_NUMBER,
       },
       methodVerified: true,
     },
@@ -131,7 +131,7 @@ const appWithMiddlewareSetup = async (config: any = {}) => {
       priorityIdentifier: "DEFAULT",
       method: {
         mfaMethodType: "AUTH_APP",
-        endPoint: "http://mock-endpoint",
+        credential: "http://mock-endpoint",
       },
       methodVerified: true,
     },

--- a/src/components/switch-backup-method/switch-backup-method-controller.ts
+++ b/src/components/switch-backup-method/switch-backup-method-controller.ts
@@ -22,7 +22,7 @@ export async function switchBackupMfaMethodGet(
 
   if (currentBackupMethod.method.mfaMethodType === "SMS") {
     currentBackupPhoneNumber = getLastNDigits(
-      currentBackupMethod.method.endPoint,
+      currentBackupMethod.method.phoneNumber,
       4
     );
   }
@@ -39,7 +39,7 @@ export async function switchBackupMfaMethodGet(
 
   if (currentDefaultMethod.method.mfaMethodType === "SMS") {
     currentDefaultPhoneNumber = getLastNDigits(
-      currentDefaultMethod.method.endPoint,
+      currentDefaultMethod.method.phoneNumber,
       4
     );
   }

--- a/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
@@ -38,7 +38,7 @@ describe("change default method", () => {
         priorityIdentifier: "DEFAULT",
         method: {
           mfaMethodType: "SMS",
-          endPoint: "12345678",
+          phoneNumber: "12345678",
         },
       });
     }

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -130,7 +130,7 @@ describe("addMfaMethodAppConfirmationGet", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "AUTH_APP",
-            endPoint: "12345678",
+            credential: "ABC",
           },
         },
       ],
@@ -156,7 +156,7 @@ describe("addMfaMethodAppConfirmationGet", () => {
           priorityIdentifier: "DEFAULT",
           method: {
             mfaMethodType: "SMS",
-            endPoint: "12345678",
+            phoneNumber: "070",
           },
         },
       ],

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -140,7 +140,7 @@ export async function removeMfaMethodConfirmationGet(
       .t("pages.removeBackupMethod.confirm.message_sms")
       .replace(
         "[phoneNumber]",
-        getLastNDigits(removedMethod.method.endPoint, 4)
+        getLastNDigits(removedMethod.method.phoneNumber, 4)
       );
   }
 
@@ -171,7 +171,7 @@ export async function changeDefaultMfaMethodConfirmationGet(
 
   const phoneNumber =
     defaultMethod.method.mfaMethodType === "SMS"
-      ? getLastNDigits(defaultMethod.method.endPoint, 4)
+      ? getLastNDigits(defaultMethod.method.phoneNumber, 4)
       : null;
 
   const message = phoneNumber

--- a/src/middleware/mfa-methods-legacy.ts
+++ b/src/middleware/mfa-methods-legacy.ts
@@ -12,7 +12,7 @@ export function legacyMfaMethodsMiddleware(
         priorityIdentifier: "DEFAULT",
         method: {
           mfaMethodType: "SMS",
-          endPoint: req.session.user.phoneNumber,
+          phoneNumber: req.session.user.phoneNumber,
         },
         methodVerified: true,
       },
@@ -24,7 +24,7 @@ export function legacyMfaMethodsMiddleware(
         priorityIdentifier: "DEFAULT",
         method: {
           mfaMethodType: "AUTH_APP",
-          endPoint: "Authenticator app",
+          credential: "ABC",
         },
         methodVerified: true,
       },

--- a/src/utils/mfa/types.d.ts
+++ b/src/utils/mfa/types.d.ts
@@ -1,13 +1,9 @@
 export type PriorityIdentifier = "DEFAULT" | "BACKUP";
-export type MfaMethodType = "SMS" | "AUTH_APP";
 
 export interface MfaMethod {
   mfaIdentifier?: number;
   priorityIdentifier: PriorityIdentifier;
-  method: {
-    mfaMethodType: MfaMethodType;
-    endPoint?: string;
-  };
+  method: smsMethod | authAppMethod;
   methodVerified?: boolean;
   smsPhoneNumber?: string;
 }
@@ -16,6 +12,16 @@ export interface AddMfaMethod {
   mfaIdentifier?: number;
   priorityIdentifier: PriorityIdentifier;
   mfaMethodType: MfaMethodType;
+}
+
+interface smsMethod {
+  mfaMethodType: "SMS";
+  phoneNumber?: string;
+}
+
+interface authAppMethod {
+  mfaMethodType: "AUTH_APP";
+  credential?: string;
 }
 
 export interface ProblemDetail {

--- a/src/utils/test/mfa.test.ts
+++ b/src/utils/test/mfa.test.ts
@@ -229,7 +229,7 @@ describe("MFA Function", () => {
       mfaIdentifier: 111111,
       methodVerified: true,
       method: {
-        endPoint: phoneNumber,
+        phoneNumber: phoneNumber,
         mfaMethodType: "SMS",
       },
       priorityIdentifier: "DEFAULT",
@@ -323,8 +323,8 @@ describe("MFA Function", () => {
       mfaIdentifier: 111111,
       methodVerified: true,
       method: {
-        endPoint: "PHONE",
         mfaMethodType: "SMS",
+        phoneNumber: "070",
       },
       priorityIdentifier: "DEFAULT",
     };
@@ -386,8 +386,8 @@ describe("MFA Function", () => {
       mfaIdentifier: 111111,
       methodVerified: true,
       method: {
-        endPoint: "PHONE",
         mfaMethodType: "SMS",
+        phoneNumber: "070",
       },
       priorityIdentifier: "DEFAULT",
     };

--- a/test/unit/middleware/mfa-method-middleware.test.ts
+++ b/test/unit/middleware/mfa-method-middleware.test.ts
@@ -54,7 +54,7 @@ describe("mfaMethodMiddleware", () => {
         mfaIdentifier: 123456,
         priorityIdentifier: "DEFAULT",
         mfaMethodType: "AUTH_APP",
-        endPoint: "http://mock-endpoint",
+        credential: "http://mock-endpoint",
         methodVerified: true,
       },
     ]);

--- a/test/unit/middleware/update-session-middleware.test.ts
+++ b/test/unit/middleware/update-session-middleware.test.ts
@@ -56,10 +56,7 @@ describe("updateSessionMiddleware", () => {
   it("should log a warning for invalid fromURL", () => {
     mockRequest.query.fromURL = "invalid-url";
     updateSessionMiddleware(mockRequest, mockResponse, nextFunction);
-    expect(loggerWarnSpy).to.be.calledWith(
-      { url: "invalid-url" },
-      "TypeError: Invalid URL"
-    );
+    expect(loggerWarnSpy).to.be.calledWith({ url: "invalid-url" });
     expect(loggerWarnSpy).to.be.calledWith(
       { trace: mockResponse.locals.sessionId },
       "fromURL in request query for contact-govuk-one-login page did not pass validation"


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2053] Replaced mfamethod scheme to have SMS phone number instead of endpoint
### What changed
<!-- Describe the changes in detail - the "what"-->
1) mfa schema updated to differentiate between AUTH APP and SMS
2) replaced endpoint with phone number
3) Fixed tests
4) Replaced logic which added backup method as AUTH APP by default 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
In line with mfa api

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example, deploying the branch to dev -->

Deployed updated stub and frontend to dev and changed phone number and added a new SMS mfa backup. 


[OLH-2053]: https://govukverify.atlassian.net/browse/OLH-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ