### PR TITLE
[OLH-2458] delete account services Welsh updates

### DIFF
--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -16,12 +16,25 @@
 
  {% if services.length %}
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph2' | translate }}</p>
+
   <ul class="govuk-list govuk-list--bullet">
     {% for service in services %}
       {% set locale = ['clientRegistry.', env, '.', service.client_id, '.'] | join %}
-        <li data-test-id="service-list-item">{{ [locale, 'header'] | join | translate }}</li>
+        <li {% if currentLngWelsh and not service.isAvailableInWelsh %}lang="en"{% endif %} data-test-id="service-list-item">{{ [locale, 'header'] | join | translate }}</li>
     {% endfor %}
     </ul>
+
+    {% if currentLngWelsh and hasEnglishOnlyServices %}
+      {% set englishServicesInWelshExplanationHtml %}
+        <p class="govuk-body">{{ 'pages.deleteAccount.englishServicesInWelshExplanation.body' | translate }}</p>
+      {% endset %}
+
+      {{ govukDetails({ 
+        summaryText: 'pages.deleteAccount.englishServicesInWelshExplanation.title' | translate, 
+        html: englishServicesInWelshExplanationHtml
+      }) }}
+    {% endif %}
+
     {% if hasGovUkEmailSubscription %}
       <p class="govuk-body" data-test-id="govuk-email-subscription-info">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
     {% endif %}

--- a/src/components/delete-account/tests/delete-account-controller.test.ts
+++ b/src/components/delete-account/tests/delete-account-controller.test.ts
@@ -59,9 +59,8 @@ describe("delete account controller", () => {
   });
 
   describe("deleteAccountGet", () => {
-    it("deleteAccountGetWithoutSubjectId", () => {
-      // eslint-disable-next-line mocha/no-nested-tests
-      it("should render delete account page", () => {
+    describe("deleteAccountGetWithoutSubjectId", () => {
+      it("should render delete account page", async () => {
         const req: any = {
           body: {},
           session: {
@@ -70,33 +69,35 @@ describe("delete account controller", () => {
           },
         };
 
-        deleteAccountGet(req as Request, res as Response);
+        await deleteAccountGet(req as Request, res as Response);
         expect(res.render).to.have.calledWith("delete-account/index.njk", {
           env: getAppEnv(),
         });
       });
     });
 
-    it("deleteAccountGetWithoutServices", () => {
-      // eslint-disable-next-line mocha/no-identical-title,mocha/no-nested-tests
-      it("should render delete account page", () => {
+    describe("deleteAccountGetWithoutServices", () => {
+      it("should render delete account page", async () => {
         req = validRequest();
         const yourServices = require("../../../utils/yourServices");
         sandbox
-          .stub(yourServices, "getAllowedListServices")
+          .stub(yourServices, "getYourServicesForAccountDeletion")
           .callsFake(function (): Service[] {
             return [];
           });
 
-        deleteAccountGet(req as Request, res as Response);
+        await deleteAccountGet(req as Request, res as Response);
         expect(res.render).to.have.calledWith("delete-account/index.njk", {
-          servicesList: [],
+          hasGovUkEmailSubscription: false,
+          services: [],
           env: getAppEnv(),
+          currentLngWelsh: false,
+          hasEnglishOnlyServices: false,
         });
       });
     });
 
-    it("deleteAccountGetWithServices", () => {
+    describe("deleteAccountGetWithServices", () => {
       const serviceList: Service[] = [
         {
           client_id: "client_id",
@@ -106,20 +107,22 @@ describe("delete account controller", () => {
         },
       ];
 
-      // eslint-disable-next-line mocha/no-nested-tests
-      it("should render the delete account page with list of services used", () => {
+      it("should render the delete account page with list of services used", async () => {
         req = validRequest();
         const yourServices = require("../../../utils/yourServices");
         sandbox
-          .stub(yourServices, "getAllowedListServices")
+          .stub(yourServices, "getYourServicesForAccountDeletion")
           .callsFake(function (): Service[] {
             return serviceList;
           });
 
-        deleteAccountGet(req as Request, res as Response);
+        await deleteAccountGet(req as Request, res as Response);
         expect(res.render).to.have.calledWith("delete-account/index.njk", {
-          servicesList: serviceList,
+          services: serviceList,
           env: getAppEnv(),
+          hasGovUkEmailSubscription: false,
+          currentLngWelsh: false,
+          hasEnglishOnlyServices: true,
         });
       });
     });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -420,7 +420,11 @@
       "paragraph5": "Os byddwch angen GOV.UK One Login yn y dyfodol, bydd yn rhaid i chi greu un newydd.",
       "details": "Ni fydd dileu eich GOV.UK One Login yn effeithio ar unrhyw gyfrifon eraill y llywodraeth sydd gennych, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
       "deleteAccount": "Dileu eich GOV.UK One Login",
-      "doNotDeleteAccount": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
+      "doNotDeleteAccount": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch",
+      "englishServicesInWelshExplanation": {
+        "title": "Pam fod rhai gwasanaethau wedi eu rhestru yn Saesneg?",
+        "body": "Os nad yw gwasanaeth rydych wedi cael mynediad iddo ar gael yn Gymraeg, bydd yn ymddangos yma yn Saesneg."
+      }
     },
     "changePhoneNumber": {
       "title": "Rhowch eich rhif ffôn symudol newydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -598,7 +598,11 @@
       "paragraph5": "If you need a GOV.UK One Login in the future, you’ll have to create a new one.",
       "details": "Deleting your GOV.UK One Login will not affect any other government accounts you may have, such as Government Gateway or Universal Credit.",
       "deleteAccount": "Delete your GOV.UK One Login",
-      "doNotDeleteAccount": "Cancel and go back to Security"
+      "doNotDeleteAccount": "Cancel and go back to Security",
+      "englishServicesInWelshExplanation": {
+        "title": "Why are some services listed in English?",
+        "body": "If a service you’ve accessed is not available in Welsh it will appear here in English."
+      }
     },
     "changePhoneNumber": {
       "title": "Enter your new mobile phone number",

--- a/test/unit/utils/yourServices.test.ts
+++ b/test/unit/utils/yourServices.test.ts
@@ -37,6 +37,22 @@ describe("YourService Util", () => {
         isAvailableInWelsh: false,
       },
       {
+        client_id: "dfeApplyForTeacherTraining",
+        count_successful_logins: 2,
+        last_accessed: 14567776,
+        last_accessed_readable_format: "last_accessed_readable_format",
+        hasDetailedCard: false,
+        isAvailableInWelsh: false,
+      },
+      {
+        client_id: "vehicleOperatorLicense",
+        count_successful_logins: 3,
+        last_accessed: 14567776,
+        last_accessed_readable_format: "last_accessed_readable_format",
+        hasDetailedCard: false,
+        isAvailableInWelsh: true,
+      },
+      {
         client_id: "nonExistent",
         count_successful_logins: 1,
         last_accessed: 14567776,
@@ -207,6 +223,14 @@ describe("YourService Util", () => {
             last_accessed: 14567776,
             last_accessed_readable_format: "1 January 1970",
           },
+          {
+            client_id: "dfeApplyForTeacherTraining",
+            count_successful_logins: 2,
+            hasDetailedCard: false,
+            isAvailableInWelsh: false,
+            last_accessed: 14567776,
+            last_accessed_readable_format: "1 January 1970",
+          },
         ],
         servicesList: [
           {
@@ -216,6 +240,14 @@ describe("YourService Util", () => {
             last_accessed: 14567776,
             last_accessed_readable_format: "1 January 1970",
             isAvailableInWelsh: false,
+          },
+          {
+            client_id: "vehicleOperatorLicense",
+            count_successful_logins: 3,
+            hasDetailedCard: false,
+            isAvailableInWelsh: true,
+            last_accessed: 14567776,
+            last_accessed_readable_format: "1 January 1970",
           },
         ],
       };
@@ -242,6 +274,22 @@ describe("YourService Util", () => {
           last_accessed_readable_format: "last_accessed_readable_format",
           isAvailableInWelsh: false,
         },
+        {
+          client_id: "dfeApplyForTeacherTraining",
+          count_successful_logins: 2,
+          hasDetailedCard: false,
+          isAvailableInWelsh: false,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
+        {
+          client_id: "vehicleOperatorLicense",
+          count_successful_logins: 3,
+          hasDetailedCard: false,
+          isAvailableInWelsh: true,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
       ];
 
       const services = await yourServices.getAllowedListServices(
@@ -254,11 +302,17 @@ describe("YourService Util", () => {
 
   describe("getYourServicesForAccountDeletion", () => {
     it("returns a list of services in the expected format", async () => {
-      const mockTranslate = sinon.stub();
-      mockTranslate.onCall(0).returns("serviceA");
-      mockTranslate.onCall(1).returns("serviceB");
+      const mockTranslate = sinon.stub().callsFake((id) => id);
 
       const expectedResponse: Service[] = [
+        {
+          client_id: "dfeApplyForTeacherTraining",
+          count_successful_logins: 2,
+          hasDetailedCard: false,
+          isAvailableInWelsh: false,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
         {
           client_id: "mortgageDeed",
           count_successful_logins: 1,
@@ -275,6 +329,14 @@ describe("YourService Util", () => {
           last_accessed_readable_format: "last_accessed_readable_format",
           isAvailableInWelsh: false,
         },
+        {
+          client_id: "vehicleOperatorLicense",
+          count_successful_logins: 3,
+          hasDetailedCard: false,
+          isAvailableInWelsh: true,
+          last_accessed: 14567776,
+          last_accessed_readable_format: "last_accessed_readable_format",
+        },
       ];
 
       const services = await yourServices.getYourServicesForAccountDeletion(
@@ -283,7 +345,6 @@ describe("YourService Util", () => {
         mockTranslate
       );
       expect(services).to.deep.equal(expectedResponse);
-      expect(mockTranslate.callCount).to.eq(2);
     });
   });
 });


### PR DESCRIPTION
### What changed

- Services listed on account deletion page are displayed in alphabetical order even when there are both English titled and Welsh titled services in the list.
- When viewing the account deletion page in Welsh services listed with English titles have the attribute `lang="en"`.
- When viewing the account deletion page in Welsh and there are English titled services in the list then a message is displayed explaining why this is.

### Why did it change

To improve the experience for users using the account deletion page in Welsh.

### Related links

https://govukverify.atlassian.net/browse/OLH-2458

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Sign-offs
<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [x] Design updates have been signed off by a member of the UCD team