### PR TITLE
BAU: Safely check for an existing secret

### DIFF
--- a/src/components/common/mfa/index.ts
+++ b/src/components/common/mfa/index.ts
@@ -25,7 +25,7 @@ export async function renderMfaMethodPage(
   try {
     assert(req.session.user.email, "email not set in session");
 
-    const authAppSecret = req.body.authAppSecret || generateMfaSecret();
+    const authAppSecret = req.body?.authAppSecret || generateMfaSecret();
 
     const qrCodeText = generateQRCodeValue(
       authAppSecret,


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Safely check for an existing auth app secret in the request body.

### Why did it change

Use optional chaining to safely check for an existing app secret. This is needed because it's possible to reach the create auth app page in such a way where there's no `req.body` present - eg. when a user is redirected to this page after confirming their password.

This fixes a bug I found when running the app locally and getting a 500 status code whenever I tried to set up a new app.

### Related links

https://gds.slack.com/archives/C011Y5SAY3U/p1742903618471749
