### PR TITLE
OLH-2560: Use Firewall Manager in build and staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,9 +127,10 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
-  UseFirewallTags: !Equals [!Ref Environment, dev]
-
-  UseFirewallManager: !Equals [!Ref Environment, dev]
+  UseFirewallManager: !Or
+    - !Equals [!Ref Environment, dev]
+    - !Equals [!Ref Environment, build]
+    - !Equals [!Ref Environment, staging]
 
 Mappings:
   ElasticLoadBalancerAccountIds:
@@ -141,10 +142,10 @@ Mappings:
       FMSGlobalCustomPolicyName: platforms
     build:
       FMSGlobalCustomPolicy: true
-      FMSGlobalCustomPolicyName: platforms
+      FMSGlobalCustomPolicyName: cloudfront
     staging:
       FMSGlobalCustomPolicy: true
-      FMSGlobalCustomPolicyName: platforms
+      FMSGlobalCustomPolicyName: cloudfront
     integration:
       FMSGlobalCustomPolicy: true
       FMSGlobalCustomPolicyName: platforms
@@ -2143,13 +2144,13 @@ Resources:
         - Key: Source
           Value: !Ref SourceTagValue
         - !If
-          - UseFirewallTags
+          - UseFirewallManager
           - Key: FMSGlobalCustomPolicy
             Value:
               !FindInMap [FirewallTags, !Ref Environment, FMSGlobalCustomPolicy]
           - !Ref AWS::NoValue
         - !If
-          - UseFirewallTags
+          - UseFirewallManager
           - Key: FMSGlobalCustomPolicyName
             Value:
               !FindInMap [


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Use Firewall Manager to manage the WAF in build and staging.

We've successfully tested in dev so we can simplify the template and make the tagging changes at the same time as we disassociate our custom ACL.

There is a risk of a few seconds downtime (of the WAF - our apps will stay up) between us removing our ACL, the tags being applied and Firewall Manager taking over. This has been investigate and accepted by security.

### Why did it change

We're moving our WAF rules to a centrally managed solution so the security team have oversight.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
