### PR TITLE
OLH-2258: don't show cookie banner when JavaScript is disabled

### DIFF
--- a/src/components/common/layout/banner.njk
+++ b/src/components/common/layout/banner.njk
@@ -54,10 +54,7 @@
                 text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translate,
                 href: "#",
                 type: "button",
-                classes:"cookie-hide-button",
-                attributes: {
-                "aria-label": "Hide cookie banner button"
-            }
+                classes:"cookie-hide-button"
             }
         ],
             hidden: true
@@ -72,13 +69,10 @@
                 text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translate,
                 href: "#",
                 type: "button",
-                classes:"cookie-hide-button",
-                attributes: {
-                "aria-label": "Hide cookie banner button"
-            }
+                classes:"cookie-hide-button"
             }
         ],
             hidden: true
         }
-    ],  hidden: false
+    ],  hidden: true
 }) }}


### PR DESCRIPTION
### What changed and why

- Cookie banner is hidden my default which means it will not appear when JavaScript is disabled. This is okay because non-essential cookies are only set on the client. Therefore if JavaScript is disabled non-essential cookies will not be set and there is no need to show the banner.
- Unnecessary `aria-label` attributes removed from cookie banner buttons. The text on the buttons is sufficient for describing what the buttons do.

### Related links

https://govukverify.atlassian.net/browse/OLH-2258

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed