### PR TITLE
OLH-2566: Enable the activity history for all users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5245,7 +5245,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#2cc023d99ed59941288c33b8cf4fb1b476de47b0",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#c3214ec3ef80ce5db978cd76fb68f5d97d816799",
       "license": "ISC"
     },
     "node_modules/diff": {


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

This updates to the latest version of the RP registry[^1] which adds Home as an allowed activity log service.

This effectively rolls the feature out to everyone as any user who's logged into Home to view their activity history must by definition have Home in their service history.

[^1]: https://github.com/govuk-one-login/di-account-management-rp-registry/pull/53

### Why did it change

The Fraud team have given us the go-ahead to release this feature to all users following our slow rollout trial period. This is the simplest way to do that release that also allows us to roll it back later if we need to.


### Related links

[Slack conversation with approval to release.](https://gds.slack.com/archives/C02F70D2LQN/p1744630647115329)

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed