### PR TITLE
OLH-2140: Use AuthApp instead of AuthenticatorApp in URL

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -116,7 +116,7 @@ export const PATH_DATA: Record<
   CHANGE_AUTHENTICATOR_APP: {
     url: "/change-authenticator-app",
     event: EventType.ValueUpdated,
-    type: UserJourney.ChangeAuthenticatorApp,
+    type: UserJourney.ChangeAuthApp,
   },
   CHECK_YOUR_PHONE: {
     url: "/check-your-phone",
@@ -136,7 +136,7 @@ export const PATH_DATA: Record<
   AUTHENTICATOR_APP_UPDATED_CONFIRMATION: {
     url: "/change-auth-app-confirmation",
     event: EventType.Confirmation,
-    type: UserJourney.ChangeAuthenticatorApp,
+    type: UserJourney.ChangeAuthApp,
   },
   DELETE_ACCOUNT: {
     url: "/delete-account",

--- a/src/components/change-authenticator-app/change-authenticator-app-controller.ts
+++ b/src/components/change-authenticator-app/change-authenticator-app-controller.ts
@@ -95,8 +95,8 @@ export function changeAuthenticatorAppPost(
     if (isAuthenticatorAppUpdated) {
       req.session.user.authAppSecret = authAppSecret;
 
-      req.session.user.state.changeAuthenticatorApp = getNextState(
-        req.session.user.state.changeAuthenticatorApp.value,
+      req.session.user.state.changeAuthApp = getNextState(
+        req.session.user.state.changeAuthApp.value,
         EventType.ValueUpdated
       );
 

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -28,7 +28,7 @@ describe("change authenticator app controller", () => {
 
     req = new RequestBuilder()
       .withBody({})
-      .withSessionUserState({ changeAuthenticatorApp: {} })
+      .withSessionUserState({ changeAuthApp: {} })
       .withTimestampT(sandbox.fake())
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
@@ -56,7 +56,7 @@ describe("change authenticator app controller", () => {
           user: {
             email: "test@test.com",
             tokens: { accessToken: "token" },
-            state: { changeAuthenticatorApp: ["VALUE_UPDATED"] },
+            state: { changeAuthApp: ["VALUE_UPDATED"] },
           },
         },
         log: { error: sinon.fake() },
@@ -148,7 +148,7 @@ describe("change authenticator app controller", () => {
         updateAuthenticatorApp: sandbox.fake.resolves(true),
       };
       req.session.user.tokens = { accessToken: "token" } as any;
-      req.session.user.state.changeAuthenticatorApp.value = "CHANGE_VALUE";
+      req.session.user.state.changeAuthApp.value = "CHANGE_VALUE";
       req.session.mfaMethods = [
         {
           mfaIdentifier: 111111,

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-integration.test.ts
@@ -91,7 +91,7 @@ describe("Integration:: change authenticator app", () => {
         req.session.user = {
           email: "test@test.com",
           state: {
-            changeAuthenticatorApp: {
+            changeAuthApp: {
               value: "CHANGE_VALUE",
               events: ["VALUE_UPDATED", "CONFIRMATION"],
             },

--- a/src/components/common/mfa/tests/index.test.ts
+++ b/src/components/common/mfa/tests/index.test.ts
@@ -35,7 +35,7 @@ describe("render mfa page", () => {
         user: {
           email: "test@test.com",
           tokens: { accessToken: "token" },
-          state: { changeAuthenticatorApp: ["VALUE_UPDATED"] },
+          state: { changeAuthApp: ["VALUE_UPDATED"] },
         },
       },
       log: { error: sinon.fake() },
@@ -82,7 +82,7 @@ describe("render mfa page", () => {
         user: {
           email: "test@test.com",
           tokens: { accessToken: "token" },
-          state: { changeAuthenticatorApp: ["VALUE_UPDATED"] },
+          state: { changeAuthApp: ["VALUE_UPDATED"] },
         },
       },
       log: { error: sinon.fake() },

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -21,7 +21,7 @@ const REDIRECT_PATHS: Record<UserJourney, string> = {
   [UserJourney.ChangeEmail]: PATH_DATA.CHANGE_EMAIL.url,
   [UserJourney.ChangePassword]: PATH_DATA.CHANGE_PASSWORD.url,
   [UserJourney.ChangePhoneNumber]: PATH_DATA.CHANGE_PHONE_NUMBER.url,
-  [UserJourney.ChangeAuthenticatorApp]: PATH_DATA.CHANGE_AUTHENTICATOR_APP.url,
+  [UserJourney.ChangeAuthApp]: PATH_DATA.CHANGE_AUTHENTICATOR_APP.url,
   [UserJourney.DeleteAccount]: PATH_DATA.DELETE_ACCOUNT.url,
   [UserJourney.AddMfaMethod]: PATH_DATA.ADD_MFA_METHOD.url,
   [UserJourney.RemoveMfaMethod]: PATH_DATA.DELETE_MFA_METHOD.url,
@@ -57,7 +57,7 @@ const OPL_VALUES: Record<
     contentId: "375aa101-7bd6-43c2-ac39-19c864b49844",
     taxonomyLevel2: "remove backup mfa",
   },
-  changeAuthenticatorApp: {
+  changeAuthApp: {
     contentId: "9f21527b-59ec-4de3-99e7-babd5846e8de",
     taxonomyLevel2: "change auth app",
   },

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -70,7 +70,7 @@ function handleAuthAppMethod(
         linkText: t(
           "pages.security.mfaSection.supportChangeMfa.defaultMethod.app.change"
         ),
-        linkHref: `${enterPasswordUrl}&type=changeAuthenticatorApp`,
+        linkHref: `${enterPasswordUrl}&type=changeAuthApp`,
         priorityIdentifier,
       }
     : {

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -424,7 +424,7 @@ describe("security controller", () => {
           {
             text: "pages.security.mfaSection.supportChangeMfa.defaultMethod.app.title",
             linkHref:
-              "/enter-password?from=security&edit=true&type=changeAuthenticatorApp",
+              "/enter-password?from=security&edit=true&type=changeAuthApp",
             linkText:
               "pages.security.mfaSection.supportChangeMfa.defaultMethod.app.change",
             priorityIdentifier: "DEFAULT",

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -85,7 +85,7 @@ export function updateAuthenticatorAppConfirmationGet(
   req: Request,
   res: Response
 ): void {
-  delete req.session.user.state.changeAuthenticatorApp;
+  delete req.session.user.state.changeAuthApp;
 
   res.render("update-confirmation/index.njk", {
     pageTitle: req.t("pages.updateAuthenticatorAppConfirmation.title"),

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -428,7 +428,7 @@
         "header": "Enter your password",
         "paragraph": "We need to make sure it’s you before you can manage how you get security codes."
       },
-      "changeAuthenticatorApp": {
+      "changeAuthApp": {
         "header": "Enter your password",
         "paragraph": "We need to make sure it’s you before you can manage how you get security codes."
       },

--- a/src/utils/state-machine.ts
+++ b/src/utils/state-machine.ts
@@ -10,7 +10,7 @@ enum UserJourney {
   ChangeEmail = "changeEmail",
   ChangePassword = "changePassword",
   ChangePhoneNumber = "changePhoneNumber",
-  ChangeAuthenticatorApp = "changeAuthenticatorApp",
+  ChangeAuthApp = "changeAuthApp",
   DeleteAccount = "deleteAccount",
   AddMfaMethod = "addMfaMethod",
   RemoveMfaMethod = "removeMfaMethod",


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use `changeAuthApp` instead of `changeAuthenticatorApp` in the URL on the enter password page.

### Why did it change

This is consistent with the rest of the content.

I could have just changed the key since that's the only part which shows up in the URL, but all the other states have have the state machine variant, key etc. all called the same thing. I think we'd be making our future lives harder if we made this one different.


## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


### Sign-offs
<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [ ] Design updates have been signed off by a member of the UCD team

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
