### PR TITLE
Revert "BAU: Bump the production-dependencies group with 9 updates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@aws-crypto/client-node": "^4.0.2",
-        "@aws-sdk/client-dynamodb": "^3.726.1",
-        "@aws-sdk/client-kms": "^3.726.1",
-        "@aws-sdk/client-sns": "^3.726.1",
-        "@aws-sdk/client-sqs": "^3.726.1",
-        "@aws-sdk/lib-dynamodb": "^3.726.1",
+        "@aws-sdk/client-dynamodb": "^3.726.0",
+        "@aws-sdk/client-kms": "^3.726.0",
+        "@aws-sdk/client-sns": "^3.726.0",
+        "@aws-sdk/client-sqs": "^3.726.0",
+        "@aws-sdk/lib-dynamodb": "^3.726.0",
         "@aws-sdk/util-dynamodb": "^3.609.0",
         "@govuk-one-login/frontend-analytics": "^3.1.0",
         "@govuk-one-login/frontend-language-toggle": "^1.1.0",
@@ -43,12 +43,12 @@
         "otplib": "^12.0.1",
         "overload-protection": "^1.2.3",
         "pino": "^9.6.0",
-        "pino-http": "^10.4.0",
+        "pino-http": "^10.3.0",
         "prettier": "^3.4.2",
         "qrcode": "^1.5.4",
         "uuid": "^10.0.0",
         "xss": "^1.0.15",
-        "xstate": "^5.19.2"
+        "xstate": "^5.19.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -384,14 +384,14 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.726.1.tgz",
-      "integrity": "sha512-r57cGOFAcFK9ezOWpPzZ5EL2+MJDNNkcyPZJ+5o36jaL/K9KjJP4gqvwYJ0/WAhkm5wlwn7MugrvioTXtlzJHQ==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.726.0.tgz",
+      "integrity": "sha512-2I3AVm8IIVJJpX471bVFOccmI/5XRrcgsODDtNP5pVY5TLktKbqwxONKIL2oDuuJSD0YooQf28bAhdX4TgiIqg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
+        "@aws-sdk/client-sts": "3.726.0",
         "@aws-sdk/core": "3.723.0",
         "@aws-sdk/credential-provider-node": "3.726.0",
         "@aws-sdk/middleware-endpoint-discovery": "3.723.0",
@@ -451,14 +451,14 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.726.1.tgz",
-      "integrity": "sha512-HYrCcSt+4lFkc6r22kfFiX61NIQ1+nON2XNqgRPVN1G9U/RjHr3ZdujObyBiOuV+59ELmw/qKwJohN3CsV8EgQ==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.726.0.tgz",
+      "integrity": "sha512-36FwfZk3k1NZENa7T/WLDjaqq62nNJfZGwjKnHy781VLE1refr6mlG1hrrE+hU4uZCccXfEO/0cUeOytHtiMNw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
+        "@aws-sdk/client-sts": "3.726.0",
         "@aws-sdk/core": "3.723.0",
         "@aws-sdk/credential-provider-node": "3.726.0",
         "@aws-sdk/middleware-host-header": "3.723.0",
@@ -502,14 +502,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.726.1.tgz",
-      "integrity": "sha512-ljh1IfdyM2yMB48ac3MuDx1jvWqHgZ/Ni4fW70N6rnSYkgIaHDPKFd6N5cxiYGzeEhi/8jt80mX9jobFfG8L+w==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.726.0.tgz",
+      "integrity": "sha512-MguTCz96zc38zgJl521YtGzKZlORYxjNOQMYD00Q+Gz6qT/jTtZo0gXnw6FHt+NTLNE/KymTAtkJw5PBigkD3Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
+        "@aws-sdk/client-sts": "3.726.0",
         "@aws-sdk/core": "3.723.0",
         "@aws-sdk/credential-provider-node": "3.726.0",
         "@aws-sdk/middleware-host-header": "3.723.0",
@@ -553,14 +553,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.726.1.tgz",
-      "integrity": "sha512-QSsmlMNVgKUzDpDC3Ya1i0tvFjVcvTBoJfSh7LBkuMJiboY2j2aeD74OX7xGkxu+QLc8wWUjT//KYDm6KwHk7w==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.726.0.tgz",
+      "integrity": "sha512-K8ELPBD7uJ7cF77T2HLw0uk8P6defg8tYY/6izwYc8XoRgB1+/CfmC3DkOXQFYXxLiwhKBkBi50HVEJuAhwD1g==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
+        "@aws-sdk/client-sts": "3.726.0",
         "@aws-sdk/core": "3.723.0",
         "@aws-sdk/credential-provider-node": "3.726.0",
         "@aws-sdk/middleware-host-header": "3.723.0",
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
-      "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.0.tgz",
+      "integrity": "sha512-047EqXv2BAn/43eP92zsozPnR3paFFMsj5gjytx9kGNtp+WV0fUZNztCOobtouAxBY0ZQ8Xx5RFnmjpRb6Kjsg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -923,12 +923,12 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.726.1.tgz",
-      "integrity": "sha512-ixFU08uIl6H/oi/47QQINL/gAl8lHGjB2mTLp46bTMlylqofQzLHG2EMng67DrEtlkhIAP2aPqCJJdFCoLncZw==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.726.0.tgz",
+      "integrity": "sha512-fFhbjmgwpRs2OwsZ+9HCjREIfWE3nU1bb56OM2yP3E1Q21Aa3Y57dVMx3r6PKN1GNwSN3i6Jvoc94q7PfgxFBA==",
       "dependencies": {
         "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/util-dynamodb": "3.726.1",
+        "@aws-sdk/util-dynamodb": "3.726.0",
         "@smithy/core": "^3.0.0",
         "@smithy/smithy-client": "^4.0.0",
         "@smithy/types": "^4.0.0",
@@ -938,7 +938,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1"
+        "@aws-sdk/client-dynamodb": "^3.726.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.726.1.tgz",
-      "integrity": "sha512-aZAJ/uaao4o9e0LAj5nb4np/ZbIPV+QC/oAJEsp0QC+s1cpFYNVLrBdcuUAWmdk3v6q0fWRCzq7rzvxwLHO2EA==",
+      "version": "3.726.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.726.0.tgz",
+      "integrity": "sha512-lYen6qxlSGidoIxRZ4HFaxbX4ZPMePa4U1nf66fRDc6lCibkmCIqGFwPNo2QdGh2r4ZunvABwUSkPIzwZYlMkg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1088,7 +1088,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.726.1"
+        "@aws-sdk/client-dynamodb": "^3.726.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
@@ -8726,9 +8726,9 @@
       }
     },
     "node_modules/pino-http": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.4.0.tgz",
-      "integrity": "sha512-vjQsKBE+VN1LVchjbfLE7B6nBeGASZNRNKsR68VS0DolTm5R3zo+47JX1wjm0O96dcbvA7vnqt8YqOWlG5nN0w==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.3.0.tgz",
+      "integrity": "sha512-kaHQqt1i5S9LXWmyuw6aPPqYW/TjoDPizPs4PnDW4hSpajz2Uo/oisNliLf7We1xzpiLacdntmw8yaZiEkppQQ==",
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^9.0.0",
@@ -10903,9 +10903,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/xstate": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.2.tgz",
-      "integrity": "sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.1.tgz",
+      "integrity": "sha512-vFt3q9EBnO/qTTf9AG/5GosGwdDEftw5VOd3ytfSwUQRvkj6oJkxeBQaCqJUANjHrkK341jMkEZP0zeqrx2tww==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^4.0.2",
-    "@aws-sdk/client-dynamodb": "^3.726.1",
-    "@aws-sdk/client-kms": "^3.726.1",
-    "@aws-sdk/client-sns": "^3.726.1",
-    "@aws-sdk/client-sqs": "^3.726.1",
-    "@aws-sdk/lib-dynamodb": "^3.726.1",
+    "@aws-sdk/client-dynamodb": "^3.726.0",
+    "@aws-sdk/client-kms": "^3.726.0",
+    "@aws-sdk/client-sns": "^3.726.0",
+    "@aws-sdk/client-sqs": "^3.726.0",
+    "@aws-sdk/lib-dynamodb": "^3.726.0",
     "@aws-sdk/util-dynamodb": "^3.609.0",
     "@govuk-one-login/frontend-analytics": "^3.1.0",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
@@ -84,12 +84,12 @@
     "otplib": "^12.0.1",
     "overload-protection": "^1.2.3",
     "pino": "^9.6.0",
-    "pino-http": "^10.4.0",
+    "pino-http": "^10.3.0",
     "prettier": "^3.4.2",
     "qrcode": "^1.5.4",
     "uuid": "^10.0.0",
     "xss": "^1.0.15",
-    "xstate": "^5.19.2"
+    "xstate": "^5.19.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",


### PR DESCRIPTION
Reverts govuk-one-login/di-account-management-frontend#1903

Reason:
Error: failed with status code 500    at onResFinished (/app/node_modules/pino-http/logger.js:115:39)    at ServerResponse.onResponseComplete (/app/node_modules/pino-http/logger.js:178:14)    at /opt/dynatrace/oneagent/agent/bin/1.303.62.20241129-131342/any/nodejs/nodejsagent.js:2273:48    at t.runInContext (/opt/dynatrace/oneagent/agent/bin/1.303.62.20241129-131342/any/nodejs/nodejsagent.js:2384:24)    at ServerResponse.onResponseComplete (/opt/dynatrace/oneagent/agent/bin/1.303.62.20241129-131342/any/nodejs/nodejsagent.js:2273:18)    at ServerResponse.emit (node:events:530:35)    at onFinish (node:_http_outgoing:1027:10)    at callback (node:internal/streams/writable:766:21)    at afterWrite (node:internal/streams/writable:710:5)    at afterWriteTick (node:internal/streams/writable:696:10)
--

Looks like Pino is causing some error's writing to the stream