### PR TITLE
OLH-2136: Fix show password script CSP issue

### DIFF
--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -62,7 +62,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript" src="/public/scripts/showPassword.js"></script>
+    <script type="text/javascript" src="/public/scripts/showPassword.js" nonce='{{ scriptNonce }}'></script>
     {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change password", contentId:"00ca6657-4139-43fa-979b-0eb3576fa94c",loggedInStatus:true,dynamic:true})}}
 {% endblock %}
 

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -58,6 +58,6 @@
     {% set contentId = oplValues[requestType].contentId if oplValues[requestType] else "undefined" %}
     {% set taxonomyLevel2Value = oplValues[requestType].taxonomyLevel2 if oplValues[requestType] else "undefined" %}
 
-    <script type="text/javascript" src="/public/scripts/showPassword.js"></script>
+    <script type="text/javascript" src="/public/scripts/showPassword.js" nonce='{{ scriptNonce }}'></script>
     {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:taxonomyLevel2Value, contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
The show password component script was not loading due to the nonce missing from the inline script tag.
This adds the nonce to the script  which should resolve the problem.

### Before (nonce is missing, script is blocked)
<img width="1057" alt="Screenshot 2024-09-18 at 19 05 00" src="https://github.com/user-attachments/assets/00dba693-37c8-4ab5-b6df-5573c20f9860">

### After (with nonce)

<img width="1012" alt="Screenshot 2024-09-18 at 19 04 24" src="https://github.com/user-attachments/assets/41fa12f7-beb8-4156-9ad4-b9b73ed75a2c">
<!-- Describe the changes in detail - the "what"-->

### Why did it change
While users can still enter their password fine without the button, having the button is a very important usability/accessibility aid.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## How to review
Tested change on my local environment.  
Double check that the button is now functioning on all the templates which import this component. 

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
