### PR TITLE
OLH-2269 - Repay my debt: update product URL and restore non-prod service cards

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -688,7 +688,7 @@
         "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych",
         "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
         "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
@@ -903,11 +903,23 @@
         "link_text": "Dod o hyd i wasanaeth CThEF rydych ei angen",
         "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs.cy"
       },
+      "iOf3hyG7eymusbSUS6LgFeQ7AtU": {
+        "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych.",
+        "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
+        "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
+        "link_href": "http://localhost:8000/landing?source=your-services"
+      },
+      "sqae3L7gOdizeRqFMw_KCDlhcyg": {
+        "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych.",
+        "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
+        "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
+        "link_href": "https://repay-my-debt.services.aks-test-ext.np.az.dwpcloud.uk/oidv-sign-in"
+      },
       "RtE7mP5yzCrdthst1kuVHS1SsSw": {
         "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych",
         "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
         "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
@@ -1202,7 +1214,7 @@
         "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych",
         "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
         "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Gwneud cais am dystysgrif allforio",
@@ -1421,7 +1433,7 @@
         "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych",
         "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
         "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Gwneud cais am dystysgrif allforio",
@@ -1640,7 +1652,7 @@
         "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych",
         "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
         "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Gwneud cais am dystysgrif allforio",
@@ -1859,7 +1871,7 @@
         "header": "Ad-dalu a rheoli arian budd-dal sy'n ddyledus gennych",
         "description": "Ad-dalu unrhyw arian sy'n ddyledus gennych i'r Adran Gwaith a Phensiynau (DWP).",
         "link_text": "Ewch i Ad-dalu a rheoli arian budd-dal sy’n ddyledus gennych",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Gwneud cais am dystysgrif allforio",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -854,7 +854,7 @@
         "header": "Repay and manage benefit money you owe",
         "description": "Repay any money you owe to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your Repay and manage benefit money you owe account",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Find and use an API from the Department for Education",
@@ -1075,11 +1075,23 @@
         "link_text": "Find the HMRC service you need",
         "link_href": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       },
+      "iOf3hyG7eymusbSUS6LgFeQ7AtU": {
+        "header": "Repay and manage benefit money you owe",
+        "description": "Use this service if you need to repay money to the Department for Work and Pensions (DWP).",
+        "link_text": "Go to your Repay and manage benefit money you owe account",
+        "link_href": "http://localhost:8000/landing?source=your-services"
+      },
+      "sqae3L7gOdizeRqFMw_KCDlhcyg": {
+        "header": "Repay and manage benefit money you owe",
+        "description": "Use this service if you need to repay money to the Department for Work and Pensions (DWP).",
+        "link_text": "Go to your Repay and manage benefit money you owe account",
+        "link_href": "https://repay-my-debt.services.aks-test-ext.np.az.dwpcloud.uk/oidv-sign-in"
+      },
       "RtE7mP5yzCrdthst1kuVHS1SsSw": {
         "header": "Repay and manage benefit money you owe",
         "description": "Repay any money you owe to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your Repay and manage benefit money you owe account",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
         "header": "Find and use an API from the Department for Education",
@@ -1380,7 +1392,7 @@
         "header": "Repay and manage benefit money you owe",
         "description": "Repay any money you owe to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your Repay and manage benefit money you owe account",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Apply for an export certificate",
@@ -1605,7 +1617,7 @@
         "header": "Repay and manage benefit money you owe",
         "description": "Repay any money you owe to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your Repay and manage benefit money you owe account",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Apply for an export certificate",
@@ -1830,7 +1842,7 @@
         "header": "Repay and manage benefit money you owe",
         "description": "Repay any money you owe to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your Repay and manage benefit money you owe account",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Apply for an export certificate",
@@ -2055,7 +2067,7 @@
         "header": "Repay and manage benefit money you owe",
         "description": "Repay any money you owe to the Department for Work and Pensions (DWP).",
         "link_text": "Go to your Repay and manage benefit money you owe account",
-        "link_href": "http://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
+        "link_href": "https://www.repay-manage-benefit-owed.service.gov.uk/oidv-sign-in"
       },
       "dbtApplyForAnExportCertificate": {
         "header": "Apply for an export certificate",


### PR DESCRIPTION
## Proposed changes

OLH-2269 - Repay my debt: update production URL and restore non-production client service cards' signed in state URLs


### What changed

DWP is different and cleanup activity to remove several integration service cards was not necessary. Also an http URL was initially provided rather than an https URL.

### Why did it change

To align the service cards accross all environments to DWPs requirements.

### Related links

Initial work was done via this PR: https://github.com/govuk-one-login/di-account-management-frontend/pull/1794/files

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing

Deploy to dev and test

### Sign-offs


## How to review
