### PR TITLE
OLH-2534: Use the MFA API client when a user adds an app

### DIFF
--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -11,6 +11,9 @@ import {
 import { PATH_DATA } from "../../../app.constants";
 import * as mfaModule from "../../../utils/mfa";
 import QRCode from "qrcode";
+import { MfaClient } from "../../../utils/mfaClient";
+import { AuthAppMethod, MfaMethod } from "../../../utils/mfaClient/types";
+import * as mfaClient from "../../../utils/mfaClient";
 
 describe("addMfaAppMethodGet", () => {
   let sandbox: SinonSandbox;
@@ -72,98 +75,60 @@ describe("addMfaAppMethodGet", () => {
 });
 
 describe("addMfaAppMethodPost", () => {
-  let sandbox: SinonSandbox;
+  let mfaClientStub: sinon.SinonStubbedInstance<MfaClient>;
+  let nextSpy: sinon.SinonSpy;
+  let logSpy: sinon.SinonSpy;
+
+  const appMethod: AuthAppMethod = {
+    type: "AUTH_APP",
+    credential: "1234567890",
+  };
+
+  const mfaMethod: MfaMethod = {
+    mfaIdentifier: "1",
+    priorityIdentifier: "BACKUP",
+    methodVerified: true,
+    method: appMethod,
+  };
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
+    mfaClientStub = sinon.createStubInstance(MfaClient);
+    sinon.stub(mfaClient, "createMfaClient").returns(mfaClientStub);
+    nextSpy = sinon.spy();
+    logSpy = sinon.spy();
   });
 
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
   });
 
-  it("should redirect to add mfa app confirmation page", async () => {
+  it("should redirect to add mfa app confirmation page when successful", async () => {
     const req = {
-      headers: {
-        "txma-audit-encoded": "txma-audit-encoded",
-      },
       body: {
         code: "123456",
-        authAppSecret: "A".repeat(20),
+        authAppSecret: appMethod.credential,
       },
-      session: {
-        id: "session_id",
-        user: {
-          email: "test@test.com",
-          tokens: { accessToken: "token" },
-          state: { addBackup: { value: "APP" } },
-        },
-      },
-      log: { error: sinon.fake() },
-      ip: "127.0.0.1",
+      session: { user: { state: { addBackup: { value: "APP" } } } },
+      log: { error: logSpy },
       t: (t: string) => t,
-      cookies: {
-        lng: "en",
-      },
     };
-    const res = {
-      locals: {
-        persistentSessionId: "persistentSessionId",
-        clientSessionId: "clientSessionId",
-        trace: "trace",
-      },
-      redirect: sandbox.fake(() => {}),
-    };
-    const next = sinon.spy();
-    const addBackup = sinon.fake.returns(
-      Promise.resolve({
-        status: 200,
-        data: {
-          mfaIdentifier: 1,
-          methodVerified: true,
-          method: {
-            mfaMethodType: "AUTH_APP",
-          },
-          priorityIdentifier: "BACKUP",
-        },
-      })
-    );
 
-    sandbox.replace(mfaModule, "verifyMfaCode", () => true);
-    sandbox.replace(
-      mfaModule,
-      "addBackup",
-      addBackup as typeof mfaModule.addBackup
-    );
+    const res = { redirect: sinon.fake(() => {}) };
+
+    sinon.replace(mfaModule, "verifyMfaCode", () => true);
+    mfaClientStub.create.resolves({
+      success: true,
+      status: 200,
+      data: mfaMethod,
+    });
 
     await addMfaAppMethodPost(
       req as unknown as Request,
       res as unknown as Response,
-      next
+      nextSpy
     );
 
-    expect(addBackup).to.have.been.calledWith(
-      {
-        email: "test@test.com",
-        otp: "123456",
-        credential: "AAAAAAAAAAAAAAAAAAAA",
-        mfaMethod: {
-          priorityIdentifier: "BACKUP",
-          method: {
-            mfaMethodType: "AUTH_APP",
-          },
-        },
-      },
-      {
-        accessToken: "token",
-        sourceIp: "127.0.0.1",
-        sessionId: "session_id",
-        persistentSessionId: "persistentSessionId",
-        userLanguage: "en",
-        clientSessionId: "clientSessionId",
-        txmaAuditEncoded: "txma-audit-encoded",
-      }
-    );
+    expect(mfaClientStub.create).to.have.been.calledWith(appMethod);
 
     expect(res.redirect).to.have.been.calledWith(
       PATH_DATA.ADD_MFA_METHOD_APP_CONFIRMATION.url
@@ -174,29 +139,21 @@ describe("addMfaAppMethodPost", () => {
     const req = {
       body: {
         code: "123456",
-        authAppSecret: "A".repeat(20),
+        authAppSecret: appMethod.credential,
       },
-      session: {
-        id: "session_id",
-        user: { email: "test@test.com", tokens: { accessToken: "token" } },
-      },
-      log: { error: sinon.fake() },
-      ip: "127.0.0.1",
+      session: { user: { state: { addBackup: { value: "APP" } } } },
+      log: { error: logSpy },
     };
-    const res = {
-      locals: {
-        persistentSessionId: "persistentSessionId",
-      },
-      render: sinon.fake(),
-    };
-    const next = sinon.spy();
+    const res = { render: sinon.fake() };
 
-    sandbox.replace(mfaModule, "verifyMfaCode", () => false);
+    sinon.replace(mfaModule, "verifyMfaCode", () => false);
 
     await addMfaAppMethodPost(
       req as unknown as Request,
       res as unknown as Response,
-      next
+      nextSpy
     );
+
+    expect(mfaClientStub.create).not.to.have.been.called;
   });
 });

--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -141,8 +141,11 @@ describe("addMfaAppMethodPost", () => {
         code: "123456",
         authAppSecret: appMethod.credential,
       },
-      session: { user: { state: { addBackup: { value: "APP" } } } },
+      session: {
+        user: { state: { addBackup: { value: "APP" } }, email: "email" },
+      },
       log: { error: logSpy },
+      t: (s: string) => s,
     };
     const res = { render: sinon.fake() };
 
@@ -155,5 +158,83 @@ describe("addMfaAppMethodPost", () => {
     );
 
     expect(mfaClientStub.create).not.to.have.been.called;
+    expect(res.render).to.have.been.calledWith("add-mfa-method-app/index.njk");
+  });
+
+  it("should render an error if the code is missing", async () => {
+    const req = {
+      body: {
+        authAppSecret: appMethod.credential,
+      },
+      session: {
+        user: { state: { addBackup: { value: "APP" } }, email: "email" },
+      },
+      log: { error: logSpy },
+      t: (s: string) => s,
+    };
+    const res = { render: sinon.fake() };
+
+    sinon.replace(mfaModule, "verifyMfaCode", () => true);
+
+    await addMfaAppMethodPost(
+      req as unknown as Request,
+      res as unknown as Response,
+      nextSpy
+    );
+
+    expect(mfaClientStub.create).not.to.have.been.called;
+    expect(res.render).to.have.been.calledWith("add-mfa-method-app/index.njk");
+  });
+
+  it("should render an error if the code has letters", async () => {
+    const req = {
+      body: {
+        code: "abc123",
+        authAppSecret: appMethod.credential,
+      },
+      session: {
+        user: { state: { addBackup: { value: "APP" } }, email: "email" },
+      },
+      log: { error: logSpy },
+      t: (s: string) => s,
+    };
+    const res = { render: sinon.fake() };
+
+    sinon.replace(mfaModule, "verifyMfaCode", () => true);
+
+    await addMfaAppMethodPost(
+      req as unknown as Request,
+      res as unknown as Response,
+      nextSpy
+    );
+
+    expect(mfaClientStub.create).not.to.have.been.called;
+    expect(res.render).to.have.been.calledWith("add-mfa-method-app/index.njk");
+  });
+
+  it("should render an error if the code is longer than 6 digits", async () => {
+    const req = {
+      body: {
+        code: "1234567",
+        authAppSecret: appMethod.credential,
+      },
+      session: {
+        user: { state: { addBackup: { value: "APP" } }, email: "email" },
+      },
+      log: { error: logSpy },
+      t: (s: string) => s,
+    };
+    const res = { render: sinon.fake() };
+
+    sinon.replace(mfaModule, "verifyMfaCode", () => true);
+
+    await addMfaAppMethodPost(
+      req as unknown as Request,
+      res as unknown as Response,
+      nextSpy
+    );
+
+    expect(mfaClientStub.create).not.to.have.been.called;
+    expect(res.render).to.have.been.calledWith("add-mfa-method-app/index.njk");
   });
 });

--- a/src/components/delete-mfa-method/delete-mfa-method-controller.ts
+++ b/src/components/delete-mfa-method/delete-mfa-method-controller.ts
@@ -2,9 +2,7 @@ import { Request, Response } from "express";
 import { HTTP_STATUS_CODES, PATH_DATA } from "../../app.constants";
 import { getLastNDigits } from "../../utils/phone-number";
 import { EventType, getNextState } from "../../utils/state-machine";
-import MfaClient from "../../utils/mfaClient";
-import { getRequestConfig } from "../../utils/http";
-import { getTxmaHeader } from "../../utils/txma-header";
+import { createMfaClient } from "../../utils/mfaClient";
 import { MfaMethod } from "../../utils/mfaClient/types";
 
 export async function deleteMfaMethodGet(
@@ -41,17 +39,7 @@ export async function deleteMfaMethodPost(
     return;
   }
 
-  const mfaClient = new MfaClient(
-    req.session.user?.publicSubjectId,
-    getRequestConfig({
-      token: req.session.user.tokens.accessToken,
-      sourceIp: req.ip,
-      persistentSessionId: res.locals.persistentSessionId,
-      sessionId: res.locals.sessionId,
-      clientSessionId: res.locals.clientSessionId,
-      txmaAuditEncoded: getTxmaHeader(req, res.locals.trace),
-    })
-  );
+  const mfaClient = createMfaClient(req, res);
 
   const response = await mfaClient.delete(methodToRemove);
 

--- a/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
+++ b/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
@@ -4,10 +4,8 @@ import { describe } from "mocha";
 import { deleteMfaMethodPost } from "../delete-mfa-method-controller";
 import { Request } from "express";
 import { sinon } from "../../../../test/utils/test-utils";
-import MfaClient from "../../../utils/mfaClient";
+import { MfaClient } from "../../../utils/mfaClient";
 import { MfaMethod, SmsMethod } from "../../../utils/mfaClient/types";
-import * as http from "../../../utils/http";
-import * as txma from "../../../utils/txma-header";
 import * as mfaClient from "../../../utils/mfaClient";
 
 describe("delete mfa method controller", () => {
@@ -57,9 +55,7 @@ describe("delete mfa method controller", () => {
 
   beforeEach(() => {
     mfaClientStub = sinon.createStubInstance(MfaClient);
-    sinon.replace(http, "getRequestConfig", sinon.stub().returns({}));
-    sinon.replace(txma, "getTxmaHeader", sinon.stub().returns("txmaHeader"));
-    sinon.stub(mfaClient, "default").returns(mfaClientStub);
+    sinon.stub(mfaClient, "createMfaClient").returns(mfaClientStub);
   });
 
   afterEach(() => {

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -24,7 +24,7 @@ export interface SmsMethod extends Method {
 }
 
 export interface AuthAppMethod extends Method {
-  mfaMethodType: "AUTH_APP";
+  type: "AUTH_APP";
   credential: string;
 }
 

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -3,7 +3,7 @@ import { describe } from "mocha";
 import sinon from "sinon";
 
 import { Http } from "../../../src/utils/http";
-import MfaClient, { buildResponse } from "../../../src/utils/mfaClient";
+import { MfaClient, buildResponse } from "../../../src/utils/mfaClient";
 import { MfaMethod, SmsMethod } from "../../../src/utils/mfaClient/types";
 import { getRequestConfig } from "../../../src/utils/http";
 import { AxiosInstance, AxiosResponse } from "axios";


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use the new MFA API client when a users adds an authenticator app as a backup method. This PR also includes some refactoring to make creating an instance of the MFA API client nicer in the controllers and some extra tests for behaviour on the 'add an app MFA' controller. 

### Why did it change

I'm replacing all the journeys with the new API client to reduce complexity and repetition in our controllers.

### Related links

This depends on #2078 being merged first.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
