### PR TITLE
OLH-2140: Allow passing a backlink to renderMfaMethodPage

### DIFF
--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -47,6 +47,7 @@ describe("addMfaAppMethodGet", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      backLink: undefined,
       errors: undefined,
       errorList: undefined,
     });

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -87,6 +87,7 @@ describe("change authenticator app controller", () => {
           authAppSecret: "A".repeat(20),
           qrCode: await QRCode.toDataURL("qrcode"),
           formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+          backLink: undefined,
           errors: undefined,
           errorList: undefined,
         }
@@ -214,6 +215,7 @@ describe("change authenticator app controller", () => {
           authAppSecret: "qwer42312345342",
           qrCode: await QRCode.toDataURL("qrcode"),
           formattedSecret: "qwer 4231 2345 342",
+          backLink: undefined,
           errors: { code: { text: undefined, href: "#code" } },
           errorList: [{ text: undefined, href: "#code" }],
         }

--- a/src/components/common/mfa/index.ts
+++ b/src/components/common/mfa/index.ts
@@ -20,7 +20,8 @@ export async function renderMfaMethodPage(
   req: Request,
   res: Response,
   next: NextFunction,
-  errors?: ReturnType<typeof formatValidationError>
+  errors?: ReturnType<typeof formatValidationError>,
+  backLink?: string
 ): Promise<void> {
   try {
     assert(req.session.user.email, "email not set in session");
@@ -38,6 +39,7 @@ export async function renderMfaMethodPage(
       authAppSecret,
       qrCode,
       formattedSecret: splitSecretKeyIntoFragments(authAppSecret).join(" "),
+      backLink,
       errors,
       errorList: generateErrorList(errors),
     });

--- a/src/components/common/mfa/tests/index.test.ts
+++ b/src/components/common/mfa/tests/index.test.ts
@@ -66,6 +66,7 @@ describe("render mfa page", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      backLink: undefined,
       errors: {},
       errorList: [],
     });
@@ -116,6 +117,7 @@ describe("render mfa page", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      backLink: undefined,
       errors: {
         code: {
           text: "pages.renderUpdateAuthAppPage.errors.maxLength",
@@ -128,6 +130,55 @@ describe("render mfa page", () => {
           href: "#code",
         },
       ],
+    });
+  });
+
+  it("should pass the supplied backlink through to the template", async () => {
+    const req = {
+      body: {
+        code: "qrcode",
+        authAppSecret: "A".repeat(20),
+      },
+      session: {
+        id: "session_id",
+        user: {
+          email: "test@test.com",
+          tokens: { accessToken: "token" },
+          state: { changeAuthenticatorApp: ["VALUE_UPDATED"] },
+        },
+      },
+      log: { error: sinon.fake() },
+      ip: "127.0.0.1",
+      t: (t: string) => t,
+    };
+    const res = {
+      locals: {
+        persistentSessionId: "persistentSessionId",
+      },
+      render: sandbox.fake(),
+      redirect: sandbox.fake(() => {}),
+    };
+    const next = sinon.spy();
+
+    sandbox.replace(mfaModule, "generateMfaSecret", () => "A".repeat(20));
+    sandbox.replace(mfaModule, "generateQRCodeValue", () => "qrcode");
+    const templateFilePath = "abc.njk";
+    await renderMfaMethodPage(
+      templateFilePath,
+      req as unknown as Request,
+      res as unknown as Response,
+      next,
+      undefined,
+      "backlink"
+    );
+
+    expect(res.render).to.have.been.calledWith(templateFilePath, {
+      authAppSecret: "A".repeat(20),
+      qrCode: await QRCode.toDataURL("qrcode"),
+      formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
+      errors: undefined,
+      errorList: undefined,
+      backLink: "backlink",
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Allow an optional backlink to be rendered on MFA pages. To do this, I've added another optional parameter to renderMfaMethodPage. Two optional parameters is ok for this function, but I think if we add another we should consider exposing the parameters as a separate interface object instead.

This just allows us to add backlinks. No pages have them set up so this PR doesn't make any changes to the user journey.

### Why did it change

I initially made this change as part of #2053, but when reviewing we realised we didn't actually want a backlink on that page. We will want on on some of the other MFA pages though, so I've pulled this commit out into a separate PR so we can use the same functionality later on. 

### Related links

#2053

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
