### PR TITLE
OLH-2534: Use MFA API client when adding a new SMS method

### DIFF
--- a/src/components/check-your-phone/check-your-phone-service.ts
+++ b/src/components/check-your-phone/check-your-phone-service.ts
@@ -5,7 +5,7 @@ import {
   UpdateInformationInput,
   UpdateInformationSessionValues,
 } from "../../utils/types";
-import { createOrUpdateMfaMethod, updateMfaMethod } from "../../utils/mfa";
+import { updateMfaMethod } from "../../utils/mfa";
 
 export function checkYourPhoneService(
   axios: Http = http
@@ -41,16 +41,8 @@ export function checkYourPhoneService(
     return updateMfaMethod(updateInput, sessionDetails);
   };
 
-  const addBackupService = async function (
-    updateInput: UpdateInformationInput,
-    sessionDetails: UpdateInformationSessionValues
-  ): Promise<boolean> {
-    return createOrUpdateMfaMethod(updateInput, sessionDetails);
-  };
-
   return {
     updatePhoneNumber,
     updatePhoneNumberWithMfaApi,
-    addBackupService,
   };
 }

--- a/src/components/check-your-phone/types.ts
+++ b/src/components/check-your-phone/types.ts
@@ -13,9 +13,4 @@ export interface CheckYourPhoneServiceInterface {
     updateInput: UpdateInformationInput,
     sessionDetails: UpdateInformationSessionValues
   ) => Promise<boolean>;
-
-  addBackupService: (
-    updateInput: UpdateInformationInput,
-    sessionDetails: UpdateInformationSessionValues
-  ) => Promise<boolean>;
 }


### PR DESCRIPTION


## Proposed changes

### What changed

This is the first change that touches the SMS OTP journey. There's a lot going on in that controller and this commit only adds to the complexity with some more nested if / else blocks. 

I'll be able to remove most of these once I come back here to make the same changes on the 'update phone number' journey.

Similarly on the tests, I think there's an opportunity to clean up and make sure we've got cases for each branch but it doesn't make sense to do that until I've also done the update phone number work.

### Why did it change

We're checking all the new MFA journeys and updating to use the new API client.

### Related links

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing
 I've deployed to dev and clicked through the journey. The real test will be in staging against Auth's real API with the SMS OTP. 