### PR TITLE
OLH-2534: Add `/v1` to the MM API base URL in dev and build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -184,7 +184,7 @@ Mappings:
       SUPPORTSEARCHABLELIST: "1"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      METHODMANAGEMENTBASEURL: "https://method-management-v1-stub.home.dev.account.gov.uk"
+      METHODMANAGEMENTBASEURL: "https://method-management-v1-stub.home.dev.account.gov.uk/v1"
       SUPPORTMETHODMANAGEMENT: "1"
       GOOGLEANALYTICS4GTMCONTAINERID: "GTM-KD86CMZ"
       GA4ENABLED: "true"
@@ -218,7 +218,7 @@ Mappings:
       SUPPORTSEARCHABLELIST: "1"
       SHOWCONTACTEMERGENCYMESSAGE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
-      METHODMANAGEMENTBASEURL: "https://method-management-v1-stub.home.build.account.gov.uk"
+      METHODMANAGEMENTBASEURL: "https://method-management-v1-stub.home.build.account.gov.uk/v1"
       SUPPORTMETHODMANAGEMENT: "0"
       SUPPORTADDBACKUPMFA: "0"
       SUPPORTCHANGEMFA: "0"


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add `/v1` to the MM API base URL in dev and build
### Why did it change

In #2105 I moved this out of the API client config because the API in staging doesn't have the `/v1` in the path yet.

I forgot that our stub API does still require it. Update the API base URLs in the environments which call the stubs so they stil work.
### Related links

#2105

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed
- [x] Application configuration is up-to-date

### Testing

I'll deploy this to dev to check it's worked.
