### PR TITLE
BAU: replace sonarqube cloud with sonarqube scan

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate coverage report
         run: npm run test:coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1 # pin@master
+        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # pin@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The sonarcloud-github-action is now deprecated. The recommendation is to replace it with the sonarqube-scan-action. This should work as a drop-in replacement.

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

<!-- Describe the changes in detail - the "what"-->
Implemented Sonarqube Scan to prepare for migration when our existing sonarqube cloud action is deprecated.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Sonarqube Cloud Action is being deprecated and replaced with Sonarqube scan.

### Related links
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
https://github.com/sonarsource/sonarcloud-github-action

## Testing
<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Workflow working in this PR.
