### PR TITLE
OLH-2217-validate-deregistration-delay-timeout-of-the-target-groups-is-higher-than-the-idle-timeout-of-the-alb

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1201,7 +1201,7 @@ Resources:
       UnhealthyThresholdCount: 2
       TargetGroupAttributes:
         - Key: "deregistration_delay.timeout_seconds"
-          Value: "5"
+          Value: "62"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ApplicationLoadBalancerTargetGroup"
@@ -1236,7 +1236,7 @@ Resources:
       UnhealthyThresholdCount: 2
       TargetGroupAttributes:
         - Key: "deregistration_delay.timeout_seconds"
-          Value: "5"
+          Value: "62"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ApplicationLoadBalancerTargetGroupGreen"

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ const port: number | string = process.env.PORT || 6001;
     .on("error", (error: Error) => {
       logger.error(`Unable to start server because of ${error.message}`);
     });
-  server.keepAliveTimeout = 61 * 1000;
+  server.keepAliveTimeout = 65 * 1000;
   server.headersTimeout = 91 * 1000;
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2217] Adjust ALB timeouts
### What changed
Increased node KeepAliveTimeout to 65s as there was not enough gap for other stuff to happen.
Increased ALB Target group Deregistration timeout to 62s following RFC 0083.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Optimising EC2 scaling.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
https://github.com/govuk-one-login/architecture/blob/913c04af8b57e2cdce07c4b242a409690852d527/rfc/0083-express-on-ecs.md

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or change

[OLH-2217]: https://govukverify.atlassian.net/browse/OLH-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ