### PR TITLE
OLH-1990: Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,17 +33,20 @@
 
 ### Testing
 
-<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
-<!-- Delete if changes do NOT include any design updates -->
-- [ ] Design updates have been signed off by a member of the UCD team
-
-<!-- Delete if changes do NOT include any analytics updates -->
-- [ ] Analytics updates have been signed off by a PA
-
 <!-- When working with feature flags, features that are flagged off should not be made available in production -->
 <!-- Delete if changes do NOT include any feature flags -->
 - [ ] Automated test coverage includes features that are flagged off
 
+### Sign-offs
+
+<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
+<!-- Delete if changes do NOT include any design updates -->
+- [ ] Design updates have been signed off by a member of the UCD team
+<!-- Delete if changes do NOT include any analytics updates -->
+- [ ] Analytics updates have been signed off by a PA
+
+
 ## How to review
+
 <!-- Provide a summary of any testing you've done -->
 <!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,10 +31,19 @@
 - [ ] Added to deployment steps
 - [ ] Added to local startup config
 
-## Testing
+### Testing
 
-<!-- Provide a summary of any manual testing you've done -->
+<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
+<!-- Delete if changes do NOT include any design updates -->
+- [ ] Design updates have been signed off by a member of the UCD team
+
+<!-- Delete if changes do NOT include any analytics updates -->
+- [ ] Analytics updates have been signed off by a PA
+
+<!-- When working with feature flags, features that are flagged off should not be made available in production -->
+<!-- Delete if changes do NOT include any feature flags -->
+- [ ] Automated test coverage includes features that are flagged off
 
 ## How to review
-
+<!-- Provide a summary of any testing you've done -->
 <!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
This commit introduces some updates on the PR template. The addition of the feature flag testing tickbox was initially prompted by an incident where a link and a page which were supposed to be behind a feature flag were inadvertently made available in prod.

I also added a UCD review checklist item and PA review checklist item. 
Questions have come up several times about the process of getting changes signed off by UCD so it seemed like a potentially useful reminder to add to the template.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
There have been questions on when changes should be signed off by UCD (or a PA, in the case of analytics). 
There was an incident where a journey that shouldn't have been visible in production yet was accidentally available to users.
<!-- Describe the reason these changes were made - the "why" -->

### Related links
https://govukverify.atlassian.net/browse/OLH-1990
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## How to review
Feed back if any of the wording could be improved, or whether there are any other PR template changes you think might be useful. 
Or conversely, feed back if the new additions are unhelpful to you. 
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
