### PR TITLE
[OLH-2140] render the correct error message when changing authentication app and code is empty

### DIFF
--- a/src/components/change-authenticator-app/change-authenticator-app-controller.ts
+++ b/src/components/change-authenticator-app/change-authenticator-app-controller.ts
@@ -30,6 +30,19 @@ export function changeAuthenticatorAppPost(
 
     assert(authAppSecret, "authAppSecret not set in body");
 
+    if (!code) {
+      return renderMfaMethodPage(
+        CHANGE_AUTHENTICATOR_APP_TEMPLATE,
+        req,
+        res,
+        next,
+        formatValidationError(
+          "code",
+          req.t("pages.addBackupApp.errors.required")
+        )
+      );
+    }
+
     if (!containsNumbersOnly(code)) {
       return renderMfaMethodPage(
         CHANGE_AUTHENTICATOR_APP_TEMPLATE,


### PR DESCRIPTION
## Proposed changes

Render the error message `Enter the code shown in your authenticator app` when changing authenticator app and a code is not entered.

### What changed

It now shows the error message `Enter the code shown in your authenticator app` when changing authenticator app and a code is not entered, rather than the error message `Enter the code using only numbers`.

### Related links

https://govukverify.atlassian.net/browse/OLH-2140

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Sign-offs

- [x] Design updates have been signed off by a member of the UCD team