### PR TITLE
Olh 2373 searchable list layout tweak

### DIFF
--- a/src/components/search-services/index.njk
+++ b/src/components/search-services/index.njk
@@ -1,5 +1,7 @@
 {% extends "common/layout/base-page.njk" %}
 {% set hideAccountNavigation = true %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitleName = 'pages.searchServices.title' | translate %}
 
@@ -9,32 +11,45 @@
     {% for paragraph in paragraphs %}
         <p class="govuk-body">{{ paragraph }}</p>
     {% endfor %}
-    <div class="govuk-form-group">
-        <form method="get" action="{{ "SEARCH_SERVICES" | getPath }}">
-            <label for="search_box" class="govuk-label govuk-!-font-weight-bold">{{ "pages.searchServices.searchLabel" | translate }}</label>
-            <input id="search_box" class="govuk-input govuk-!-width-three-quarters" name="q" type="search" value="{{query}}" />
-            <button type="submit" class="govuk-button">{{ "pages.searchServices.searchButton" | translate }}</button>
-            {% if hasSearch %} 
-            <p class='govuk-body'>
-                {% if resultsCount === 1 %}
-                    {{ "pages.searchServices.oneResult" | translate }}
-                {% elseif (resultsCount > 0) %}
-                    {{ "pages.searchServices.manyResults" | translate | replace("[count]", resultsCount) }}
-                {% else %}
-                    {{ "pages.searchServices.noResults" | translate }}     
-                {% endif %}
-            </p>
-            {% endif %}
-        </form>
-    </div>
+    <form method="get" action="{{ "SEARCH_SERVICES" | getPath }}">
+      {% set submitButton %}
+        {{ govukButton({
+          "text": "pages.searchServices.searchButton" | translate
+        }) }}
+      {% endset %}
+      {{ govukInput({
+        label: {
+          text: "pages.searchServices.searchLabel" | translate
+        },
+        formGroup: {
+          afterInput: { html: submitButton}
+        },
+        id: "search_box",
+        type: "search",
+        name: "q",
+        classes: "govuk-!-width-three-quarters"
+      }) }}
+
+      {% if hasSearch %} 
+      <p class='govuk-body'>
+        {% if resultsCount === 1 %}
+            {{ "pages.searchServices.oneResult" | translate }}
+        {% elseif (resultsCount > 0) %}
+            {{ "pages.searchServices.manyResults" | translate | replace("[count]", resultsCount) }}
+        {% else %}
+            {{ "pages.searchServices.noResults" | translate }}     
+        {% endif %}
+      </p>
+      {% endif %}
+    </form>
     
     <ul class="govuk-list search-results">
-        {% for service in services %}
-            <li>
-                <a class="govuk-link" target="_blank" href="{{ ['clientRegistry.', env, '.', service, '.link_href'] | join | translate }}">
-                    {{ ['clientRegistry.', env, '.', service, '.header'] | join | translate }}
-                </a>
-            </li>
-        {% endfor %}
+      {% for service in services %}
+        <li>
+          <a class="govuk-link" href="{{ ['clientRegistry.', env, '.', service, '.link_href'] | join | translate }}">
+            {{ ['clientRegistry.', env, '.', service, '.header'] | join | translate }}
+          </a>
+        </li>
+      {% endfor %}
     </ul>
 {% endblock %}

--- a/src/components/search-services/index.njk
+++ b/src/components/search-services/index.njk
@@ -3,7 +3,7 @@
 
 {% set pageTitleName = 'pages.searchServices.title' | translate %}
 
-{% block content %}
+{% block pageContent %}
     <h1 class="govuk-heading-l">{{ "pages.searchServices.heading" | translate }}</h1>
     {% set paragraphs = 'pages.searchServices.paragraphs' | translate({ returnObjects: true }) %}
     {% for paragraph in paragraphs %}


### PR DESCRIPTION
## Proposed changes

### What changed

Change "searchable list" layout to the standards two-thirds layout used on all other OLH home pages.

Replace custom html markup with design system components. 
<!-- Describe the changes in detail - the "what"-->

| Before | After |
| --- | --- |
| <img width="1191" alt="Screenshot 2025-01-23 at 09 55 38" src="https://github.com/user-attachments/assets/69300079-4bdb-4077-9a79-0b7550245f76" /> | ![Screenshot 2025-01-24 at 18 18 21](https://github.com/user-attachments/assets/d4bbe97d-5b68-473e-80a8-b2a55d205cd3) |




### Why did it change
We should use the standard layout and out-of-the-box Design System components where possible
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## How to review
The page is behind a feature flag and likely to undergo many more design changes.
You can visually check the updates by running the application locally and visiting `/search-services`
Not much would have changed visually, other than width of the content on the page.
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
