### PR TITLE
Update the MFA management base URL in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -39,7 +39,7 @@ ENVIRONMENT=
 VERIFY_ACCESS_VALUE=
 # subjectId returned from oidc stub
 MY_ONE_LOGIN_USER_ID=user_id
-METHOD_MANAGEMENT_BASE_URL=https://method-management-v1-stub.home.dev.account.gov.uk
+METHOD_MANAGEMENT_BASE_URL=https://method-management-v1-stub.home.dev.account.gov.uk/v1
 GOOGLE_ANALYTICS_4_GTM_CONTAINER_ID="GTM-KD86CMZ"
 GA4_ENABLED="true"
 SELECT_TRACKING_ENABLED="true"


### PR DESCRIPTION
### What changed

Update `.env.sample` with the correct URL for the MFA method management stub API.