### PR TITLE
OLH-2163 - update analytics package to 3.0.1

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -184,8 +184,9 @@ Mappings:
       SUPPORTMETHODMANAGEMENT: "1"
       UNIVERSALANALYTICSGTMCONTAINERID: "GTM-TK92W68"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-KD86CMZ"
-      GA4DISABLED: "false"
-      UADISABLED: "false"
+      GA4ENABLED: "true"
+      UAENABLED: "true"
+      SELECTTRACKINGENABLED: "true"
       SUPPORTADDBACKUPMFA: "1"
       SUPPORTCHANGEMFA: "1"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
@@ -221,8 +222,9 @@ Mappings:
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       UNIVERSALANALYTICSGTMCONTAINERID: "GTM-TK92W68"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-KD86CMZ"
-      GA4DISABLED: "false"
-      UADISABLED: "false"
+      GA4ENABLED: "true"
+      UAENABLED: "true"
+      SELECTTRACKINGENABLED: "true"
       LANGUAGETOGGLE: "1"
       DTRUMURL: ""
     staging:
@@ -254,8 +256,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "GTM-TK92W68"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-KD86CMZ"
-      GA4DISABLED: "false"
-      UADISABLED: "false"
+      GA4ENABLED: "true"
+      UAENABLED: "true"
+      SELECTTRACKINGENABLED: "true"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"
       DTRUMURL: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/e87dc9cd0e7082fb_complete.js"
@@ -288,8 +291,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "TBD"
       GOOGLEANALYTICS4GTMCONTAINERID: "TBD"
-      GA4DISABLED: "true"
-      UADISABLED: "true"
+      GA4ENABLED: "false"
+      UAENABLED: "false"
+      SELECTTRACKINGENABLED: "false"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"
       DTRUMURL: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/416cd438acc3a6f_complete.js"
@@ -322,8 +326,9 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       UNIVERSALANALYTICSGTMCONTAINERID: "GTM-TT5HDKV"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-K4PBJH3"
-      GA4DISABLED: "false"
-      UADISABLED: "false"
+      GA4ENABLED: "true"
+      UAENABLED: "true"
+      SELECTTRACKINGENABLED: "false"
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"
       DTRUMURL: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf04188tda/b9835209cd235d3a_complete.js"
@@ -854,12 +859,19 @@ Resources:
                   !Ref Environment,
                   GOOGLEANALYTICS4GTMCONTAINERID,
                 ]
-            - Name: "GA4_DISABLED"
+            - Name: "GA4_ENABLED"
               Value:
-                !FindInMap [EnvironmentVariables, !Ref Environment, GA4DISABLED]
-            - Name: "UA_DISABLED"
+                !FindInMap [EnvironmentVariables, !Ref Environment, GA4ENABLED]
+            - Name: "UA_ENABLED"
               Value:
-                !FindInMap [EnvironmentVariables, !Ref Environment, UADISABLED]
+                !FindInMap [EnvironmentVariables, !Ref Environment, UAENABLED]
+            - Name: "SELECT_TRACKING_ENABLED"
+              Value:
+                !FindInMap [
+                  EnvironmentVariables,
+                  !Ref Environment,
+                  SELECTTRACKINGENABLED,
+                ]
             - Name: "ACCESSIBILITY_STATEMENT_URL"
               Value:
                 !FindInMap [

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@aws-sdk/client-sqs": "^3.699.0",
         "@aws-sdk/lib-dynamodb": "^3.699.0",
         "@aws-sdk/util-dynamodb": "^3.609.0",
-        "@govuk-one-login/frontend-analytics": "2.0.1",
+        "@govuk-one-login/frontend-analytics": "^3.0.1",
         "@govuk-one-login/frontend-language-toggle": "^1.1.0",
         "@govuk-one-login/frontend-vital-signs": "^0.0.4",
         "axios": "^1.7.8",
@@ -1782,11 +1782,12 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-2.0.1.tgz",
-      "integrity": "sha512-8xAsQrRomVYxedFOQ8JDVdYx1JReJevSjU5EDZlcS/x3PhpCxm9DHjEqyOIvTo34zkFFoI4f2um6YkdD9IRQAg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.0.1.tgz",
+      "integrity": "sha512-Si1ZHG+RV4JBdDBH2bAAJFHRxnukExeix/JOL12prMThUkLsnZbamgPUAcVoByZRydYYXzilJgRw7PNiO1g1Kg==",
       "dependencies": {
-        "copy-webpack-plugin": "^12.0.2"
+        "copy-webpack-plugin": "^12.0.2",
+        "loglevel": "^1.9.1"
       }
     },
     "node_modules/@govuk-one-login/frontend-language-toggle": {
@@ -7549,6 +7550,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/loopbench": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/client-sqs": "^3.699.0",
     "@aws-sdk/lib-dynamodb": "^3.699.0",
     "@aws-sdk/util-dynamodb": "^3.609.0",
-    "@govuk-one-login/frontend-analytics": "2.0.1",
+    "@govuk-one-login/frontend-analytics": "^3.0.1",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-vital-signs": "^0.0.4",
     "axios": "^1.7.8",

--- a/src/components/change-default-method/index.njk
+++ b/src/components/change-default-method/index.njk
@@ -1,17 +1,21 @@
 {% extends "common/layout/base-page.njk" %}
 
 {% block pageContent %}
-        <h1 class="govuk-heading-l">{{ "pages.changeDefaultMethod.title" | translate }}</h1>
+  <h1 class="govuk-heading-l">{{ "pages.changeDefaultMethod.title" | translate }}</h1>
 
-        {% if currentMethodType == "SMS" %}
-          <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsPhone" | translate | safe | replace("[phoneNumber]", phoneNumber) }}</p>
-          <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToApp" | translate }}</p>
-          <a href='{{ "CHANGE_DEFAULT_METHOD_APP" | getPath }}' class="govuk-button" data-module="govuk-button">{{ "pages.changeDefaultMethod.setUpAppButton" | translate }}</a>
-        {% endif %}
+  {% if currentMethodType == "SMS" %}
+    <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsPhone" | translate | safe | replace("[phoneNumber]", phoneNumber) }}</p>
+    <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToApp" | translate }}</p>
+    <a href='{{ "CHANGE_DEFAULT_METHOD_APP" | getPath }}' class="govuk-button" data-module="govuk-button">{{ "pages.changeDefaultMethod.setUpAppButton" | translate }}</a>
+  {% endif %}
 
-        {% if currentMethodType == "AUTH_APP" %}
-          <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsApp" | translate }}</p>
-          <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToPhone" | translate }}</p>
-          <a href='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}' class="govuk-button" data-module="govuk-button">{{ "pages.changeDefaultMethod.setUpPhoneButton" | translate }}</a>
-        {% endif %}
-    </form>{% endblock pageContent %}
+  {% if currentMethodType == "AUTH_APP" %}
+    <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsApp" | translate }}</p>
+    <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToPhone" | translate }}</p>
+    <a href='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}'
+      class="govuk-button"
+      data-module="govuk-button"
+      data-nav="true"
+      data-link='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}'>{{ "pages.changeDefaultMethod.setUpPhoneButton" | translate }}</a>
+  {% endif %}
+{% endblock %}

--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -15,9 +15,10 @@
       <p class="govuk-body">{{'error.error404.content.paragraph1' | translate }}</p>
       <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
       {{ govukButton({
-          "text": buttonText,
-          "href": accountHome
-          }) }}
+        "text": buttonText,
+        "href": accountHome,
+        "attributes": {"data-nav": true,"data-link": accountHome}
+      }) }}
     </div>
   </div>
   {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"404",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"undefined", contentId:"undefined",loggedInStatus:true,dynamic:true})}}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -155,10 +155,16 @@
         ga4ContainerId: "{{ga4ContainerId}}",
         uaContainerId: "{{uaContainerId}}"
       }, {
-        disableGa4Tracking: {{isGa4Disabled}},
-        disableUaTracking: {{isUaDisabled}},
+        enableGa4Tracking: {{isGa4Enabled}},
+        enableUaTracking: {{isUaEnabled}},
         cookieDomain: "{{analyticsCookieDomain}}",
-        isDataSensitive: true
+        isDataSensitive: true,
+        enablePageViewTracking: true,
+        enableFormResponseTracking: true,
+        enableFormChangeTracking: true,
+        enableFormErrorTracking: true,
+        enableNavigationTracking: true,
+        enableSelectContentTracking: {{isSelectContentTrackingEnabled}}
       });
     }
   </script>

--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -16,7 +16,7 @@
       actions: {
         items: [
           {
-            href: enterPasswordUrl + "&type=changeEmail&edit=true",
+            href: enterPasswordUrl + "&type=changeEmail",
             text: 'pages.security.accountDetails.summaryList.changeEmail' | translate
           }
         ]
@@ -33,7 +33,7 @@
       actions: {
         items: [
           {
-            href: enterPasswordUrl + "&type=changePassword&edit=true",
+            href: enterPasswordUrl + "&type=changePassword",
             text: 'pages.security.accountDetails.summaryList.changePassword' | translate
           }
         ]

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -10,7 +10,7 @@ import { getLastNDigits } from "../../utils/phone-number";
 
 export async function securityGet(req: Request, res: Response): Promise<void> {
   const { email } = req.session.user;
-  const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=security`;
+  const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=security&edit=true`;
   const supportActivityLogFlag = supportActivityLog();
 
   const hasHmrc = await hasAllowedRSAServices(req, res);

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -63,11 +63,12 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: true,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security",
+        enterPasswordUrl: "/enter-password?from=security&edit=true",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?from=security&type=changePhoneNumber",
+            linkHref:
+              "/enter-password?from=security&edit=true&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",
@@ -115,11 +116,12 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: false,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security",
+        enterPasswordUrl: "/enter-password?from=security&edit=true",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?from=security&type=changePhoneNumber",
+            linkHref:
+              "/enter-password?from=security&edit=true&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",
@@ -169,11 +171,12 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: false,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security",
+        enterPasswordUrl: "/enter-password?from=security&edit=true",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?from=security&type=changePhoneNumber",
+            linkHref:
+              "/enter-password?from=security&edit=true&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",
@@ -292,11 +295,12 @@ describe("security controller", () => {
         email: "test@test.com",
         supportActivityLog: true,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security",
+        enterPasswordUrl: "/enter-password?from=security&edit=true",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.title",
-            linkHref: "/enter-password?from=security&type=changePhoneNumber",
+            linkHref:
+              "/enter-password?from=security&edit=true&type=changePhoneNumber",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.phoneNumber.change",
             priorityIdentifier: "DEFAULT",

--- a/src/components/session-expired/index.njk
+++ b/src/components/session-expired/index.njk
@@ -18,8 +18,8 @@
 
     {{ govukButton({
         "text": button_text|default('error.timeoutError.content.signInButtonText' | translate, true),
-        "type": "Submit",
-        "href": '/'
+        "href": '/',
+        "attributes": {"data-nav": true,"data-link": "/"}
     }) }}
 
     <p class="govuk-body">

--- a/src/components/update-confirmation/index.njk
+++ b/src/components/update-confirmation/index.njk
@@ -3,7 +3,8 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% set pageTitleName = pageTitle %}
 {% set hideAccountNavigation = hideAccountNavigation %}
-{% set contentId = contentId%}
+{% set govUkLink = "https://www.gov.uk" %}
+{% set contentId = contentId %}
 {% set taxonomyLevel2 = taxonomyLevel2 %}
 
 {% block pageContent %}
@@ -18,13 +19,21 @@
 
 {% if showGovUKButton %}
 {{ govukButton({
-    "text": button_text|default('general.backToGovUKButtonText' | translate, true),
-    "href": "https://www.gov.uk"
+  "text": button_text|default('general.backToGovUKButtonText' | translate, true),
+  "href": govUkLink,
+  "attributes": {
+    "data-nav": true,
+    "data-link": govUkLink
+  }
 }) }}
 {% else %}
 {{ govukButton({
-    "text": button_text|default('general.backToAccountButtonText' | translate, true),
-    "href": "/manage-your-account"
+  "text": button_text|default('general.backToAccountButtonText' | translate, true),
+  "href": YOUR_SERVICES | getPath,
+  "attributes": {
+    "data-nav": true,
+    "data-link": YOUR_SERVICES | getPath
+  }
 }) }}
 {% endif %}
 {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:taxonomyLevel2, contentId:contentId,loggedInStatus:true,dynamic:true})}}

--- a/src/config.ts
+++ b/src/config.ts
@@ -401,12 +401,16 @@ export function universalAnalyticsGtmContainerId(): string {
   return process.env.UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID;
 }
 
-export function googleAnalytics4Disabled(): string {
-  return process.env.GA4_DISABLED || "true";
+export function googleAnalytics4Enabled(): boolean {
+  return process.env.GA4_ENABLED === "true";
 }
 
-export function universalAnalyticsDisabled(): string {
-  return process.env.UA_DISABLED || "false";
+export function universalAnalyticsEnabled(): boolean {
+  return process.env.UA_ENABLED === "true";
+}
+
+export function selectContentTrackingEnabled(): boolean {
+  return process.env.SELECT_TRACKING_ENABLED === "true";
 }
 
 export function getMfaServiceUrl(): string {

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -6,8 +6,9 @@ import {
   getYourAccountUrl,
   googleAnalytics4GtmContainerId,
   universalAnalyticsGtmContainerId,
-  googleAnalytics4Disabled,
-  universalAnalyticsDisabled,
+  googleAnalytics4Enabled,
+  universalAnalyticsEnabled,
+  selectContentTrackingEnabled,
   getDtRumUrl,
 } from "../config";
 import { generateNonce } from "../utils/strings";
@@ -31,8 +32,9 @@ export async function setLocalVarsMiddleware(
   res.locals.accountSignOut = PATH_DATA.SIGN_OUT.url;
   res.locals.ga4ContainerId = googleAnalytics4GtmContainerId();
   res.locals.uaContainerId = universalAnalyticsGtmContainerId();
-  res.locals.isGa4Disabled = googleAnalytics4Disabled();
-  res.locals.isUaDisabled = universalAnalyticsDisabled();
+  res.locals.isGa4Enabled = googleAnalytics4Enabled();
+  res.locals.isUaEnabled = universalAnalyticsEnabled();
+  res.locals.isSelectContentTrackingEnabled = selectContentTrackingEnabled();
   res.locals.currentUrl = getCurrentUrl(req);
 
   const sessionIds = getSessionIdsFrom(req);


### PR DESCRIPTION
## Proposed changes
Redeploy - OLH-2163 - update analytics package to 3.0.1

### What changed
Bump the frontend analytics package to version 3.0.1. 
Followed the documentation outlined here 
https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/4416143374/Frontend+Analytics+v3+Implementation+Guide 
In essence:
- the global flag has been refactored: originally it was written as `disableGa4Tracking` which was confusing to read as the negative meant the Boolean value against the flag would be mirrored (setting it to `true` would turn the package off). The default value for the global flag is now set to `false`
- tracker specific feature flags have been added (I couldn't see any reason to turn any of them off per se, so I hard coded them to `true` as I imagine as long as GA4 is on, these trackers should all be on as well 🤔  open to opposing perspectives)
- the "select tracking" flag is off in production while PA team test and confirm it's working as expected
- `edit=true` parameter has been added to all the links leading into the "change" type journeys in account management

### Why did it change

### Related links
https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/3801317710/Frontend+Analytics+Implementation+Guide

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config


## How to review
Baseline manual test with a browser extension (like GA debug) to ensure that everything is still working as before.
[Slack conversation](https://gds.slack.com/archives/C012GEZBZM0/p1729690434085639) covers most of the points here. 
Check nothing is missing as per the implementation guide. 