### PR TITLE
OLH-2559: Tag the Cloudfront distribution in dev

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,10 +127,28 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
+  UseFirewallTags: !Equals [!Ref Environment, dev]
+
 Mappings:
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416
+  FirewallTags:
+    dev:
+      FMSGlobalCustomPolicy: true
+      FMSGlobalCustomPolicyName: platforms
+    build:
+      FMSGlobalCustomPolicy: true
+      FMSGlobalCustomPolicyName: platforms
+    staging:
+      FMSGlobalCustomPolicy: true
+      FMSGlobalCustomPolicyName: platforms
+    integration:
+      FMSGlobalCustomPolicy: true
+      FMSGlobalCustomPolicyName: platforms
+    production:
+      FMSGlobalCustomPolicy: true
+      FMSGlobalCustomPolicyName: platforms
   Container:
     dev:
       CPU: 1024
@@ -2119,6 +2137,22 @@ Resources:
           Value: !Ref OwnerTagValue
         - Key: Source
           Value: !Ref SourceTagValue
+        - !If
+          - UseFirewallTags
+          - Key: FMSGlobalCustomPolicy
+            Value:
+              !FindInMap [FirewallTags, !Ref Environment, FMSGlobalCustomPolicy]
+          - !Ref AWS::NoValue
+        - !If
+          - UseFirewallTags
+          - Key: FMSGlobalCustomPolicyName
+            Value:
+              !FindInMap [
+                FirewallTags,
+                !Ref Environment,
+                FMSGlobalCustomPolicyName,
+              ]
+          - !Ref AWS::NoValue
 
   CloudFrontOriginRequestPolicy:
     Type: AWS::CloudFront::OriginRequestPolicy


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Tag the Cloudfront distribution in dev for firewall manager. I've deployed this to dev to make sure I've used the conditions right.

### Why did it change

Security engineering are rolling out firewall manager to manage all our WAF rules centrally. This is controlled by tags on the resources that we want to enroll in firewall manager.

Set up these tags and conditionally only apply them to the dev environment so we can test enrollment.

### Related links

See the [parent Jira ticket](https://govukverify.atlassian.net/jira/software/c/projects/OLH/boards/195?selectedIssue=OLH-2281) for more details.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
