### PR TITLE
OLH-2175 - Fix Dynatrace RUM script CSP issue

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -13,6 +13,8 @@ export const helmetConfiguration: HelmetOptions = {
         "https://*.googletagmanager.com",
         "https://*.google-analytics.com",
         "https://*.analytics.google.com",
+        "https://*.ruxit.com",
+        "https://*.dynatrace.com",
       ],
       imgSrc: [
         "'self'",
@@ -28,6 +30,8 @@ export const helmetConfiguration: HelmetOptions = {
         "https://*.google-analytics.com",
         "https://*.analytics.google.com",
         "https://*.g.doubleclick.net",
+        "https://*.ruxit.com",
+        "https://*.dynatrace.com",
       ],
       formAction: ["'self'", "https://*.account.gov.uk"],
     },


### PR DESCRIPTION
## Proposed changes
OLH-2175 - Fix Dynatrace RUM script CSP issue

### What changed

Relax CSP to allow script from dynatrace and ruxit to load.


### Why did it change
So that scripts from dynatrace can load.

### Related links
Previous PRs to get RUM working on One Login Home: https://github.com/govuk-one-login/di-account-management-frontend/pull/1624

Previous User Story: https://govukverify.atlassian.net/browse/OLH-1973

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing

Due to RUM being available in staging upwards, not able to test in lower environments.

### Sign-offs


## How to review