### PR TITLE
OLH-2132: label contact centre hours as UK time

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -527,7 +527,7 @@
           "paragraphs1": [
             "Cael help gan gynorthwyydd digidol GOV.UK One Login neu sgwrsio gydag aelod o'r tîm cymorth.",
             "Efallai y gofynnir i chi am eich cod cyfeirio pan fyddwch yn siarad â ni.",
-            "Gallwch sgwrsio'n fyw gyda'n tîm cymorth o ddydd Llun i ddydd Gwener, 8am i 8pm.",
+            "Gallwch sgwrsio'n fyw gyda'n tîm cymorth o ddydd Llun i ddydd Gwener, 8am i 8pm amser y DU.",
             "Mae'r cynorthwyydd digidol bob amser ar gael."
           ],
           "linkText": "Defnyddio gwe-sgwrs",
@@ -544,7 +544,7 @@
               "Y tu allan i'r DU:<br><strong>+44 208 629 0008</strong>"
             ]
           },
-          "paragraph2": "Gallwch ein ffonio o ddydd Llun i ddydd Gwener, 8am i 8pm.",
+          "paragraph2": "Gallwch ein ffonio o ddydd Llun i ddydd Gwener, 8am i 8pm amser y DU.",
           "callChargesLinkText": "Darganfyddwch fwy am gostau galwadau",
           "waitingTimeWarning": "Mae amseroedd aros hir ar y ffôn ar hyn o bryd. Os nad yw'ch galwad yn un brys, rhowch gynnig arall yn nes ymlaen neu <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">cwblhewch y ffurflen gyswllt</a>."
         },
@@ -553,7 +553,7 @@
           "paragraphs": [
             "<a class=\"govuk-link\" href=\"[emailServiceLinkHref]\">Cwblhewch y ffurflen gyswllt</a>  i ofyn am help.",
             "Byddwn yn ateb drwy e-bost o fewn 2 ddiwrnod gwaith.",
-            "Byddwn yn ymateb yn ystod oriau swyddfa:<br>Dydd Llun i ddydd Gwener, 9:30am i 5:30pm"
+            "Byddwn yn ymateb yn ystod oriau swyddfa:<br>Dydd Llun i ddydd Gwener, 9:30am i 5:30pm amser y DU"
           ]
         }
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -695,7 +695,7 @@
           "paragraphs1": [
             "Get help from GOV.UK One Login’s digital assistant or chat with a member of the support team.",
             "You might be asked for your reference code when you chat to us.",
-            "You can chat live with our support team Monday to Friday, 8am to 8pm.",
+            "You can chat live with our support team Monday to Friday, 8am to 8pm UK time.",
             "The digital assistant is always available."
           ],
           "linkText": "Use webchat",
@@ -710,7 +710,7 @@
               "<strong>Outside the UK:</strong><br>+44 208 629 0008"
             ]
           },
-          "paragraph2": "You can call us Monday to Friday, 8am to 8pm.",
+          "paragraph2": "You can call us Monday to Friday, 8am to 8pm UK time.",
           "callChargesLinkText": "Find out about call charges",
           "waitingTimeWarning": "There are currently long waiting times on the phone. If your call is not urgent, try again later or <a class=\"govuk-link\" href=\"[contactEmailServiceUrl]\" rel=\"nofollow\">fill in the contact form</a>."
         },
@@ -719,7 +719,7 @@
           "paragraphs": [
             "<a class=\"govuk-link\" href=\"[emailServiceLinkHref]\">Fill in the contact form</a> to ask for help.",
             "We’ll reply by email within 2 days.",
-            "We’ll respond during office hours:<br>Monday to Friday, 9:30am to 5:30pm"
+            "We’ll respond during office hours:<br>Monday to Friday, 9:30am to 5:30pm UK time"
           ]
         }
       },


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed and why
There was a request to label contact centre hours as UK time as some RPs have large numbers of users outside of the UK.
The content change recommended has been to add "UK time" to the different contact channels.

| Changed content in English  | Changed content in Welsh |
| ------------- | ------------- |
| ![Screenshot 2024-10-23 at 09 46 30](https://github.com/user-attachments/assets/c0038590-a7b6-491c-913b-b35a719257fc) | ![Screenshot 2024-10-23 at 09 47 37](https://github.com/user-attachments/assets/6836cb8f-6629-4f3f-a3e8-dfff8d981112) |

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Sign-offs
- [x] Design updates have been signed off by a member of the UCD team



<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
