### PR TITLE
OLH-2140: Add a backlink to the "Set up an authenticator app" page

### DIFF
--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -47,6 +47,7 @@ describe("addMfaAppMethodGet", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      backLink: undefined,
       errors: undefined,
       errorList: undefined,
     });

--- a/src/components/change-authenticator-app/change-authenticator-app-controller.ts
+++ b/src/components/change-authenticator-app/change-authenticator-app-controller.ts
@@ -14,12 +14,21 @@ import { containsNumbersOnly } from "../../utils/strings";
 
 const CHANGE_AUTHENTICATOR_APP_TEMPLATE = "change-authenticator-app/index.njk";
 
+const backLink = `${PATH_DATA.ENTER_PASSWORD.url}?type=changeAuthApp`;
+
 export async function changeAuthenticatorAppGet(
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {
-  return renderMfaMethodPage(CHANGE_AUTHENTICATOR_APP_TEMPLATE, req, res, next);
+  return renderMfaMethodPage(
+    CHANGE_AUTHENTICATOR_APP_TEMPLATE,
+    req,
+    res,
+    next,
+    undefined,
+    backLink
+  );
 }
 
 export function changeAuthenticatorAppPost(
@@ -39,7 +48,8 @@ export function changeAuthenticatorAppPost(
         formatValidationError(
           "code",
           req.t("pages.addMfaMethodApp.errors.invalidFormat")
-        )
+        ),
+        backLink
       );
     }
 
@@ -52,7 +62,8 @@ export function changeAuthenticatorAppPost(
         formatValidationError(
           "code",
           req.t("pages.addMfaMethodApp.errors.maxLength")
-        )
+        ),
+        backLink
       );
     }
 
@@ -65,7 +76,8 @@ export function changeAuthenticatorAppPost(
         formatValidationError(
           "code",
           req.t("pages.addMfaMethodApp.errors.invalidCode")
-        )
+        ),
+        backLink
       );
     }
 

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -87,6 +87,7 @@ describe("change authenticator app controller", () => {
           authAppSecret: "A".repeat(20),
           qrCode: await QRCode.toDataURL("qrcode"),
           formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+          backLink: undefined,
           errors: undefined,
           errorList: undefined,
         }
@@ -214,6 +215,7 @@ describe("change authenticator app controller", () => {
           authAppSecret: "qwer42312345342",
           qrCode: await QRCode.toDataURL("qrcode"),
           formattedSecret: "qwer 4231 2345 342",
+          backLink: undefined,
           errors: { code: { text: undefined, href: "#code" } },
           errorList: [{ text: undefined, href: "#code" }],
         }

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -87,7 +87,7 @@ describe("change authenticator app controller", () => {
           authAppSecret: "A".repeat(20),
           qrCode: await QRCode.toDataURL("qrcode"),
           formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
-          backLink: undefined,
+          backLink: `${PATH_DATA.ENTER_PASSWORD.url}?type=changeAuthApp`,
           errors: undefined,
           errorList: undefined,
         }
@@ -215,7 +215,7 @@ describe("change authenticator app controller", () => {
           authAppSecret: "qwer42312345342",
           qrCode: await QRCode.toDataURL("qrcode"),
           formattedSecret: "qwer 4231 2345 342",
-          backLink: undefined,
+          backLink: `${PATH_DATA.ENTER_PASSWORD.url}?type=changeAuthApp`,
           errors: { code: { text: undefined, href: "#code" } },
           errorList: [{ text: undefined, href: "#code" }],
         }

--- a/src/components/common/mfa/index.ts
+++ b/src/components/common/mfa/index.ts
@@ -20,7 +20,8 @@ export async function renderMfaMethodPage(
   req: Request,
   res: Response,
   next: NextFunction,
-  errors?: ReturnType<typeof formatValidationError>
+  errors?: ReturnType<typeof formatValidationError>,
+  backLink?: string
 ): Promise<void> {
   try {
     assert(req.session.user.email, "email not set in session");
@@ -38,6 +39,7 @@ export async function renderMfaMethodPage(
       authAppSecret,
       qrCode,
       formattedSecret: splitSecretKeyIntoFragments(authAppSecret).join(" "),
+      backLink,
       errors,
       errorList: generateErrorList(errors),
     });

--- a/src/components/common/mfa/tests/index.test.ts
+++ b/src/components/common/mfa/tests/index.test.ts
@@ -66,6 +66,7 @@ describe("render mfa page", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      backLink: undefined,
       errors: {},
       errorList: [],
     });
@@ -116,6 +117,7 @@ describe("render mfa page", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      backLink: undefined,
       errors: {
         code: {
           text: "pages.renderUpdateAuthAppPage.errors.maxLength",
@@ -128,6 +130,55 @@ describe("render mfa page", () => {
           href: "#code",
         },
       ],
+    });
+  });
+
+  it("should pass the supplied backlink through to the template", async () => {
+    const req = {
+      body: {
+        code: "qrcode",
+        authAppSecret: "A".repeat(20),
+      },
+      session: {
+        id: "session_id",
+        user: {
+          email: "test@test.com",
+          tokens: { accessToken: "token" },
+          state: { changeAuthenticatorApp: ["VALUE_UPDATED"] },
+        },
+      },
+      log: { error: sinon.fake() },
+      ip: "127.0.0.1",
+      t: (t: string) => t,
+    };
+    const res = {
+      locals: {
+        persistentSessionId: "persistentSessionId",
+      },
+      render: sandbox.fake(),
+      redirect: sandbox.fake(() => {}),
+    };
+    const next = sinon.spy();
+
+    sandbox.replace(mfaModule, "generateMfaSecret", () => "A".repeat(20));
+    sandbox.replace(mfaModule, "generateQRCodeValue", () => "qrcode");
+    const templateFilePath = "abc.njk";
+    await renderMfaMethodPage(
+      templateFilePath,
+      req as unknown as Request,
+      res as unknown as Response,
+      next,
+      undefined,
+      "backlink"
+    );
+
+    expect(res.render).to.have.been.calledWith(templateFilePath, {
+      authAppSecret: "A".repeat(20),
+      qrCode: await QRCode.toDataURL("qrcode"),
+      formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      errors: undefined,
+      errorList: undefined,
+      backLink: "backlink",
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add a backlink to the "Set up an authenticator app" page which takes the user back to the enter password page with the correct `type` parameter for this journey. This works for both the GET and POST responses when the template is
re-rendered with errors.

I'm 90% sure this works fine with our state machine. I've clicked back and forth a few times and I'm able to complete the journey. We'll be able to catch any errors in our next team review before we put this live.

To do this, I've added another optional parameter to `renderMfaMethodPage`. Two optional parameters is ok for this function, but  think if we add another we should consider exposing the parameters as a separate interface object instead.

![image](https://github.com/user-attachments/assets/64bffc68-8731-49d3-817b-00828f372f84)

### Why did it change

To match the Figma design.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [ ] Design updates have been signed off by a member of the UCD team
