### PR TITLE
OLH-2534: Use the MFA API client when a user switches the default method

### DIFF
--- a/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
+++ b/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
@@ -84,7 +84,7 @@ export async function addMfaAppMethodPost(
     }
 
     const newMethod: AuthAppMethod = {
-      type: "AUTH_APP",
+      mfaMethodType: "AUTH_APP",
       credential: authAppSecret,
     };
 

--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -80,7 +80,7 @@ describe("addMfaAppMethodPost", () => {
   let logSpy: sinon.SinonSpy;
 
   const appMethod: AuthAppMethod = {
-    type: "AUTH_APP",
+    mfaMethodType: "AUTH_APP",
     credential: "1234567890",
   };
 

--- a/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
+++ b/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
@@ -18,7 +18,7 @@ describe("delete mfa method controller", () => {
     mfaIdentifier: "1",
     priorityIdentifier: "BACKUP",
     methodVerified: true,
-    method: { type: "SMS", phoneNumber: "1234567890" } as SmsMethod,
+    method: { mfaMethodType: "SMS", phoneNumber: "1234567890" } as SmsMethod,
   };
 
   const generateRequest = (idToRemove: string) => {

--- a/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
@@ -81,7 +81,7 @@ describe("change default method", () => {
   describe("POST", () => {
     let mfaClientStub: sinon.SinonStubbedInstance<mfaClient.MfaClient>;
     const appMethod: AuthAppMethod = {
-      type: "AUTH_APP",
+      mfaMethodType: "AUTH_APP",
       credential: "1234567890",
     };
 

--- a/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
@@ -6,16 +6,12 @@ import {
   switchBackupMfaMethodPost,
   switchBackupMfaMethodGet,
 } from "../switch-backup-method-controller";
-import * as mfa from "../../../utils/mfa";
-import * as mfaCommon from "../../common/mfa";
-import { UpdateInformationSessionValues } from "../../../utils/types";
+import * as mfaClient from "../../../utils/mfaClient";
+import { AuthAppMethod, MfaMethod } from "../../../utils/mfaClient/types";
 
 describe("change default method", () => {
-  let sandbox: sinon.SinonSandbox;
-
   const statusFn = sinon.spy();
   const redirectFn = sinon.spy();
-  const changeFn = sinon.spy();
 
   const generateRequest = (id: string, noBackup = true, noDefault = true) => {
     const mfaMethods: any[] = [];
@@ -60,18 +56,6 @@ describe("change default method", () => {
     };
   };
 
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.replace(mfa, "changeDefaultMfaMethod", changeFn);
-    sandbox.replace(mfaCommon, "generateSessionDetails", () => {
-      return Promise.resolve({} as UpdateInformationSessionValues);
-    });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe("GET", () => {
     it("should return a 404 if there is no backup method", async () => {
       const req = generateRequest("1", true);
@@ -95,18 +79,61 @@ describe("change default method", () => {
   });
 
   describe("POST", () => {
+    let mfaClientStub: sinon.SinonStubbedInstance<mfaClient.MfaClient>;
+    const appMethod: AuthAppMethod = {
+      type: "AUTH_APP",
+      credential: "1234567890",
+    };
+
+    const mfaMethod: MfaMethod = {
+      mfaIdentifier: "1",
+      priorityIdentifier: "BACKUP",
+      methodVerified: true,
+      method: appMethod,
+    };
+
+    beforeEach(() => {
+      mfaClientStub = sinon.createStubInstance(mfaClient.MfaClient);
+      sinon.stub(mfaClient, "createMfaClient").returns(mfaClientStub);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it("should change the DEFAULT MFA method", async () => {
-      const req = generateRequest("1", false);
+      const req = {
+        session: {
+          mfaMethods: [
+            mfaMethod,
+            { ...mfaMethod, priorityIdentifier: "DEFAULT", mfaIdentifier: "2" },
+          ],
+          user: {
+            state: {
+              switchBackupMethod: {
+                value: "CHANGE_VALUE",
+              },
+            },
+          },
+        },
+        body: { newDefault: mfaMethod.mfaIdentifier },
+      };
       const res = generateResponse();
+
+      mfaClientStub.makeDefault.resolves({
+        data: [mfaMethod],
+        success: true,
+        status: 200,
+      });
 
       //@ts-expect-error req and res aren't valid objects since they are mocked
       await switchBackupMfaMethodPost(req as Request, res as Response);
 
-      expect(changeFn).to.be.calledWith(1);
+      expect(mfaClientStub.makeDefault).to.be.calledWith(mfaMethod);
       expect(redirectFn).to.be.calledWith("/switch-methods-confirmation");
     });
 
-    it("should return a 404 if the new defualt method doesn't exist", async () => {
+    it("should return a 404 if the new default method doesn't exist", async () => {
       const req = generateRequest("5", false);
       const res = generateResponse();
 
@@ -116,13 +143,12 @@ describe("change default method", () => {
       expect(statusFn).to.be.calledWith(404);
     });
 
-    it("should return a 500 if there is an error when changing the defualt method", async () => {
-      sandbox.restore();
-      sandbox.replace(mfa, "changeDefaultMfaMethod", () => {
-        throw Error("error!");
-      });
-      sandbox.replace(mfaCommon, "generateSessionDetails", () => {
-        return Promise.resolve({} as UpdateInformationSessionValues);
+    it("should return a 500 if the request to the API fails", async () => {
+      mfaClientStub.makeDefault.resolves({
+        data: [mfaMethod],
+        success: false,
+        status: 500,
+        problem: { title: "Internal server error" },
       });
 
       const req = generateRequest("1", false);

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -90,7 +90,7 @@ describe("update confirmation controller", () => {
       mfaIdentifier: "1",
       priorityIdentifier: "BACKUP",
       methodVerified: true,
-      method: { type: "SMS", phoneNumber: "1234567890" } as SmsMethod,
+      method: { mfaMethodType: "SMS", phoneNumber: "1234567890" } as SmsMethod,
     };
 
     req = {

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -132,11 +132,11 @@ export async function removeMfaMethodConfirmationGet(
     return "" + m.mfaIdentifier == req.query.id;
   }) as unknown as MfaMethod;
 
-  if (removedMethod?.method.type === "AUTH_APP") {
+  if (removedMethod?.method.mfaMethodType === "AUTH_APP") {
     message = req.t("pages.removeBackupMethod.confirm.message_app");
   }
 
-  if (removedMethod?.method.type === "SMS") {
+  if (removedMethod?.method.mfaMethodType === "SMS") {
     const method = removedMethod.method as SmsMethod;
     message = req
       .t("pages.removeBackupMethod.confirm.message_sms")

--- a/src/utils/mfa/index.ts
+++ b/src/utils/mfa/index.ts
@@ -67,30 +67,6 @@ export function addBackup(
   );
 }
 
-export async function changeDefaultMfaMethod(
-  mfaMethodId: number,
-  sessionDetails: UpdateInformationSessionValues
-): Promise<void> {
-  const http = new Http(getMfaServiceUrl());
-  const { accessToken, sourceIp, persistentSessionId, sessionId } =
-    sessionDetails;
-
-  return http.client.put(
-    format(METHOD_MANAGEMENT_API.MFA_METHODS_PUT, mfaMethodId),
-    {
-      mfaMethod: {
-        priorityIdentifier: "DEFAULT",
-      },
-    },
-    getRequestConfig({
-      token: accessToken,
-      sourceIp,
-      persistentSessionId,
-      sessionId,
-    })
-  );
-}
-
 async function retrieveMfaMethods(
   accessToken: string,
   email: string,

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -58,6 +58,17 @@ export class MfaClient implements MfaClientInterface {
 
     return buildResponse(response);
   }
+
+  async makeDefault(method: MfaMethod) {
+    const newMfaMethod: MfaMethod = {
+      mfaIdentifier: method.mfaIdentifier,
+      methodVerified: method.methodVerified,
+      priorityIdentifier: "DEFAULT",
+      method: method.method,
+    };
+
+    return this.update(newMfaMethod);
+  }
 }
 
 export function buildResponse<T>(response: AxiosResponse<T>): ApiResponse<T> {

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -5,6 +5,7 @@ export interface MfaClientInterface {
   create: (method: Method) => Promise<ApiResponse<MfaMethod>>;
   update: (method: MfaMethod) => Promise<ApiResponse<MfaMethod[]>>;
   delete: (method: MfaMethod) => Promise<ApiResponse<any>>;
+  makeDefault: (method: MfaMethod) => Promise<ApiResponse<MfaMethod[]>>;
 }
 
 export interface MfaMethod {

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -16,16 +16,16 @@ export interface MfaMethod {
 }
 
 export interface Method {
-  type: string;
+  mfaMethodType: string;
 }
 
 export interface SmsMethod extends Method {
-  type: "SMS";
+  mfaMethodType: "SMS";
   phoneNumber: string;
 }
 
 export interface AuthAppMethod extends Method {
-  type: "AUTH_APP";
+  mfaMethodType: "AUTH_APP";
   credential: string;
 }
 

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -127,6 +127,36 @@ describe("MfaClient", () => {
         .true;
     });
   });
+
+  describe("makeDefault", () => {
+    it("should PUT to the endpoint", async () => {
+      const putStub = sinon.stub().resolves({ data: [mfaMethod] });
+      axiosStub.put = putStub;
+
+      const response = await client.makeDefault(mfaMethod);
+
+      expect(response.data.length).to.eq(1);
+      expect(response.data[0]).to.eq(mfaMethod);
+      expect(putStub.calledOnce).to.be.true;
+    });
+
+    it("should call the API and change the priority to DEFAULT", async () => {
+      const putStub = sinon.stub().resolves({ data: [mfaMethod] });
+      axiosStub.put = putStub;
+
+      const backupMethod: MfaMethod = {
+        ...mfaMethod,
+        priorityIdentifier: "BACKUP",
+      };
+
+      await client.makeDefault(backupMethod);
+
+      expect(putStub).to.have.been.calledWith(
+        "/mfa-methods/publicSubjectId/1234",
+        { mfaMethod }
+      );
+    });
+  });
 });
 
 describe("buildRequest", () => {

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -18,7 +18,7 @@ const mfaMethod: MfaMethod = {
   mfaIdentifier: "1234",
   methodVerified: true,
   method: {
-    type: "SMS",
+    mfaMethodType: "SMS",
     phoneNumber: "123456789",
   } as SmsMethod,
   priorityIdentifier: "DEFAULT",
@@ -75,7 +75,7 @@ describe("MfaClient", () => {
       axiosStub.post = postStub;
 
       const response = await client.create({
-        type: "SMS",
+        mfaMethodType: "SMS",
         phoneNumber: "123456",
       } as SmsMethod);
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use the MFA API client when a user switches their default method. To do this I've

1. added a new `.makeDefault` method to the API client
2. Used that method in the switch backup method controller
3. Deleted the old implementation

I've also corrected a mistake in one of the property names - the type should be called `mfaMethodType` (see [the API spec](https://github.com/govuk-one-login/openapi-specs/blob/main/auth/account-management-api/account-management-with-mfa-method-management.yaml#L395))

### Why did it change

I'm replacing all the journeys with the new API client to reduce complexity and repetition in our controllers.

### Related links

#2078 
#2081 

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

