### PR TITLE
OLH-2567: Reproducible builds using npm ci

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Generate coverage report
         run: npm run test:coverage
       - name: SonarCloud Scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY tsconfig.json ./
 COPY ./src ./src
 COPY ./@types ./@types
 
-RUN npm install && npm run build && npm run clean-modules && npm install --production=true
+RUN npm ci && npm run build && npm run clean-modules && npm ci --production=true
 
 FROM node:20.19.0-alpine@sha256:8bda036ddd59ea51a23bc1a1035d3b5c614e72c01366d989f4120e8adca196d4 as final
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ npm run test:integration
 
 ### Install dependencies
 
-> To install dependencies, run npm install
+> To install dependencies, run npm ci
 
 ```shell script
-npm install
+npm ci
 ```
 
 Installs the dependencies required to run the application.

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 
 EXPOSE $PORT
 
-CMD npm install && npm run copy-assets && npm run dev
+CMD npm ci && npm run copy-assets && npm run dev

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "copy-assets": "copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && npm run copy-scripts",
     "copy-scripts": "rm -r dist/public/scripts || true && mkdir -p dist/public/scripts && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js dist/public/scripts && cp -r src/assets/javascript/* dist/public/scripts/",
     "doctor": "NODE_ENV=production clinic doctor --autocannon [ -c 10 -d 10 /healthcheck ] -- node -r dotenv/config dist/server.js && echo '\n\nRemember to clean up files in .clinic and node_trace.*.log\n'",
-    "deep-clean": "npm cache clear --force && npm cache clean --force && npm run clean && npm install && npm run build",
+    "deep-clean": "npm cache clear --force && npm cache clean --force && npm run clean && npm ci && npm run build",
     "dev": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\"",
     "dummy-server": "node dev-app.js",
     "depcheck": "depcheck",


### PR DESCRIPTION
### What changed

Use `npm ci` instead of `npm install` to install dependencies.

### Why did it change

Use of `npm ci` ensures reproducible builds by strictly installing the versions of dependencies specified in the `package-lock.json` file.

### Related links

https://govukverify.atlassian.net/browse/OLH-2567

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed