### PR TITLE
OLH-2534: Create new MFA methods as backup 

### DIFF
--- a/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
+++ b/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
@@ -6,7 +6,7 @@ import { formatValidationError } from "../../utils/validation";
 import { EventType, getNextState } from "../../utils/state-machine";
 import { renderMfaMethodPage } from "../common/mfa";
 import { containsNumbersOnly } from "../../utils/strings";
-import { createMfaClient } from "../../utils/mfaClient";
+import { createMfaClient, formatErrorMessage } from "../../utils/mfaClient";
 import { AuthAppMethod } from "src/utils/mfaClient/types";
 
 const ADD_MFA_METHOD_AUTH_APP_TEMPLATE = "add-mfa-method-app/index.njk";
@@ -114,9 +114,12 @@ export async function addMfaAppMethodPost(
     const response = await mfaClient.create(newMethod);
 
     if (!response.success) {
-      throw Error(
-        `Failed to add MFA method, response status: ${response.status}`
+      const errorMessage = formatErrorMessage(
+        "Failed to add MFA method",
+        response
       );
+      req.log.error({ trace: res.locals.trace }, errorMessage);
+      throw new Error(errorMessage);
     }
 
     req.session.user.state.addBackup = getNextState(

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -43,7 +43,7 @@ export class MfaClient implements MfaClientInterface {
   async create(method: SmsMethod | AuthAppMethod, otp?: string) {
     validateCreate(method, otp);
     const payload: CreateMfaPayload = {
-      priorityIdentifier: "DEFAULT",
+      priorityIdentifier: "BACKUP",
       method: method,
     };
     if (otp) {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Fix a bug we found in staging where the API client tries to create new MFA methods as default. This is a mistake as users can only create backup methods - they'll always need to create a new one as a backup and then switch their backup and default.

I've also improved the logs we get when this request fails to make it easier to diagnose this problem in the future.

### Why did it change

This fixes a bug which prevented users from adding a new MFA method.


## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
