### PR TITLE
[OLH-1983] serve valid robots.txt to hopefully show crown logo in search engine results

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1389,10 +1389,9 @@ Resources:
         - Type: fixed-response
           FixedResponseConfig:
             ContentType: text/plain
-            MessageBody: >
-              "user-agent: *"
-              "disallow: /"
-              "allow: /contact-gov-uk-one-login"
+            MessageBody: |
+              User-agent: *
+              Disallow:
             StatusCode: 200
       Conditions:
         - Field: path-pattern

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1382,24 +1382,24 @@ Resources:
       FromPort: !Ref ContainerPort
       ToPort: !Ref ContainerPort
 
-  # ApplicationLoadBalancerListenerRuleRobots:
-  #   Type: AWS::ElasticLoadBalancingV2::ListenerRule
-  #   Properties:
-  #     Actions:
-  #       - Type: fixed-response
-  #         FixedResponseConfig:
-  #           ContentType: text/plain
-  #           MessageBody: |
-  #             User-agent: *
-  #             Disallow:
-  #           StatusCode: 200
-  #     Conditions:
-  #       - Field: path-pattern
-  #         PathPatternConfig:
-  #           Values:
-  #             - "/robots.txt"
-  #     ListenerArn: !Ref ApplicationLoadBalancerListenerHTTPS
-  #     Priority: 10
+  ApplicationLoadBalancerListenerRuleRobots:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - Type: fixed-response
+          FixedResponseConfig:
+            ContentType: text/plain
+            MessageBody: |
+              User-agent: *
+              Disallow:
+            StatusCode: 200
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/robots.txt"
+      ListenerArn: !Ref ApplicationLoadBalancerListenerHTTPS
+      Priority: 10
 
   #
   # ECS Alarms

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1389,9 +1389,14 @@ Resources:
         - Type: fixed-response
           FixedResponseConfig:
             ContentType: text/plain
-            MessageBody: |
-              User-agent: *
-              Disallow:
+            MessageBody: !If
+              - IsProduction
+              - |
+                User-agent: *
+                Disallow:
+              - |
+                User-agent: *
+                Disallow: /
             StatusCode: 200
       Conditions:
         - Field: path-pattern

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1382,24 +1382,24 @@ Resources:
       FromPort: !Ref ContainerPort
       ToPort: !Ref ContainerPort
 
-  ApplicationLoadBalancerListenerRuleRobots:
-    Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Properties:
-      Actions:
-        - Type: fixed-response
-          FixedResponseConfig:
-            ContentType: text/plain
-            MessageBody: |
-              User-agent: *
-              Disallow:
-            StatusCode: 200
-      Conditions:
-        - Field: path-pattern
-          PathPatternConfig:
-            Values:
-              - "/robots.txt"
-      ListenerArn: !Ref ApplicationLoadBalancerListenerHTTPS
-      Priority: 10
+  # ApplicationLoadBalancerListenerRuleRobots:
+  #   Type: AWS::ElasticLoadBalancingV2::ListenerRule
+  #   Properties:
+  #     Actions:
+  #       - Type: fixed-response
+  #         FixedResponseConfig:
+  #           ContentType: text/plain
+  #           MessageBody: |
+  #             User-agent: *
+  #             Disallow:
+  #           StatusCode: 200
+  #     Conditions:
+  #       - Field: path-pattern
+  #         PathPatternConfig:
+  #           Values:
+  #             - "/robots.txt"
+  #     ListenerArn: !Ref ApplicationLoadBalancerListenerHTTPS
+  #     Priority: 10
 
   #
   # ECS Alarms

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -14,10 +14,6 @@
     <script src='{{ dynatraceRumUrl }}' crossorigin="anonymous" nonce='{{ scriptNonce }}'></script>
     {% endif %}
     <link href="/public/style.css" rel="stylesheet">
-
-    {% if not allowCrawl %}
-    <meta name="robots" content="noindex">
-    {% endif %}
 {% endblock %}
 
 {% block pageTitle %}

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -6,7 +6,6 @@
 {% set secondaryContactMethodEnabled = contactPhoneEnabled or contactWebchatEnabled %}
 {% set webchatLang = "welsh" if language == "cy" else "hgsgds" %}
 {% set hideTitleProductName = true %}
-{% set allowCrawl = true %}
 
 {% block head %}
   {{ super() }}


### PR DESCRIPTION
### What changed

- Updates `robots.txt` to ensure its format is valid and to allow access to all URLs in production and no URLs otherwise.
- Removes unnecessary meta robots tag from contact page.

### Why did it change

When investigating why Google is not displaying the favicon in search results for the contact page I noticed that there were some issues with the way we are controlling robot access to the site.

Standard practice is to allow access to all URLs and then blacklist specific URLs rather than to block all URLs and then whitelist certain URLs.

These current changes allow access to all URLs with nothing blacklisted. This also means that the favicons are accessible and so hopefully Google will start to show them in the search results for the contact page (I'll make a ticket to check in a few weeks).

**If there are any specific URLs we don't want to show in search results then please comment on this PR and I'll add disallow rules for them.**

Having checked the docs at https://developers.google.com/search/docs/appearance/favicon-in-search our icons appear to be configured correctly to show in the search results so hopefully these changes will be enough to get it working.

### Related links

https://govukverify.atlassian.net/browse/OLH-1983

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed