### PR TITLE
OLH-2534: Fix the API calls to create an MFA method

### DIFF
--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -10,9 +10,11 @@ import {
   AuthAppMethod,
   MfaClientInterface,
   MfaMethod,
+  CreateMfaPayload,
 } from "./types";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 import { getTxmaHeader } from "../txma-header";
+import { validateCreate } from "./validate";
 
 export class MfaClient implements MfaClientInterface {
   private readonly publicSubjectId: string;
@@ -38,10 +40,18 @@ export class MfaClient implements MfaClientInterface {
     return buildResponse(response);
   }
 
-  async create(method: SmsMethod | AuthAppMethod) {
+  async create(method: SmsMethod | AuthAppMethod, otp?: string) {
+    validateCreate(method, otp);
+    const payload: CreateMfaPayload = {
+      priorityIdentifier: "DEFAULT",
+      method: method,
+    };
+    if (otp) {
+      payload.otp = otp;
+    }
     const response = await this.http.client.post<MfaMethod>(
       `/mfa-methods/${this.publicSubjectId}`,
-      { priorityIdentifier: "DEFAULT", method: method },
+      payload,
       this.requestConfig
     );
 

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -51,7 +51,7 @@ export class MfaClient implements MfaClientInterface {
     }
     const response = await this.http.client.post<MfaMethod>(
       `/mfa-methods/${this.publicSubjectId}`,
-      payload,
+      { mfaMethod: payload },
       this.requestConfig
     );
 

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -3,7 +3,8 @@ import { ProblemDetail, ValidationProblem } from "../mfa/types";
 export interface MfaClientInterface {
   retrieve: () => Promise<ApiResponse<MfaMethod[]>>;
   create: (
-    method: SmsMethod | AuthAppMethod
+    method: SmsMethod | AuthAppMethod,
+    otp?: string
   ) => Promise<ApiResponse<MfaMethod>>;
   update: (method: MfaMethod) => Promise<ApiResponse<MfaMethod[]>>;
   delete: (method: MfaMethod) => Promise<ApiResponse<any>>;
@@ -34,4 +35,10 @@ export interface ApiResponse<T> {
   status: number;
   data: T;
   problem?: ValidationProblem | ProblemDetail;
+}
+
+export interface CreateMfaPayload {
+  priorityIdentifier: PriorityIdentifier;
+  method: SmsMethod | AuthAppMethod;
+  otp?: string;
 }

--- a/src/utils/mfaClient/validate.ts
+++ b/src/utils/mfaClient/validate.ts
@@ -9,6 +9,6 @@ export function validateCreate(
   }
 
   if (method.mfaMethodType == "SMS" && !otp) {
-    throw new Error("Must provice OTP when mfaMethodType is SMS");
+    throw new Error("Must provide OTP when mfaMethodType is SMS");
   }
 }

--- a/src/utils/mfaClient/validate.ts
+++ b/src/utils/mfaClient/validate.ts
@@ -1,0 +1,14 @@
+import { AuthAppMethod, SmsMethod } from "./types";
+
+export function validateCreate(
+  method: AuthAppMethod | SmsMethod,
+  otp?: string
+) {
+  if (method.mfaMethodType == "AUTH_APP" && otp) {
+    throw new Error("Must not provide OTP when mfaMethodType is AUTH_APP");
+  }
+
+  if (method.mfaMethodType == "SMS" && !otp) {
+    throw new Error("Must provice OTP when mfaMethodType is SMS");
+  }
+}

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -9,7 +9,12 @@ import {
   buildResponse,
   createMfaClient,
 } from "../../../src/utils/mfaClient";
-import { MfaMethod, SmsMethod } from "../../../src/utils/mfaClient/types";
+import {
+  AuthAppMethod,
+  MfaMethod,
+  SmsMethod,
+} from "../../../src/utils/mfaClient/types";
+import { validateCreate } from "../../../src/utils/mfaClient/validate";
 import { getRequestConfig } from "../../../src/utils/http";
 import { AxiosInstance, AxiosResponse } from "axios";
 import { ProblemDetail, ValidationProblem } from "../../../src/utils/mfa/types";
@@ -70,17 +75,56 @@ describe("MfaClient", () => {
   });
 
   describe("create", () => {
-    it("should POST to the endpoint", async () => {
+    it("should POST to the endpoint with an SMS app and an OTP", async () => {
       const postStub = sinon.stub().resolves({ data: mfaMethod });
       axiosStub.post = postStub;
 
-      const response = await client.create({
-        mfaMethodType: "SMS",
-        phoneNumber: "123456",
-      } as SmsMethod);
+      const response = await client.create(
+        {
+          mfaMethodType: "SMS",
+          phoneNumber: "123456",
+        },
+        "OTP"
+      );
 
       expect(response.data).to.eq(mfaMethod);
       expect(postStub.calledOnce).to.be.true;
+    });
+
+    it("should POST to the endpoint with an auth app and no OTP", async () => {
+      const authApp: MfaMethod = {
+        mfaIdentifier: "1234",
+        methodVerified: true,
+        method: {
+          mfaMethodType: "AUTH_APP",
+          credential: "abc123",
+        },
+        priorityIdentifier: "DEFAULT",
+      };
+
+      const postStub = sinon.stub().resolves({ data: authApp });
+      axiosStub.post = postStub;
+
+      const response = await client.create({
+        mfaMethodType: "AUTH_APP",
+        credential: "123456",
+      });
+
+      expect(response.data).to.eq(authApp);
+      expect(postStub.calledOnce).to.be.true;
+    });
+
+    it("should raise an error with an SMS app and no OTP", async () => {
+      const postStub = sinon.stub().resolves({ data: mfaMethod });
+      axiosStub.post = postStub;
+
+      expect(
+        client.create({
+          mfaMethodType: "SMS",
+          phoneNumber: "123456",
+        })
+      ).to.be.rejected;
+      expect(postStub.notCalled).to.be.true;
     });
   });
 
@@ -232,5 +276,40 @@ describe("createMfaClient", () => {
     expect(client.create).to.be.a("Function");
     expect(client.update).to.be.a("Function");
     expect(client.delete).to.be.a("Function");
+  });
+});
+
+describe("validateCreate", () => {
+  const smsMethod: SmsMethod = {
+    mfaMethodType: "SMS",
+    phoneNumber: "0123456789",
+  };
+  const authAppMethod: AuthAppMethod = {
+    mfaMethodType: "AUTH_APP",
+    credential: "abc123",
+  };
+
+  it("doesn't throw an error with an SMS method and an OTP", () => {
+    expect(() => {
+      validateCreate(smsMethod, "1234");
+    }).not.to.throw;
+  });
+
+  it("doesn't throw an error with an auth app method and no OTP", () => {
+    expect(() => {
+      validateCreate(authAppMethod);
+    }).not.to.throw;
+  });
+
+  it("throws an error with an auth app method and an OTP", () => {
+    expect(() => {
+      validateCreate(authAppMethod, "1234");
+    }).to.throw;
+  });
+
+  it("throws an error with an SMS method and no OTP", () => {
+    expect(() => {
+      validateCreate(smsMethod);
+    }).to.throw;
   });
 });

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -292,24 +292,24 @@ describe("validateCreate", () => {
   it("doesn't throw an error with an SMS method and an OTP", () => {
     expect(() => {
       validateCreate(smsMethod, "1234");
-    }).not.to.throw;
+    }).not.to.throw();
   });
 
   it("doesn't throw an error with an auth app method and no OTP", () => {
     expect(() => {
       validateCreate(authAppMethod);
-    }).not.to.throw;
+    }).not.to.throw();
   });
 
   it("throws an error with an auth app method and an OTP", () => {
     expect(() => {
       validateCreate(authAppMethod, "1234");
-    }).to.throw;
+    }).to.throw("Must not provide OTP when mfaMethodType is AUTH_APP");
   });
 
   it("throws an error with an SMS method and no OTP", () => {
     expect(() => {
       validateCreate(smsMethod);
-    }).to.throw;
+    }).to.throw("Must provide OTP when mfaMethodType is SMS");
   });
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

This PR includes 2 fixes to the MFA API client:
1. Pass the OTP in the API call when a user creates an SMS method.
2. Use the correct payload structure when creating a new method.

We only need to pass the OTP when a user is creating an SMS method. When they create an authenticator app our frontend can (and does) do all the required validation on the OTP they provide. 

The journey to create a new SMS method isn't migrated to use the API client yet - I'll include the OTP in the calls from the controller when I do that. This PR just has the API client changes.

### Why did it change

Andrew and I found these mistakes when we were debugging the journeys in staging. 

### Related links

[API spec](https://github.com/govuk-one-login/openapi-specs/blob/main/auth/account-management-api/account-management-with-mfa-method-management.yaml)

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed