### PR TITLE
OLH-2170 Add Air pollution assesment service

### DIFF
--- a/localstack/provision.sh
+++ b/localstack/provision.sh
@@ -163,6 +163,22 @@ create_and_populate_user_services_table() {
                     "S": "20 January 1970"
                   }
                 }
+              },
+              {
+                "M": {
+                  "count_successful_logins": {
+                    "N": "4"
+                  },
+                  "client_id": {
+                    "S": "airPollutionAssesment"
+                  },
+                  "last_accessed": {
+                    "N": "1699969996"
+                  },
+                  "last_accessed_pretty": {
+                    "S": "20 January 1970"
+                  }
+                }
               }
             ]
           }

--- a/scripts/sync-translations.sh
+++ b/scripts/sync-translations.sh
@@ -1,0 +1,42 @@
+function extract_keys_fe() {
+  local environment=$1
+  local language=$2
+
+  jq -r ".clientRegistry.$environment | keys | .[]" "../src/locales/$language/translation.json"
+}
+
+function extract_keys_be() {
+  local environment=$1
+  local language=$2
+
+  jq -r ".$environment | keys | .[]" "../../di-account-management-backend/src/config/clientRegistry.$language.json"
+}
+
+function check_keys() {
+  local environment=$1
+  local language=$2
+
+  local keys_fe=$(extract_keys_fe $environment $language)
+  local keys_be=$(extract_keys_be $environment $language)
+
+  echo "Missing in frontend:"
+  for key in $keys_be; do
+    if [[ ! $keys_fe =~ $key ]]; then
+     echo $key
+     local value=$(jq ".$environment.[\"$key\"]" ../../di-account-management-backend/src/config/clientRegistry.$language.json)
+     echo $value
+     jq ".clientRegistry.$environment = .clientRegistry.$environment + { \"$key\": $value }" ../src/locales/$language/translation.json > tmp.$$.json && mv tmp.$$.json "./src/locales/$language/translation.json"
+    fi
+  done
+}
+
+environments=("production" "staging" "integration" "build" "dev" "local")
+languages=("en" "cy")
+
+for language in "${languages[@]}"; do
+  for environment in "${environments[@]}"; do
+    echo "Checking $environment $language"
+    check_keys $environment $language
+    echo ""
+  done
+done

--- a/src/config.ts
+++ b/src/config.ts
@@ -206,6 +206,8 @@ const CHECK_FAMILY_ELIGIBILITY_PROD = "CKHfr_Kz84LYFnsP7m6YJBXqBzw";
 const CHECK_FAMILY_ELIGIBILITY_NON_PROD = "checkFamilyEligibility";
 const FIND_A_TENDER_PROD = "L8SSq5Iz8DstkBgno0Hx5aujelE";
 const FIND_A_TENDER_NON_PROD = "findATender";
+const AIR_POLLUTION_ASSESMENT_ARCHIVE_PROD = "glcH6E9VxtnCAPPwBt550zDh22Q";
+const AIR_POLLUTION_ASSESMENT_ARCHIVE_NON_PROD = "airPollutionAssesment";
 
 export const getAllowedAccountListClientIDs: string[] = [
   GOV_UK_EMAIL_PROD,
@@ -281,6 +283,8 @@ export const getAllowedAccountListClientIDs: string[] = [
   DFE_QUALIFIED_TEACHER_STATUS_NON_PROD,
   FIND_A_TENDER_PROD,
   FIND_A_TENDER_NON_PROD,
+  AIR_POLLUTION_ASSESMENT_ARCHIVE_NON_PROD,
+  AIR_POLLUTION_ASSESMENT_ARCHIVE_PROD,
 ];
 
 export const hmrcClientIds: string[] = [HMRC_NON_PROD, "hmrc"];
@@ -362,6 +366,7 @@ export const clientsToShowInSearchProd: string[] = [
   FAA_PROD,
   DFE_TEACHER_VACANCIES_PROD,
   CMAD_PROD,
+  AIR_POLLUTION_ASSESMENT_ARCHIVE_PROD,
 ];
 
 function getProtocol(): string {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -824,6 +824,12 @@
         "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
         "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
         "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
+      },
+      "KcKmx2g1GH6ersWFvzMi1bhehq4": {
+        "header": "Eich GOV.UK One Login",
+        "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
+        "link_text": "",
+        "link_href": "https://home.account.gov.uk"
       }
     },
     "integration": {
@@ -1090,6 +1096,12 @@
         "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
         "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
         "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
+      },
+      "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB": {
+        "header": "Eich GOV.UK One Login",
+        "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
+        "link_text": "",
+        "link_href": "https://home.integration.account.gov.uk"
       }
     },
     "staging": {
@@ -1344,6 +1356,12 @@
         "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
         "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "EMGmY82k-92QSakDl_9keKDFmZY": {
+        "header": "Eich GOV.UK One Login",
+        "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
+        "link_text": "",
+        "link_href": "https://home.staging.account.gov.uk"
       }
     },
     "build": {
@@ -1598,6 +1616,12 @@
         "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
         "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "oneLoginHome": {
+        "header": "Eich GOV.UK One Login",
+        "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
+        "link_text": "",
+        "link_href": "https://home.build.account.gov.uk"
       }
     },
     "dev": {
@@ -1852,6 +1876,12 @@
         "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
         "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "oneLoginHome": {
+        "header": "Eich GOV.UK One Login",
+        "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
+        "link_text": "",
+        "link_href": "https://home.dev.account.gov.uk"
       }
     },
     "local": {
@@ -2106,6 +2136,12 @@
         "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
         "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "oneLoginHome": {
+        "header": "Eich GOV.UK One Login",
+        "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
+        "link_text": "",
+        "link_href": "https://home.dev.account.gov.uk"
       }
     }
   }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -818,6 +818,12 @@
         "description": "Cyhoeddi cyfleoedd fel y gall cyflenwyr chwilio a gwneud cais amdanynt.",
         "link_text": "Ewch i'ch cyfrif Dod o hyd i dendr",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "glcH6E9VxtnCAPPwBt550zDh22Q": {
+        "header": "Gwasanaeth asesu llygredd aer",
+        "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
+        "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
+        "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
       }
     },
     "integration": {
@@ -1078,6 +1084,12 @@
         "description": "Cyhoeddi cyfleoedd fel y gall cyflenwyr chwilio a gwneud cais amdanynt.",
         "link_text": "Ewch i'ch cyfrif Dod o hyd i dendr",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "glcH6E9VxtnCAPPwBt550zDh22Q": {
+        "header": "Gwasanaeth asesu llygredd aer",
+        "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
+        "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
+        "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
       }
     },
     "staging": {
@@ -1326,6 +1338,12 @@
         "description": "Cyhoeddi cyfleoedd fel y gall cyflenwyr chwilio a gwneud cais amdanynt.",
         "link_text": "Ewch i'ch cyfrif Dod o hyd i dendr",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Gwasanaeth asesu llygredd aer",
+        "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
+        "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
+        "link_href": "https://register-dev.aerius.uk"
       }
     },
     "build": {
@@ -1574,6 +1592,12 @@
         "description": "Cyhoeddi cyfleoedd fel y gall cyflenwyr chwilio a gwneud cais amdanynt.",
         "link_text": "Ewch i'ch cyfrif Dod o hyd i dendr",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Gwasanaeth asesu llygredd aer",
+        "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
+        "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
+        "link_href": "https://register-dev.aerius.uk"
       }
     },
     "dev": {
@@ -1822,6 +1846,12 @@
         "description": "Cyhoeddi cyfleoedd fel y gall cyflenwyr chwilio a gwneud cais amdanynt.",
         "link_text": "Ewch i'ch cyfrif Dod o hyd i dendr",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Gwasanaeth asesu llygredd aer",
+        "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
+        "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
+        "link_href": "https://register-dev.aerius.uk"
       }
     },
     "local": {
@@ -2070,6 +2100,12 @@
         "description": "Cyhoeddi cyfleoedd fel y gall cyflenwyr chwilio a gwneud cais amdanynt.",
         "link_text": "Ewch i'ch cyfrif Dod o hyd i dendr",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Gwasanaeth asesu llygredd aer",
+        "description": "Llwytho canlyniadau asesu risg amgylcheddol i'w defnyddio ar gyfer asesiadau cyfunol.",
+        "link_text": "Ewch i'ch Cyfrif gwasanaeth asesu llygredd aer",
+        "link_href": "https://register-dev.aerius.uk"
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1003,6 +1003,12 @@
         "description": "Upload environmental risk assessment results to use for in-combination assessments.",
         "link_text": "Go to your Air pollution assessment service account",
         "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
+      },
+      "KcKmx2g1GH6ersWFvzMi1bhehq4": {
+        "header": "Your GOV.UK One Login",
+        "description": "This includes ‘Security’ and ‘Your services’",
+        "link_text": "",
+        "link_href": "https://home.account.gov.uk"
       }
     },
     "integration": {
@@ -1275,6 +1281,12 @@
         "description": "Upload environmental risk assessment results to use for in-combination assessments.",
         "link_text": "Go to your Air pollution assessment service account",
         "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
+      },
+      "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB": {
+        "header": "Your GOV.UK One Login",
+        "description": "This includes ‘Security’ and ‘Your services’",
+        "link_text": "",
+        "link_href": "https://home.integration.account.gov.uk"
       }
     },
     "staging": {
@@ -1535,6 +1547,12 @@
         "description": "Upload environmental risk assessment results to use for in-combination assessments.",
         "link_text": "Go to your Air pollution assessment service account",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "EMGmY82k-92QSakDl_9keKDFmZY": {
+        "header": "Your GOV.UK One Login",
+        "description": "This includes ‘Security’ and ‘Your services’",
+        "link_text": "",
+        "link_href": "https://home.staging.account.gov.uk"
       }
     },
     "build": {
@@ -1795,6 +1813,12 @@
         "description": "Upload environmental risk assessment results to use for in-combination assessments.",
         "link_text": "Go to your Air pollution assessment service account",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "oneLoginHome": {
+        "header": "Your GOV.UK One Login",
+        "description": "This includes ‘Security’ and ‘Your services’",
+        "link_text": "",
+        "link_href": "https://home.build.account.gov.uk"
       }
     },
     "dev": {
@@ -2055,6 +2079,12 @@
         "description": "Upload environmental risk assessment results to use for in-combination assessments.",
         "link_text": "Go to your Air pollution assessment service account",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "oneLoginHome": {
+        "header": "Your GOV.UK One Login",
+        "description": "This includes ‘Security’ and ‘Your services’",
+        "link_text": "",
+        "link_href": "https://home.dev.account.gov.uk"
       }
     },
     "local": {
@@ -2315,6 +2345,12 @@
         "description": "Upload environmental risk assessment results to use for in-combination assessments.",
         "link_text": "Go to your Air pollution assessment service account",
         "link_href": "https://register-dev.aerius.uk"
+      },
+      "oneLoginHome": {
+        "header": "Your GOV.UK One Login",
+        "description": "This includes ‘Security’ and ‘Your services’",
+        "link_text": "",
+        "link_href": "https://home.dev.account.gov.uk"
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -997,6 +997,12 @@
         "description": "Publish opportunities so that suppliers can search and apply for them.",
         "link_text": "Go to your Find a tender account",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "glcH6E9VxtnCAPPwBt550zDh22Q": {
+        "header": "Air pollution assessment service",
+        "description": "Upload environmental risk assessment results to use for in-combination assessments.",
+        "link_text": "Go to your Air pollution assessment service account",
+        "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
       }
     },
     "integration": {
@@ -1263,6 +1269,12 @@
         "description": "Publish opportunities so that suppliers can search and apply for them.",
         "link_text": "Go to your Find a tender account",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "glcH6E9VxtnCAPPwBt550zDh22Q": {
+        "header": "Air pollution assessment service",
+        "description": "Upload environmental risk assessment results to use for in-combination assessments.",
+        "link_text": "Go to your Air pollution assessment service account",
+        "link_href": "https://get-an-air-pollution-assessment-archive.service.gov.uk"
       }
     },
     "staging": {
@@ -1517,6 +1529,12 @@
         "description": "Publish opportunities so that suppliers can search and apply for them.",
         "link_text": "Go to your Find a tender account",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Air pollution assessment service",
+        "description": "Upload environmental risk assessment results to use for in-combination assessments.",
+        "link_text": "Go to your Air pollution assessment service account",
+        "link_href": "https://register-dev.aerius.uk"
       }
     },
     "build": {
@@ -1771,6 +1789,12 @@
         "description": "Publish opportunities so that suppliers can search and apply for them.",
         "link_text": "Go to your Find a tender account",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Air pollution assessment service",
+        "description": "Upload environmental risk assessment results to use for in-combination assessments.",
+        "link_text": "Go to your Air pollution assessment service account",
+        "link_href": "https://register-dev.aerius.uk"
       }
     },
     "dev": {
@@ -2025,6 +2049,12 @@
         "description": "Publish opportunities so that suppliers can search and apply for them.",
         "link_text": "Go to your Find a tender account",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Air pollution assessment service",
+        "description": "Upload environmental risk assessment results to use for in-combination assessments.",
+        "link_text": "Go to your Air pollution assessment service account",
+        "link_href": "https://register-dev.aerius.uk"
       }
     },
     "local": {
@@ -2279,6 +2309,12 @@
         "description": "Publish opportunities so that suppliers can search and apply for them.",
         "link_text": "Go to your Find a tender account",
         "link_href": "https://supplier-information.private-beta.find-tender.service.gov.uk/"
+      },
+      "airPollutionAssesment": {
+        "header": "Air pollution assessment service",
+        "description": "Upload environmental risk assessment results to use for in-combination assessments.",
+        "link_text": "Go to your Air pollution assessment service account",
+        "link_href": "https://register-dev.aerius.uk"
       }
     }
   }


### PR DESCRIPTION
Adds the Air Pollution Service

<img width="720" alt="Screenshot 2025-01-13 at 16 38 50" src="https://github.com/user-attachments/assets/5cacd0c3-87c9-47f7-9594-54fcee3150c4" />
<img width="790" alt="Screenshot 2025-01-13 at 16 30 25" src="https://github.com/user-attachments/assets/2dd6cf07-8985-4d52-a73f-639bd28135ae" />

Also adds (and ran) a script which ensures all entries in the backend clientRegistry are in the frontend clientRegistry as well. It is then safe to copy of the frontend clientRegistry to the backend.
