### PR TITLE
OLH-2207: Fix translation errors

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -24,7 +24,7 @@
     {% endif %}
     {% set emailParagraphs =  'pages.contact.section3.email.paragraphs' | translate({ returnObjects: true }) %}
     {% for paragraph in emailParagraphs %}
-      <p class="govuk-body">{{ paragraph | safe | replace('[emailServiceLinkHref]', contactEmailServiceUrl | translate ) }}</p>
+      <p class="govuk-body">{{ paragraph | safe | replace('[emailServiceLinkHref]', contactEmailServiceUrl ) }}</p>
     {% endfor %}
   </section>
 {% endset %}

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -76,7 +76,7 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
                   href: `${enterPasswordUrl}&type=changePhoneNumber`,
                   text: req.t("general.change"),
                   visuallyHiddenText: req.t(
-                    "pages.security.mfaSection.summaryList.app.hiddenText"
+                    "pages.security.mfaSection.summaryList.phoneNumber.hiddenText"
                   ),
                 },
               ],

--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -88,14 +88,7 @@
         {% endfor %}
       </ul>
       {% endif %}
-      {% set detailsHTML %}
-        <p class="govuk-body">{{ 'pages.yourServices.informationBox.details.paragraph' | translate }}</p>
-         <ul class="govuk-list govuk-list--bullet">
-          {% for serviceLink in serviceLinks %}
-            <li><a class="govuk-link" href="{{ serviceLink["href"] }}">{{ serviceLink["text"] }}</a></li>
-          {% endfor %}
-        </ul>
-      {% endset %}
+
       <div class="information-box">
         <h2 class="govuk-heading-m">{{ 'pages.yourServices.informationBox.heading' | translate }}</h2>
         <p class="govuk-body">{{ 'pages.yourServices.informationBox.paragraph1' | translate }}</p>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -149,8 +149,7 @@
             "hiddenText": "Rhif ffôn"
           },
           "app": {
-            "title": "Ap dilysydd",
-            "hiddenText": "Ap dilysydd"
+            "title": "Ap dilysydd"
           }
         }
       },


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Logs in cloudwatch were showing multiple errors flagging that key '/track-and-redirect' was missing for the en and cy languages. There was no such key in our translation files. I traced it back to the contact triage page where the nunjucks translate filter was accidentally used on a local variable. This didn't have any user-facing consequence so it went unnoticed for a while.

I addressed a couple other errors at the same time:
- on the your services page, it seems like the details element was removed but the njk html block that used to be its content was not. The contents of that nunjucks block were leading to a translation error as the relevant strings had been removed from the translation files
- on the security page, the translation being passed as visually hidden text for the phone number "change" link was incorrect

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Reduce errors being logged
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## How to review
Tested by stepping through the affected page(s) locally.
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
