### PR TITLE
BAU: remove redundant call to `showPassword` script

### DIFF
--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -58,7 +58,6 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript" src="/public/scripts/showPassword.js" nonce='{{ scriptNonce }}'></script>
     {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change password", contentId:"00ca6657-4139-43fa-979b-0eb3576fa94c",loggedInStatus:true,dynamic:true})}}
 {% endblock %}
 


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
The `showPassword` script has been removed as part of the work to replace the OLH local show password component with the DS equivalent in this PR [#1850](https://github.com/govuk-one-login/di-account-management-frontend/pull/1850)

I missed this `<script>` tag in the process of removing the old component. All assets related to this component are now automatically imported from the DS package (`govuk-frontend`) so this is not needed anymore.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This script no longer exists so there is a 404 error on the change password page.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
