### PR TITLE
OLH-2534: Update the error type returned by the MFA API

### DIFF
--- a/src/components/delete-mfa-method/delete-mfa-method-controller.ts
+++ b/src/components/delete-mfa-method/delete-mfa-method-controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { HTTP_STATUS_CODES, PATH_DATA } from "../../app.constants";
 import { getLastNDigits } from "../../utils/phone-number";
 import { EventType, getNextState } from "../../utils/state-machine";
-import { createMfaClient } from "../../utils/mfaClient";
+import { createMfaClient, formatErrorMessage } from "../../utils/mfaClient";
 
 export async function deleteMfaMethodGet(
   req: Request,
@@ -51,9 +51,14 @@ export async function deleteMfaMethodPost(
     req.session.removedMfaMethods = [methodToRemove];
 
     res.redirect(`${PATH_DATA.DELETE_MFA_METHOD_CONFIRMATION.url}`);
-  } else if (response.problem) {
-    throw new Error(response.problem.title);
+  } else if (response.error) {
+    req.log.error(
+      { trace: res.locals.trace },
+      formatErrorMessage("Failed delete MFA", response)
+    );
+    throw new Error(response.error.message);
   } else {
+    req.log.error({ trace: res.locals.trace }, "Failed delete MFA");
     throw new Error(`Error deleting MFA`);
   }
 }

--- a/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
+++ b/src/components/delete-mfa-method/tests/delete-mfa-method-controller.test.ts
@@ -91,7 +91,7 @@ describe("delete mfa method controller", () => {
       success: false,
       status: 400,
       data: {},
-      problem: { title: "Bad request" },
+      error: { message: "Bad request", code: 1 },
     });
 
     expect(

--- a/src/components/switch-backup-method/switch-backup-method-controller.ts
+++ b/src/components/switch-backup-method/switch-backup-method-controller.ts
@@ -3,7 +3,7 @@ import { HTTP_STATUS_CODES, PATH_DATA } from "../../app.constants";
 import { getLastNDigits } from "../../utils/phone-number";
 import { EventType, getNextState } from "../../utils/state-machine";
 import { logger } from "../../utils/logger";
-import { createMfaClient } from "../../utils/mfaClient";
+import { createMfaClient, formatErrorMessage } from "../../utils/mfaClient";
 
 export async function switchBackupMfaMethodGet(
   req: Request,
@@ -77,8 +77,10 @@ export async function switchBackupMfaMethodPost(
     if (!response.success) {
       res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
       logger.error(
-        "Switch backup method controller: error updating default MFA method",
-        response.problem.title
+        formatErrorMessage(
+          "Switch backup method controller: error updating default MFA method",
+          response
+        )
       );
       return;
     }

--- a/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
@@ -148,7 +148,7 @@ describe("change default method", () => {
         data: [mfaMethod],
         success: false,
         status: 500,
-        problem: { title: "Internal server error" },
+        error: { message: "Internal server error", code: 1 },
       });
 
       const req = generateRequest("1", false);

--- a/src/middleware/mfa-method-middleware.ts
+++ b/src/middleware/mfa-method-middleware.ts
@@ -3,7 +3,7 @@ import { ERROR_MESSAGES } from "../app.constants";
 import { getMfaServiceUrl, supportMfaPage } from "../config";
 import { logger } from "../utils/logger";
 import { legacyMfaMethodsMiddleware } from "./mfa-methods-legacy";
-import { createMfaClient } from "../utils/mfaClient";
+import { createMfaClient, formatErrorMessage } from "../utils/mfaClient";
 
 export async function mfaMethodMiddleware(
   req: Request,
@@ -19,7 +19,7 @@ export async function mfaMethodMiddleware(
     } else {
       req.log.error(
         { trace: res.locals.trace },
-        `Failed MFA retrieve with error: ${response.problem.title}`
+        formatErrorMessage("Failed MFA retrieve", response)
       );
     }
     next();

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -2,7 +2,6 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { Request, Response } from "express";
 import { getRequestConfig, Http } from "../http";
 import { getMfaServiceUrl } from "../../config";
-import { ProblemDetail, ValidationProblem } from "../mfa/types";
 
 import {
   ApiResponse,
@@ -11,6 +10,7 @@ import {
   MfaClientInterface,
   MfaMethod,
   CreateMfaPayload,
+  SimpleError,
 } from "./types";
 import { HTTP_STATUS_CODES } from "../../app.constants";
 import { getTxmaHeader } from "../txma-header";
@@ -91,28 +91,17 @@ export function buildResponse<T>(response: AxiosResponse<T>): ApiResponse<T> {
   const { status, data } = response;
   const success =
     status == HTTP_STATUS_CODES.OK || status == HTTP_STATUS_CODES.NO_CONTENT;
+  const apiResponse: ApiResponse<T> = {
+    success,
+    status,
+    data,
+  };
 
-  if (success) {
-    return {
-      success,
-      status,
-      data,
-    };
-  } else {
-    let problem: ValidationProblem | ProblemDetail;
-
-    if (status == HTTP_STATUS_CODES.BAD_REQUEST) {
-      problem = data as ValidationProblem;
-    } else {
-      problem = data as ProblemDetail;
-    }
-    return {
-      status,
-      success,
-      data,
-      problem,
-    };
+  if (!success) {
+    apiResponse.error = data as SimpleError;
   }
+
+  return apiResponse;
 }
 
 export function createMfaClient(req: Request, res: Response): MfaClient {
@@ -127,4 +116,11 @@ export function createMfaClient(req: Request, res: Response): MfaClient {
       txmaAuditEncoded: getTxmaHeader(req, res.locals.trace),
     })
   );
+}
+
+export function formatErrorMessage<T>(
+  prefix: string,
+  response: ApiResponse<T>
+) {
+  return `${prefix}. Status code: ${response.status}, API error code: ${response.error.code}, API error message: ${response.error.message}`;
 }

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -1,5 +1,3 @@
-import { ProblemDetail, ValidationProblem } from "../mfa/types";
-
 export interface MfaClientInterface {
   retrieve: () => Promise<ApiResponse<MfaMethod[]>>;
   create: (
@@ -34,11 +32,16 @@ export interface ApiResponse<T> {
   success: boolean;
   status: number;
   data: T;
-  problem?: ValidationProblem | ProblemDetail;
+  error?: SimpleError;
 }
 
 export interface CreateMfaPayload {
   priorityIdentifier: PriorityIdentifier;
   method: SmsMethod | AuthAppMethod;
   otp?: string;
+}
+
+export interface SimpleError {
+  code: number;
+  message: string;
 }

--- a/test/unit/middleware/mfa-method-middleware.test.ts
+++ b/test/unit/middleware/mfa-method-middleware.test.ts
@@ -62,14 +62,14 @@ describe("mfaMethodMiddleware", () => {
     mfaClientStub.retrieve.resolves({
       success: false,
       status: 403,
-      problem: { title: "Forbidden" },
+      error: { message: "Forbidden", code: 1 },
       data: [],
     });
 
     await mfaMethodMiddleware(req as Request, res as Response, next);
     expect(error).to.have.been.calledWith(
       { trace: res.locals.trace },
-      "Failed MFA retrieve with error: Forbidden"
+      "Failed MFA retrieve. Status code: 403, API error code: 1, API error message: Forbidden"
     );
     expect(next).to.have.been.called;
   });


### PR DESCRIPTION




## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update the error type returned by the MFA API client to match the API spec[^1].

I've also added a helper function that takes a response and formats the error data into a nice string. I considered making a new class that implements the `ApiResponse` interface so that function could be a class method but it felt like a lot of boilerplate for what's essentially the same outcome. If we have one more function that needs to operate on a response object we should reconsider that decision.

### Why did it change

Originally the API design was going to use RFC 9457[^2] as a standard format for error messages returned by the API. We'd set up the parsing, interfaces etc. to handle errors in this format.

We've now changed our mind about using the format described in that RFC and gone with a simpler error structure.

### Related links

The relevant part of the API spec is the error schema:
```yaml
    SimpleError:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
          description: API specific error code
        message:
          type: string
          description: Human readable error message
```

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

[^1]: https://github.com/govuk-one-login/openapi-specs/blob/main/auth/account-management-api/account-management-with-mfa-method-management.yaml
[^2]: https://www.rfc-editor.org/rfc/rfc9457.html