### PR TITLE
OLH-2137-ucd-fixes-confirmation-pages

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -23,7 +23,7 @@ export const PATH_DATA: Record<
     type: UserJourney.AddMfaMethod,
   },
   ADD_MFA_METHOD_APP_CONFIRMATION: {
-    url: "/add-mfa-method-app-confirmation",
+    url: "/backup-auth-app-confirmation",
     event: EventType.Confirmation,
     type: UserJourney.AddMfaMethod,
   },
@@ -33,7 +33,7 @@ export const PATH_DATA: Record<
     type: UserJourney.AddMfaMethod,
   },
   ADD_MFA_METHOD_SMS_CONFIRMATION: {
-    url: "/add-mfa-method-sms-confirmation",
+    url: "/backup-text-message-confirmation",
     event: EventType.Confirmation,
     type: UserJourney.ChangePhoneNumber,
   },
@@ -63,7 +63,7 @@ export const PATH_DATA: Record<
     event: EventType.ValueUpdated,
   },
   SWITCH_BACKUP_METHOD_CONFIRMATION: {
-    url: "/switch-method-confirm",
+    url: "/switch-methods-confirmation",
     type: UserJourney.SwitchBackupMethod,
     event: EventType.Confirmation,
   },

--- a/src/components/common/confirmation-page/confirmation.njk
+++ b/src/components/common/confirmation-page/confirmation.njk
@@ -1,5 +1,7 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% block backLinkBlock %}
+{% endblock %}
 {% block pageContent %}
     {{ govukPanel({
         titleText: heading

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -75,12 +75,14 @@
           })
           }}
         {% endif %}
+        {% block backLinkBlock %}
         {% if backLink %}
           <a href="{{backLink}}" class="govuk-back-link js-back-link">
             {{ backLinkText }}
             {{'general.back' | translate if not backLinkText}}
           </a>
         {% endif %}
+        {% endblock %}
         {% block beforeContent %}{% endblock %}
 
         <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main" {% if mainLang %} lang="{{ mainLang }}" {% endif %}>

--- a/src/components/delete-mfa-method/delete-mfa-method-controller.ts
+++ b/src/components/delete-mfa-method/delete-mfa-method-controller.ts
@@ -51,7 +51,5 @@ export async function deleteMfaMethodPost(
 
   req.session.removedMfaMethods = [methodToRemove];
 
-  res.redirect(
-    `${PATH_DATA.DELETE_MFA_METHOD_CONFIRMATION.url}?id=${methodToRemove.mfaIdentifier}`
-  );
+  res.redirect(`${PATH_DATA.DELETE_MFA_METHOD_CONFIRMATION.url}`);
 }

--- a/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
+++ b/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
@@ -63,7 +63,7 @@ describe("delete mfa method controller", () => {
     await deleteMfaMethodPost(req as Request, res as Response);
 
     expect(removeFn).to.be.calledWith(1);
-    expect(redirectFn).to.be.calledWith("/remove-backup-confirmation?id=1");
+    expect(redirectFn).to.be.calledWith("/remove-backup-confirmation");
   });
 
   it("should return a 404 if a non existant method is tried", async () => {

--- a/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
@@ -103,7 +103,7 @@ describe("change default method", () => {
       await switchBackupMfaMethodPost(req as Request, res as Response);
 
       expect(changeFn).to.be.calledWith(1);
-      expect(redirectFn).to.be.calledWith("/switch-method-confirm");
+      expect(redirectFn).to.be.calledWith("/switch-methods-confirmation");
     });
 
     it("should return a 404 if the new defualt method doesn't exist", async () => {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -259,23 +259,23 @@
       "confirm": {
         "title": "Add back-up phone number",
         "heading": "You've added a back-up method for getting security codes",
-        "message": "If your default method for getting security codes is not available, you can get a code to your phone number ending in [mobile] instead",
+        "message": "If your default method for getting security codes is not available, you can get a code to your phone number ending with [mobile] instead.",
         "backLink": "Back to Security"
       }
     },
     "removeBackupMethod": {
       "title": "Remove your back-up method for getting security codes",
       "paragraph": "This will delete your back-up method for getting security codes.",
-      "sms": "We'll no longer send security codes by text message to your phone number ending in <strong>[phoneNumber]</strong>",
-      "app": "We'll no longer send security codes to your authenticator app",
+      "sms": "We'll no longer send security codes by text message to your phone number ending with <strong>[phoneNumber]</strong>.",
+      "app": "We'll no longer send security codes to your authenticator app.",
       "button": "Remove back-up method",
       "backLinkText": "Back to security",
       "confirm": {
         "title": "You've removed your back-up method for getting security codes",
-        "heading": "You've removed your back-up method for getting security codes",
-        "message_app": "You'll no longer get security codes to your authenticator app",
-        "message_sms": "You'll no longer get security codes to your phone number ending <strong>[phoneNumber]</strong>",
-        "message_unknown": "You'll no longer get security codes to your backup method"
+        "heading": "You've removed your back-up method for getting security codes.",
+        "message_app": "You'll no longer get security codes to your authenticator app.",
+        "message_sms": "You'll no longer get security codes to your phone number ending <strong>[phoneNumber]</strong>.",
+        "message_unknown": "You'll no longer get security codes to your backup method."
       }
     },
     "activityHistory": {
@@ -517,7 +517,7 @@
     "checkYourPhone": {
       "title": "Check your phone",
       "header": "Check your phone",
-      "text": "We have sent a code to your phone number ending with <strong>[mobile]</strong>",
+      "text": "We have sent a code to your phone number ending with <strong>[mobile]</strong>.",
       "info": {
         "paragraph": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
@@ -538,7 +538,7 @@
     },
     "changeDefaultMethod": {
       "title": "Use a different default method",
-      "currentIsPhone": "Your default method for getting security codes is currently by text message to your phone number ending with <strong>[phoneNumber]</strong>",
+      "currentIsPhone": "Your default method for getting security codes is currently by text message to your phone number ending with <strong>[phoneNumber]</strong>.",
       "switchToApp": "You can use an authenticator app instead",
       "currentIsApp": "Your default method for getting security codes is currently using your authenticator app",
       "switchToPhone": "You can get codes by text message instead.",
@@ -548,7 +548,7 @@
       "confirmation": {
         "title": "Change default method",
         "heading": "You've changed your default method for getting security codes",
-        "app": "Your default method for getting security codes is now your authenticator app",
+        "app": "Your default method for getting security codes is now your authenticator app.",
         "back": "Back to Security"
       }
     },
@@ -608,7 +608,7 @@
       "continue": "Get security code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
       "phoneNumber": {
-        "insetText": "We will send a code to your phone number ending with <strong>[mobile]</strong>",
+        "insetText": "We will send a code to your phone number ending with <strong>[mobile]</strong>.",
         "paragraph": "Text messages can sometimes take a few minutes to arrive."
       },
       "email": {
@@ -619,16 +619,16 @@
     "switchBackupMethod": {
       "title": "Switch your back-up and default methods",
       "newDefaultApp": "Your default method for getting secrity codes will be using your authenticator app.",
-      "newDefaultSms": "Your default method for getting security codes will be text message to your phone number ending in <strong>[phoneNumber]</strong>",
-      "newBackupApp": "Your authenticator app will become your back-up method",
-      "newBackupSms": "Your back-up method will be a text message to your phone number ending in <strong>[phoneNumber]</strong>",
+      "newDefaultSms": "Your default method for getting security codes will be text messages to your phone number ending with <strong>[phoneNumber]</strong>.",
+      "newBackupApp": "Your authenticator app will become your back-up method.",
+      "newBackupSms": "Your back-up method will be a text message to your phone number ending with <strong>[phoneNumber]</strong>.",
       "button": "Switch methods",
       "confirm": {
         "title": "Switch security codes",
         "heading": "You've switched your back-up and default methods for getting security codes",
         "backLinkText": "Back to Security",
-        "messageSms": "We'll send security codes to your phone number ending in <strong>[phoneNumber]</strong>",
-        "messageApp": "You'll use your authenticator app to get security codes to sign in"
+        "messageSms": "We'll send security codes to your phone number ending with <strong>[phoneNumber]</strong>.",
+        "messageApp": "You'll use your authenticator app to get security codes to sign in."
       }
     },
     "contact": {


### PR DESCRIPTION
## Proposed changes
[OLH-2137] UCD Fixes confirmation pages

### What changed
- Updated mfa text displayed to user to have fullstops
- corrected URL's to follow design 
- added backLinkBlock
- override backLinkBlock in confirmation page
- removed ?id= from delete mfa method controller
- replaced text 'phone number ending in' with 'phone number ending with'

### Why did it change

UCD Review

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Sign-offs

<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [ ] Design updates have been signed off by a member of the UCD team
<!-- Delete if changes do NOT include any analytics updates -->
- [ ] Analytics updates have been signed off by a PA

## How to review
Validated changes locally

Reviewer to validate text's with full stops have not included unintended changes and use of backLinkBlock is not problematic due to unfamiliarity with frontend.


[OLH-2137]: https://govukverify.atlassian.net/browse/OLH-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ