### PR TITLE
OLH-2236 Resolve Trivy DB rate limit error

### DIFF
--- a/.github/workflows/validate-docker-image-dev.yml
+++ b/.github/workflows/validate-docker-image-dev.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@master # pin@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 
@@ -64,7 +64,9 @@ jobs:
           docker build -t $DEV_ECR_REGISTRY/$DEV_ECR_REPOSITORY:$IMAGE_TAG .
 
       - name: Vulnerability Scan
-        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee # pin@master
+        uses: aquasecurity/trivy-action@cf990b19d84bbbe1eb8833659989a7c1029132e3 # pin@master
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.DEV_ECR_REPOSITORY }}:latest
           format: "table"

--- a/.github/workflows/validate-docker-image-dev.yml
+++ b/.github/workflows/validate-docker-image-dev.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
+      - uses: actions/checkout@master # pin@v3
         with:
           ref: ${{ inputs.gitRef || github.ref }}
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2236] Resolve Trivy DB rate limit error

### What changed
<!-- Describe the changes in detail - the "what"-->

NOTE: This is the temp fix suggested by the Trivy Action team while they continue to investigate a solution 

GCHR have changed something / trivy action has become a lot more popular leading to the db exceeding the ceiling traffic of 44,000 requests per minute from all traffic. The team themselves are unsure what the fix is but have provided a temporary solution through a db mirror. Additionally, in a newer version of trivy action they have supported caching which will lead to less calls to the endpoint.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
If the rate limit was reached on the public endpoint we were blocked from merging our PR's into main. I did not see a current method to skip this but we can explore this in the future. Temp solution was to wait a minute and then try again.

### Related links
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
https://github.com/aquasecurity/trivy/discussions/7668

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
Validated the db mirror was used along with the caching.


[OLH-2236]: https://govukverify.atlassian.net/browse/OLH-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ