### PR TITLE
OLH-2076 Collect cloudfront header used to populate connection-port in txMA event

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2110,6 +2110,7 @@ Resources:
           Headers:
             - CloudFront-Viewer-Country
             - CloudFront-Viewer-JA3-Fingerprint
+            - CloudFront-Viewer-Address
         Name: !Sub "${AWS::StackName}-OriginRequestPolicy"
         QueryStringsConfig:
           QueryStringBehavior: all
@@ -2129,6 +2130,7 @@ Resources:
             HeaderBehavior: whitelist
             Headers:
               - CloudFront-Viewer-Country
+              - CloudFront-Viewer-Address
           QueryStringsConfig:
             QueryStringBehavior: none
           EnableAcceptEncodingBrotli: true


### PR DESCRIPTION
## Proposed changes

### What changed

Update our CloudFront policy, to forward the `CloudFront-View-Address` header to the app 

### Why did it change

The `connection_port` header was missing from the `AUTH_DELETE_ACCOUNT` event that we send. I can see from [here
](https://github.com/govuk-one-login/devplatform-fraud-function/blob/53d68c01bc5c0175bfb12081227a1f9b5837aa39/cloudformation/fraud-function/fraud-function.js#L48-L51) that it comes from the `CloudFront-View-Address` header.