### PR TITLE
OLH-2095 - Fix issue with di-account-frontend deployment failing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2130,7 +2130,6 @@ Resources:
             HeaderBehavior: whitelist
             Headers:
               - CloudFront-Viewer-Country
-              - CloudFront-Viewer-Address
           QueryStringsConfig:
             QueryStringBehavior: none
           EnableAcceptEncodingBrotli: true


### PR DESCRIPTION
## Proposed changes

OLH-2095 - Fix issue with di-account-frontend deployment failing

### What changed

Remove Cloudfront-Viewer-Address from Cloudfront cache policy because as per guide here: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-cloudfront-headers.html

CloudFront-Viewer-Address can be added in an origin request policy, but not in a cache policy.

### Why did it change

To fix deployment failures.

### Related links
https://govukverify.atlassian.net/browse/OLH-2076

## Checklists


### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing

Deploy to dev and confirm deployment successful

### Sign-offs



## How to review
Login to aws in dev and confirm with codepipeline deployment completes successfully.