### PR TITLE
[BAU] Increase ApiGatewayStatus4xxAlarm Threshold

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2263,8 +2263,8 @@ Resources:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
-      DatapointsToAlarm: 3
-      Threshold: 20
+      DatapointsToAlarm: 5
+      Threshold: 80
       TreatMissingData: missing
       Metrics:
         - Id: errorThreshold


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[BAU] Increase ApiGatewayStatus4xxAlarm Threshold

### What changed

<!-- Describe the changes in detail - the "what"-->
Threshold increased along with number of datapoints to alarm

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Currently the alarm is tripping due to bot traffic scanning the site. This is diluting the alert's in the channel whilst provided no benefit. The purpose of the alarm was to notify us if all users were getting 4xx messages as quick as possible. Thus the threshold has been increased to identify a more significant number of errors over a longer period. 

