### PR TITLE
OLH-2244: style guide formatting correction

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -875,9 +875,9 @@
         "link_href": "https://fishingpermitsandcatches.service.gov.wales"
       },
       "Gk-D7WMvytB44Nze7oEC5KcThQZ4yl7sAA": {
-        "header": "Register of immigration advisors",
+        "header": "Register of immigration advisers",
         "description": "Authorise and register an immigration adviser or organisation.",
-        "link_text": "Go to your Register of immigration advisors account",
+        "link_text": "Go to your Register of immigration advisers account",
         "link_href": "https://portal.oisc.gov.uk/"
       },
       "XbPzF-ccO0utCxlifxSyA4Ng0API2XTCQQ": {
@@ -1124,9 +1124,9 @@
         "link_href": "https://fishingpermitsandcatches.service.gov.wales"
       },
       "Gk-D7WMvytB44Nze7oEC5KcThQZ4yl7sAA": {
-        "header": "Register of immigration advisors",
+        "header": "Register of immigration advisers",
         "description": "Authorise and register an immigration adviser or organisation.",
-        "link_text": "Go to your Register of immigration advisors account",
+        "link_text": "Go to your Register of immigration advisers account",
         "link_href": "https://portal.oisc.gov.uk/"
       },
       "XbPzF-ccO0utCxlifxSyA4Ng0API2XTCQQ": {
@@ -1355,9 +1355,9 @@
         "link_href": "https://fishingpermitsandcatches.service.gov.wales"
       },
       "iaa": {
-        "header": "Register of immigration advisors",
+        "header": "Register of immigration advisers",
         "description": "Authorise and register an immigration adviser or organisation.",
-        "link_text": "Go to your Register of immigration advisors account",
+        "link_text": "Go to your Register of immigration advisers account",
         "link_href": "https://portal.oisc.gov.uk/"
       },
       "prisonVisits": {
@@ -1592,9 +1592,9 @@
         "link_href": "https://fishingpermitsandcatches.service.gov.wales"
       },
       "iaa": {
-        "header": "Register of immigration advisors",
+        "header": "Register of immigration advisers",
         "description": "Authorise and register an immigration adviser or organisation.",
-        "link_text": "Go to your Register of immigration advisors account",
+        "link_text": "Go to your Register of immigration advisers account",
         "link_href": "https://portal.oisc.gov.uk/"
       },
       "prisonVisits": {
@@ -1829,9 +1829,9 @@
         "link_href": "https://fishingpermitsandcatches.service.gov.wales"
       },
       "iaa": {
-        "header": "Register of immigration advisors",
+        "header": "Register of immigration advisers",
         "description": "Authorise and register an immigration adviser or organisation.",
-        "link_text": "Go to your Register of immigration advisors account",
+        "link_text": "Go to your Register of immigration advisers account",
         "link_href": "https://portal.oisc.gov.uk/"
       },
       "prisonVisits": {
@@ -2066,9 +2066,9 @@
         "link_href": "https://fishingpermitsandcatches.service.gov.wales"
       },
       "iaa": {
-        "header": "Register of immigration advisors",
+        "header": "Register of immigration advisers",
         "description": "Authorise and register an immigration adviser or organisation.",
-        "link_text": "Go to your Register of immigration advisors account",
+        "link_text": "Go to your Register of immigration advisers account",
         "link_href": "https://portal.oisc.gov.uk/"
       },
       "prisonVisits": {


### PR DESCRIPTION
## Proposed changes

The style guide states we should use "adviser" with an "e" as opposed to "advisor" with an "o".
Correct all instances of "advisor" to "adviser", for consistency.


## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
