### PR TITLE
OLH-2534: Refactor the MFA method types

### DIFF
--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -4,7 +4,13 @@ import { getRequestConfig, Http } from "../http";
 import { getMfaServiceUrl } from "../../config";
 import { ProblemDetail, ValidationProblem } from "../mfa/types";
 
-import { ApiResponse, Method, MfaClientInterface, MfaMethod } from "./types";
+import {
+  ApiResponse,
+  SmsMethod,
+  AuthAppMethod,
+  MfaClientInterface,
+  MfaMethod,
+} from "./types";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 import { getTxmaHeader } from "../txma-header";
 
@@ -32,7 +38,7 @@ export class MfaClient implements MfaClientInterface {
     return buildResponse(response);
   }
 
-  async create(method: Method) {
+  async create(method: SmsMethod | AuthAppMethod) {
     const response = await this.http.client.post<MfaMethod>(
       `/mfa-methods/${this.publicSubjectId}`,
       { priorityIdentifier: "DEFAULT", method: method },

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -2,7 +2,9 @@ import { ProblemDetail, ValidationProblem } from "../mfa/types";
 
 export interface MfaClientInterface {
   retrieve: () => Promise<ApiResponse<MfaMethod[]>>;
-  create: (method: Method) => Promise<ApiResponse<MfaMethod>>;
+  create: (
+    method: SmsMethod | AuthAppMethod
+  ) => Promise<ApiResponse<MfaMethod>>;
   update: (method: MfaMethod) => Promise<ApiResponse<MfaMethod[]>>;
   delete: (method: MfaMethod) => Promise<ApiResponse<any>>;
   makeDefault: (method: MfaMethod) => Promise<ApiResponse<MfaMethod[]>>;
@@ -11,20 +13,16 @@ export interface MfaClientInterface {
 export interface MfaMethod {
   mfaIdentifier: string;
   priorityIdentifier: PriorityIdentifier;
-  method: Method;
+  method: SmsMethod | AuthAppMethod;
   methodVerified: boolean;
 }
 
-export interface Method {
-  mfaMethodType: string;
-}
-
-export interface SmsMethod extends Method {
+export interface SmsMethod {
   mfaMethodType: "SMS";
   phoneNumber: string;
 }
 
-export interface AuthAppMethod extends Method {
+export interface AuthAppMethod {
   mfaMethodType: "AUTH_APP";
   credential: string;
 }


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Refactor the MFA method types to use a union type for the `method` property. 

### Why did it change

When I initially set this up I thought that the Typescript compiler would allow us to pass any interface that extended `Method` to a function that required a `Method` and then would infer which interface it was based on the properties.

Unfortunately that's not quite how it works. The more Typescript-native approach to allowing multiple options for the shape of an object is a union type. This achieves the original functionality I wanted and also gives some extra protections as when we use the union type the compiler forces us to write code that can handle each variant.
### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
