### PR TITLE
OLH-2205-performance-testing-implementation-of-overload-protection-library-causing-http-503-errors-remove-fast-memoize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "express": "^4.21.1",
         "express-session": "^1.18.1",
         "express-validator": "^7.2.0",
-        "fast-memoize": "^2.5.2",
         "govuk-frontend": "^5.7.0",
         "helmet": "7.1.0",
         "i18next": "^23.16.4",
@@ -6022,11 +6021,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "express": "^4.21.1",
     "express-session": "^1.18.1",
     "express-validator": "^7.2.0",
-    "fast-memoize": "^2.5.2",
     "govuk-frontend": "^5.7.0",
     "helmet": "7.1.0",
     "i18next": "^23.16.4",

--- a/src/components/activity-history/activity-history-controller.ts
+++ b/src/components/activity-history/activity-history-controller.ts
@@ -4,14 +4,13 @@ import {
   activityLogItemsPerPage,
   getOIDCClientId,
 } from "../../config";
-import { PATH_DATA } from "../../app.constants";
+import { PATH_DATA, HTTP_STATUS_CODES } from "../../app.constants";
 import {
   generatePagination,
   formatActivityLogs,
   filterAndDecryptActivity,
 } from "../../utils/activityHistory";
 import { presentActivityHistory } from "../../utils/present-activity-history";
-import { HTTP_STATUS_CODES } from "../../app.constants";
 import { logger } from "../../utils/logger";
 import { ActivityLogEntry, FormattedActivityLog } from "../../utils/types";
 

--- a/src/components/activity-history/tests/activity-history-integration.test.ts
+++ b/src/components/activity-history/tests/activity-history-integration.test.ts
@@ -175,7 +175,7 @@ const appWithMiddlewareSetup = async (data?: any, config?: any) => {
     });
   });
 
-  sandbox.stub(oidc, "getJWKS").callsFake(() => {
+  sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
     return new Promise((resolve) => {
       resolve({});
     });

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
@@ -139,7 +139,7 @@ describe("Integration:: change authenticator app", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/change-email/tests/change-email-integration.test.ts
+++ b/src/components/change-email/tests/change-email-integration.test.ts
@@ -21,7 +21,7 @@ describe("Integration:: change email", () => {
   let app: any;
   let baseApi: string;
   let oidc: { getOIDCClient: any };
-  let oidcgetJWKS: { getJWKS: any };
+  let oidcgetCachedJWKS: { getCachedJWKS: any };
 
   const TEST_SUBJECT_ID = "jkduasd";
 
@@ -66,8 +66,8 @@ describe("Integration:: change email", () => {
       });
     });
 
-    oidcgetJWKS = require("../../../utils/oidc");
-    sandbox.stub(oidcgetJWKS, "getJWKS").callsFake(() => {
+    oidcgetCachedJWKS = require("../../../utils/oidc");
+    sandbox.stub(oidcgetCachedJWKS, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/change-password/tests/change-password-integration.test.ts
+++ b/src/components/change-password/tests/change-password-integration.test.ts
@@ -57,7 +57,7 @@ describe("Integration:: change password", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-integration.test.ts
@@ -61,7 +61,7 @@ describe("Integration:: change phone number", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -59,7 +59,7 @@ describe("Integration:: check your email", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -69,7 +69,7 @@ describe("Integration:: check your phone", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -104,7 +104,7 @@ describe("Integration:: delete account", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -65,7 +65,7 @@ describe("Integration::enter password", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -7,18 +7,20 @@ import {
   getTokenValidationClockSkew,
 } from "../../config";
 import { destroyUserSessions } from "../../utils/session-store";
-import { getJWKS } from "../../utils/oidc";
+import { getCachedJWKS } from "../../utils/oidc";
 import { getOIDCConfig } from "../../config/oidc";
 
 const BACK_CHANNEL_LOGOUT_EVENT =
   "http://schemas.openid.net/event/backchannel-logout";
+
+const oidcCongif = getOIDCConfig();
 
 async function verifyLogoutToken(req: Request): Promise<LogoutToken> {
   if (!(req.body && Object.keys(req.body).includes("logout_token"))) {
     return undefined;
   }
   try {
-    req.issuerJWKS = await getJWKS(getOIDCConfig());
+    req.issuerJWKS = await getCachedJWKS(oidcCongif);
 
     const token = await jwtVerify(req.body.logout_token, req.issuerJWKS, {
       issuer: req.oidc.issuer.metadata.issuer,

--- a/src/components/global-logout/tests/global-logout-controller.test.ts
+++ b/src/components/global-logout/tests/global-logout-controller.test.ts
@@ -12,13 +12,13 @@ import {
   FlattenedJWSInput,
   generateKeyPair,
   GenerateKeyPairResult,
+  GetKeyFunction,
   JWSHeaderParameters,
   JWTPayload,
   SignJWT,
   UnsecuredJWT,
 } from "jose";
 
-import { GetKeyFunction } from "jose/dist/types/types";
 import { logger } from "../../../utils/logger";
 import * as SessionStore from "../../../utils/session-store";
 
@@ -94,7 +94,7 @@ describe("global logout controller", () => {
       keys: [await exportJWK(keySet.publicKey)],
     });
 
-    sandbox.stub(oidc, "getJWKS").returns(issuerJWKS);
+    sandbox.stub(oidc, "getCachedJWKS").returns(issuerJWKS);
 
     res = {
       status: sandbox.stub().returnsThis(),

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -65,7 +65,7 @@ describe("Integration:: request email code", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/resend-phone-code/tests/resend-phone-code-integration.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-integration.test.ts
@@ -66,7 +66,7 @@ describe("Integration:: request phone code", () => {
       });
     });
 
-    sandbox.stub(oidc, "getJWKS").callsFake(() => {
+    sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
       return new Promise((resolve) => {
         resolve({});
       });

--- a/src/components/security/tests/security-integration.test.ts
+++ b/src/components/security/tests/security-integration.test.ts
@@ -153,7 +153,7 @@ const appWithMiddlewareSetup = async (config: any = {}) => {
     });
   });
 
-  sandbox.stub(oidc, "getJWKS").callsFake(() => {
+  sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
     return new Promise((resolve) => {
       resolve({});
     });

--- a/src/components/your-services/tests/your-services-integration.test.ts
+++ b/src/components/your-services/tests/your-services-integration.test.ts
@@ -185,7 +185,7 @@ const appWithMiddlewareSetup = async (data?: {
     });
   });
 
-  sandbox.stub(oidc, "getJWKS").callsFake(() => {
+  sandbox.stub(oidc, "getCachedJWKS").callsFake(() => {
     return new Promise((resolve) => {
       resolve({});
     });

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,37 @@
+import LRUCache from "lru-cache";
+import { logger } from "./logger";
+
+const cache = new LRUCache<string, { data: any; expiresAt: number }>({
+  max: 1000,
+  maxAge: 24 * 60 * 60 * 1000,
+});
+
+async function cacheWithExpiration<T>(
+  key: string,
+  fn: () => Promise<T>,
+  cacheDuration: number = 24 * 60 * 60 * 1000 // 24 hours
+): Promise<T> {
+  return Promise.resolve().then(async () => {
+    const cachedData = cache.get(key);
+    if (cachedData && Date.now() < cachedData.expiresAt) {
+      return cachedData.data;
+    }
+
+    try {
+      const data = await fn();
+      const expiresAt = Date.now() + cacheDuration;
+      cache.set(key, { data, expiresAt });
+      return data;
+    } catch (error) {
+      invalidateCache(key);
+      logger.error("Error fetching data:", error);
+      throw error;
+    }
+  });
+}
+
+function invalidateCache(key: string): void {
+  cache.del(key);
+}
+
+export { cacheWithExpiration, invalidateCache };

--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -1,24 +1,30 @@
 import { Issuer, Client, custom, generators } from "openid-client";
 import { OIDCConfig } from "../types";
-import memoize from "fast-memoize";
 import { ClientAssertionServiceInterface, KmsService } from "./types";
 import { kmsService } from "./kms";
 import base64url from "base64url";
 import random = generators.random;
-import { decodeJwt, createRemoteJWKSet } from "jose";
+import { decodeJwt, createRemoteJWKSet, JSONWebKeySet } from "jose";
+import { cacheWithExpiration } from "./cache";
+
+const issuerCacheDuration = 24 * 60 * 60 * 1000;
+const jwksRefreshInterval = 24 * 60 * 60 * 1000;
 
 custom.setHttpOptionsDefaults({
   timeout: 20000,
 });
 
-async function getIssuer(discoveryUri: string) {
-  return await Issuer.discover(discoveryUri);
+async function getCachedIssuer(discoveryUri: string): Promise<Issuer<Client>> {
+  const cacheKey = `oidc:issuer:${discoveryUri.toLowerCase()}`;
+  return await cacheWithExpiration(
+    cacheKey,
+    () => Issuer.discover(discoveryUri),
+    issuerCacheDuration
+  );
 }
 
-const cachedIssuer = memoize(getIssuer);
-
 async function getOIDCClient(config: OIDCConfig): Promise<Client> {
-  const issuer = await cachedIssuer(config.idp_url);
+  const issuer = await getCachedIssuer(config.idp_url);
 
   return new issuer.Client({
     client_id: config.client_id,
@@ -30,14 +36,21 @@ async function getOIDCClient(config: OIDCConfig): Promise<Client> {
   });
 }
 
-async function getJWKS(config: OIDCConfig) {
-  const issuer = await cachedIssuer(config.idp_url);
-  return createRemoteJWKSet(new URL(issuer.metadata.jwks_uri), {
-    headers: { "User-Agent": '"AccountManagement/1.0.0"' },
-  });
+async function getCachedJWKS(config: OIDCConfig): Promise<JSONWebKeySet> {
+  const issuer = await getCachedIssuer(config.idp_url);
+  const issuerUrl = issuer.metadata.jwks_uri;
+  const cacheKey = `oidc:jwks:${issuerUrl.toLowerCase()}`;
+  return await cacheWithExpiration(
+    cacheKey,
+    async () => {
+      const remoteJWKSet = createRemoteJWKSet(new URL(issuerUrl), {
+        headers: { "User-Agent": "AccountManagement/1.0.0" },
+      });
+      return remoteJWKSet.jwks();
+    },
+    jwksRefreshInterval
+  );
 }
-
-const cachedJwks = memoize(getJWKS);
 
 function isTokenExpired(token: string): boolean {
   const decodedToken = decodeJwt(token);
@@ -45,7 +58,7 @@ function isTokenExpired(token: string): boolean {
   const next60Seconds = new Date();
   next60Seconds.setSeconds(60);
 
-  return (decodedToken.exp as number) < next60Seconds.getTime() / 1000;
+  return decodedToken.exp < next60Seconds.getTime() / 1000;
 }
 
 function clientAssertionGenerator(
@@ -97,8 +110,8 @@ function clientAssertionGenerator(
 
 export {
   getOIDCClient,
-  cachedJwks as getJWKS,
+  getCachedJWKS,
   isTokenExpired,
   clientAssertionGenerator,
-  cachedIssuer as getIssuer,
+  getCachedIssuer,
 };

--- a/test/unit/utils/oidc.test.ts
+++ b/test/unit/utils/oidc.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, beforeEach, afterEach } from "mocha";
 import {
   clientAssertionGenerator,
-  getIssuer,
-  getJWKS,
+  getCachedIssuer,
+  getCachedJWKS,
   getOIDCClient,
 } from "../../../src/utils/oidc";
 import { sinon, expect } from "../../utils/test-utils";
@@ -85,7 +85,7 @@ describe("OIDC Functions", () => {
       await expect(getOIDCClient(mockConfig)).to.be.rejectedWith(errorMessage);
     });
 
-    it("should memoize OIDC client result", async () => {
+    it("should cache OIDC client result", async () => {
       const memoizeConfig = mockConfig;
       memoizeConfig.idp_url = "https://example.memoize.oidc.com";
       const clientFirstCall = await getOIDCClient(memoizeConfig);
@@ -105,7 +105,7 @@ describe("OIDC Functions", () => {
     });
   });
 
-  describe("getJWKS", () => {
+  describe("getCachedJWKS", () => {
     let sandbox: sinon.SinonSandbox;
     let mockIssuer: any;
     let mockCreateRemoteJWKSet: sinon.SinonStub;
@@ -138,23 +138,24 @@ describe("OIDC Functions", () => {
       sandbox.restore();
     });
 
-    it("should memoize JWKS for valid config", async () => {
+    it("should cache JWKS for valid config", async () => {
       const mockJWKS = {
-        getKey: async () => ({ kid: "test-kid" }),
+        keys: [{ kid: "test-kid" }],
       };
-      mockCreateRemoteJWKSet.returns(mockJWKS);
+      mockCreateRemoteJWKSet.returns({ jwks: async () => mockJWKS });
 
-      const result1 = await getJWKS(config);
+      // First call to getCachedJWKS
+      const result1 = await getCachedJWKS(config);
       expect(result1).to.deep.equal(mockJWKS);
       expect(Issuer.discover).to.have.been.calledOnceWith(config.idp_url);
       expect(mockCreateRemoteJWKSet).to.have.been.calledOnceWith(
         new URL(mockIssuer.metadata.jwks_uri),
         {
-          headers: { "User-Agent": '"AccountManagement/1.0.0"' },
+          headers: { "User-Agent": "AccountManagement/1.0.0" },
         }
       );
 
-      const result2 = await getJWKS(config);
+      const result2 = await getCachedJWKS(config);
       expect(result2).to.deep.equal(mockJWKS);
 
       expect(Issuer.discover).to.have.been.calledOnce;
@@ -163,14 +164,27 @@ describe("OIDC Functions", () => {
 
     it("should throw an error if JWKS creation fails", async () => {
       const errorMessage = "Failed to create JWKS";
-      mockCreateRemoteJWKSet.throws(new Error(errorMessage));
-      const configError = config;
-      configError.idp_url = "https://example.jwk.error.com";
-      await expect(getJWKS(configError)).to.be.rejectedWith(errorMessage);
+      mockCreateRemoteJWKSet.returns({
+        jwks: async () => {
+          throw new Error(errorMessage);
+        },
+      });
+
+      const configError = {
+        ...config,
+        idp_url: "https://example.jwk.error.com",
+      };
+
+      try {
+        await getCachedJWKS(configError);
+        expect.fail("Failed to create JWKS");
+      } catch (error) {
+        expect(error.message).to.equal(errorMessage);
+      }
     });
   });
 
-  describe("getIssuer", () => {
+  describe("getCachedIssuer", () => {
     let sandbox: sinon.SinonSandbox;
     let discoverStub: sinon.SinonStub;
     let mockIssuer: any;
@@ -194,7 +208,7 @@ describe("OIDC Functions", () => {
         "https://example.com/.well-known/openid-configuration";
       discoverStub.resolves(mockIssuer);
 
-      const issuer = await getIssuer(mockDiscoveryUri);
+      const issuer = await getCachedIssuer(mockDiscoveryUri);
 
       expect(discoverStub).to.have.been.calledOnceWith(mockDiscoveryUri);
       expect(issuer).to.equal(mockIssuer);
@@ -206,7 +220,7 @@ describe("OIDC Functions", () => {
       const errorMessage = "Discovery failed";
       discoverStub.rejects(new Error(errorMessage));
 
-      await expect(getIssuer(mockDiscoveryUri)).to.be.rejectedWith(
+      await expect(getCachedIssuer(mockDiscoveryUri)).to.be.rejectedWith(
         errorMessage
       );
     });
@@ -216,8 +230,8 @@ describe("OIDC Functions", () => {
         "https://example.com/memoize/.well-known/openid-configuration";
       discoverStub.resolves(mockIssuer);
 
-      const issuerFirstCall = await getIssuer(mockDiscoveryUri);
-      const issuerSecondCall = await getIssuer(mockDiscoveryUri);
+      const issuerFirstCall = await getCachedIssuer(mockDiscoveryUri);
+      const issuerSecondCall = await getCachedIssuer(mockDiscoveryUri);
 
       expect(discoverStub).to.have.been.calledOnceWith(mockDiscoveryUri);
       expect(issuerFirstCall).to.equal(mockIssuer);


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2205] Replace fast memoize with custom caching mechanism

### What changed
<!-- Describe the changes in detail - the "what"-->
- Removed fast memoise
- Implemented custom caching mechanism
- Cached getJwks and getIssuer

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
- Fast memoise was not caching the well known end point for an unknown reason
- As the end point does not change often (every 2 years or so) it is better to implement a custom caching mechanism with a longer TTL

### Related links
## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
- deployed to Dev
- Ran against performance tests

[OLH-2205]: https://govukverify.atlassian.net/browse/OLH-2205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ