### PR TITLE
OLH-2219-use-tini-as-your-pid-1-handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
 FROM node:20.18.0-alpine@sha256:c13b26e7e602ef2f1074aef304ce6e9b7dd284c419b35d89fcf3cc8e44a8def9 as builder
+
 ENV HUSKY=0
+
 WORKDIR /app
+
 COPY package.json ./
 COPY package-lock.json ./
 COPY tsconfig.json ./
 COPY ./src ./src
 COPY ./@types ./@types
+
 RUN npm install && npm run build && npm run clean-modules && npm install --production=true
 
 FROM node:20.18.0-alpine@sha256:c13b26e7e602ef2f1074aef304ce6e9b7dd284c419b35d89fcf3cc8e44a8def9 as final
-RUN apk --no-cache add curl
+
+RUN ["apk", "add", "--no-cache", "tini"]
+RUN ["apk", "add", "--no-cache", "curl"]
+
 WORKDIR /app
+
 COPY --chown=node:node --from=builder /app/package*.json ./
 COPY --chown=node:node --from=builder /app/node_modules/ node_modules
 COPY --chown=node:node --from=builder /app/dist/ dist
@@ -21,7 +29,12 @@ ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 ENV NODE_ENV "production"
 ENV PORT 6001
-
 EXPOSE $PORT
+
+HEALTHCHECK CMD curl --fail http://localhost:6001/healthcheck || exit 1
+
 USER node
+
+ENTRYPOINT ["tini", "--"]
+
 CMD ["npm", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7163,18 +7163,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/loglevel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
-    },
     "node_modules/loopbench": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/loopbench/-/loopbench-1.2.0.tgz",


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
<!-- Describe the changes in detail - the "what"-->
[OLH-2219] - Set tini as pid1 handler

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Advice in RFC for frontend performance improvements

### Related links
https://github.com/govuk-one-login/architecture/blob/913c04af8b57e2cdce07c4b242a409690852d527/rfc/0083-express-on-ecs.md

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

<!-- When working with feature flags, features that are flagged off should not be made available in production -->
<!-- Delete if changes do NOT include any feature flags -->
- [ ] Automated test coverage includes features that are flagged off

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
Deployed to Dev


[OLH-2219]: https://govukverify.atlassian.net/browse/OLH-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ