### PR TITLE
[OLH-2135] MFA journey fixes post UCD review

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -27,8 +27,8 @@ export const PATH_DATA: Record<
     type: UserJourney.addBackup,
   },
   ADD_MFA_METHOD_GO_BACK: {
-    url: "/back-from-set-up-auth-app",
-    event: EventType.ValueUpdated,
+    url: "/back-from-set-up-method",
+    event: EventType.GoBackToChooseBackup,
     type: UserJourney.addBackup,
   },
   ADD_MFA_METHOD_APP_CONFIRMATION: {

--- a/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
+++ b/src/components/add-mfa-method-app/add-mfa-method-app-controller.ts
@@ -11,7 +11,9 @@ import { AuthAppMethod } from "src/utils/mfaClient/types";
 
 const ADD_MFA_METHOD_AUTH_APP_TEMPLATE = "add-mfa-method-app/index.njk";
 
-export async function addMfaAppMethodGoBackGet(
+const backLink = PATH_DATA.ADD_MFA_METHOD_GO_BACK.url;
+
+export async function addMfaMethodGoBackGet(
   req: Request,
   res: Response
 ): Promise<void> {
@@ -33,7 +35,7 @@ export async function addMfaAppMethodGet(
     res,
     next,
     undefined,
-    PATH_DATA.ADD_MFA_METHOD_GO_BACK.url
+    backLink
   );
 }
 
@@ -57,7 +59,7 @@ export async function addMfaAppMethodPost(
           "code",
           req.t("pages.addBackupApp.errors.required")
         ),
-        PATH_DATA.ADD_MFA_METHOD_GO_BACK.url
+        backLink
       );
     }
 
@@ -71,7 +73,7 @@ export async function addMfaAppMethodPost(
           "code",
           req.t("pages.addBackupApp.errors.invalidFormat")
         ),
-        PATH_DATA.ADD_MFA_METHOD_GO_BACK.url
+        backLink
       );
     }
 
@@ -85,7 +87,7 @@ export async function addMfaAppMethodPost(
           "code",
           req.t("pages.addBackupApp.errors.maxLength")
         ),
-        PATH_DATA.ADD_MFA_METHOD_GO_BACK.url
+        backLink
       );
     }
 
@@ -101,7 +103,7 @@ export async function addMfaAppMethodPost(
           "code",
           req.t("pages.addBackupApp.errors.invalidCode")
         ),
-        PATH_DATA.ADD_MFA_METHOD_GO_BACK.url
+        backLink
       );
     }
 

--- a/src/components/add-mfa-method-app/add-mfa-method-app-routes.ts
+++ b/src/components/add-mfa-method-app/add-mfa-method-app-routes.ts
@@ -4,7 +4,7 @@ import { requiresAuthMiddleware } from "../../middleware/requires-auth-middlewar
 import {
   addMfaAppMethodGet,
   addMfaAppMethodPost,
-  addMfaAppMethodGoBackGet,
+  addMfaMethodGoBackGet,
 } from "./add-mfa-method-app-controller";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
@@ -22,7 +22,7 @@ router.get(
   PATH_DATA.ADD_MFA_METHOD_GO_BACK.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  globalTryCatchAsync(addMfaAppMethodGoBackGet)
+  globalTryCatchAsync(addMfaMethodGoBackGet)
 );
 
 router.post(

--- a/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
+++ b/src/components/add-mfa-method-app/tests/add-mfa-methods-app-controller.test.ts
@@ -6,7 +6,7 @@ import { sinon } from "../../../../test/utils/test-utils";
 
 import {
   addMfaAppMethodGet,
-  addMfaAppMethodGoBackGet,
+  addMfaMethodGoBackGet,
   addMfaAppMethodPost,
 } from "../add-mfa-method-app-controller";
 import { PATH_DATA } from "../../../app.constants";
@@ -16,7 +16,7 @@ import { MfaClient } from "../../../utils/mfaClient";
 import { AuthAppMethod, MfaMethod } from "../../../utils/mfaClient/types";
 import * as mfaClient from "../../../utils/mfaClient";
 
-describe("addMfaAppMethodGoBackGet", () => {
+describe("addMfaMethodGoBackGet", () => {
   let sandbox: SinonSandbox;
 
   beforeEach(() => {
@@ -33,7 +33,7 @@ describe("addMfaAppMethodGoBackGet", () => {
     };
     const res = { redirect: sinon.fake(() => {}) };
 
-    await addMfaAppMethodGoBackGet(
+    await addMfaMethodGoBackGet(
       req as unknown as Request,
       res as unknown as Response
     );
@@ -77,7 +77,7 @@ describe("addMfaAppMethodGet", () => {
       authAppSecret: "A".repeat(20),
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "AAAA AAAA AAAA AAAA AAAA",
-      backLink: "/back-from-set-up-auth-app",
+      backLink: "/back-from-set-up-method",
       errors: undefined,
       errorList: undefined,
     });
@@ -192,7 +192,7 @@ describe("addMfaAppMethodPost", () => {
       authAppSecret: "1234567890",
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "1234 5678 90",
-      backLink: "/back-from-set-up-auth-app",
+      backLink: "/back-from-set-up-method",
       errors: {
         code: { text: "pages.addBackupApp.errors.invalidCode", href: "#code" },
       },
@@ -229,7 +229,7 @@ describe("addMfaAppMethodPost", () => {
       authAppSecret: "1234567890",
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "1234 5678 90",
-      backLink: "/back-from-set-up-auth-app",
+      backLink: "/back-from-set-up-method",
       errors: {
         code: { text: "pages.addBackupApp.errors.required", href: "#code" },
       },
@@ -267,7 +267,7 @@ describe("addMfaAppMethodPost", () => {
       authAppSecret: "1234567890",
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "1234 5678 90",
-      backLink: "/back-from-set-up-auth-app",
+      backLink: "/back-from-set-up-method",
       errors: {
         code: {
           text: "pages.addBackupApp.errors.invalidFormat",
@@ -308,7 +308,7 @@ describe("addMfaAppMethodPost", () => {
       authAppSecret: "1234567890",
       qrCode: await QRCode.toDataURL("qrcode"),
       formattedSecret: "1234 5678 90",
-      backLink: "/back-from-set-up-auth-app",
+      backLink: "/back-from-set-up-method",
       errors: {
         code: { text: "pages.addBackupApp.errors.maxLength", href: "#code" },
       },

--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
@@ -21,11 +21,13 @@ import { BadRequestError } from "../../utils/errors";
 
 const CHANGE_PHONE_NUMBER_TEMPLATE = "add-mfa-method-sms/index.njk";
 
+const backLink = PATH_DATA.ADD_MFA_METHOD_GO_BACK.url;
+
 export async function addMfaSmsMethodGet(
   req: Request,
   res: Response
 ): Promise<void> {
-  res.render("add-mfa-method-sms/index.njk");
+  res.render("add-mfa-method-sms/index.njk", { backLink });
 }
 export function addMfaSmsMethodPost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
@@ -81,14 +83,16 @@ export function addMfaSmsMethodPost(
           "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
         )
       );
-      return renderBadRequest(res, req, CHANGE_PHONE_NUMBER_TEMPLATE, error);
+      return renderBadRequest(res, req, CHANGE_PHONE_NUMBER_TEMPLATE, error, {
+        backLink,
+      });
     } else {
       throw new BadRequestError(response.message, response.code);
     }
   };
 }
 
-export async function addMfaAppMethodConfirmationGet(
+export async function addMfaSmsMethodConfirmationGet(
   req: Request,
   res: Response
 ): Promise<void> {

--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-routes.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-routes.ts
@@ -3,7 +3,7 @@ import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 import {
-  addMfaAppMethodConfirmationGet,
+  addMfaSmsMethodConfirmationGet,
   addMfaSmsMethodGet,
   addMfaSmsMethodPost,
 } from "./add-mfa-method-sms-controller";
@@ -32,7 +32,7 @@ router.get(
   PATH_DATA.ADD_MFA_METHOD_SMS_CONFIRMATION.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  globalTryCatchAsync(addMfaAppMethodConfirmationGet)
+  globalTryCatchAsync(addMfaSmsMethodConfirmationGet)
 );
 
 export { router as addBackupSmsRouter };

--- a/src/components/add-mfa-method-sms/index.njk
+++ b/src/components/add-mfa-method-sms/index.njk
@@ -1,2 +1,4 @@
 {% set formAction =  "ADD_MFA_METHOD_SMS" | getPath %}
+{% set pathToTitleString =  "pages.addBackupSms.title" %}
+{% set pathToHeadingString =  "pages.addBackupSms.heading" %}
 {% include "common/mfa/add-phone-number.njk" %}

--- a/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
+++ b/src/components/change-authenticator-app/tests/change-authenticator-app-controller.test.ts
@@ -29,7 +29,7 @@ describe("change authenticator app controller", () => {
     req = new RequestBuilder()
       .withBody({})
       .withSessionUserState({ changeAuthApp: {} })
-      .withTimestampT(sandbox.fake())
+      .withTranslate(sandbox.fake())
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
 

--- a/src/components/change-default-method/tests/change-default-method-controller.test.ts
+++ b/src/components/change-default-method/tests/change-default-method-controller.test.ts
@@ -30,7 +30,7 @@ describe("change default method controller", () => {
     req = new RequestBuilder()
       .withBody({ code: "123456", authAppSecret: "A".repeat(20) })
       .withSessionUserState({ changeDefaultMethod: { value: "APP" } })
-      .withTimestampT(sandbox.fake())
+      .withTranslate(sandbox.fake())
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
 

--- a/src/components/change-email/tests/change-email-controller.test.ts
+++ b/src/components/change-email/tests/change-email-controller.test.ts
@@ -29,7 +29,7 @@ describe("change email controller", () => {
     sandbox = sinon.createSandbox();
     req = new RequestBuilder()
       .withBody({ email: NEW_EMAIL })
-      .withTimestampT(sandbox.fake())
+      .withTranslate(sandbox.fake())
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
 

--- a/src/components/change-password/tests/change-password-controller.test.ts
+++ b/src/components/change-password/tests/change-password-controller.test.ts
@@ -41,7 +41,7 @@ describe("change password controller", () => {
     req = new RequestBuilder()
       .withBody({})
       .withSessionUserState({ changePassword: {} })
-      .withTimestampT(sandbox.fake())
+      .withTranslate(sandbox.fake())
       .withHeaders({
         "txma-audit-encoded": TXMA_AUDIT_ENCODED,
       })

--- a/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
@@ -34,7 +34,7 @@ describe("change phone number controller", () => {
     req = new RequestBuilder()
       .withBody({})
       .withSessionUserState({ changePhoneNumber: {} })
-      .withTimestampT(sandbox.fake())
+      .withTranslate(sandbox.fake())
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
 

--- a/src/components/choose-backup/index.njk
+++ b/src/components/choose-backup/index.njk
@@ -34,7 +34,7 @@
     {% if showSingleMethod %}
       <input type="hidden" name="addBackup" value="sms" />
       <h1 class="govuk-heading-l">{{ "pages.addBackup.backup.title" | translate }}</h1>
-      <p class="govuk-body">{{ pages.addBackup.backup.sms.message | translate }}</p>
+      <p class="govuk-body">{{ "pages.addBackup.backup.sms.message" | translate }}</p>
         {{ govukButton({
             "text": button_text|default("pages.addBackup.backup.sms.button" | translate, true),
             "type": "Submit",

--- a/src/components/common/mfa/add-phone-number.njk
+++ b/src/components/common/mfa/add-phone-number.njk
@@ -20,7 +20,7 @@
       label: {
       text: 'pages.changePhoneNumber.ukPhoneNumber.label' | translate
       },
-      classes: "govuk-!-width-one-half",
+      classes: "govuk-input--width-20",
       id: "phoneNumber",
       name: "phoneNumber",
       type: "tel",
@@ -37,7 +37,7 @@
         name: "internationalPhoneNumber",
         type: "tel",
         autocomplete: "tel",
-        classes: "govuk-!-width-one-half",
+        classes: "govuk-input--width-20",
         label: {
           text: 'pages.changePhoneNumber.internationalPhoneNumber.label' | translate
         },

--- a/src/components/common/mfa/add-phone-number.njk
+++ b/src/components/common/mfa/add-phone-number.njk
@@ -4,12 +4,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
-{% set pageTitleName = 'pages.changePhoneNumber.title' | translate %}
+{% set pageTitleName = pathToTitleString | translate or 'pages.changePhoneNumber.title' | translate %}
 
 {% block content %}
   {% include "common/errors/errorSummary.njk" %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.changePhoneNumber.header' |
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ pathToHeadingString | translate or 'pages.changePhoneNumber.header' |
     translate}}</h1>
 
   <form action="{{ formAction }}" method="post" novalidate>
@@ -20,7 +20,7 @@
       label: {
       text: 'pages.changePhoneNumber.ukPhoneNumber.label' | translate
       },
-      classes: "govuk-!-width-two-thirds",
+      classes: "govuk-!-width-one-half",
       id: "phoneNumber",
       name: "phoneNumber",
       type: "tel",
@@ -37,7 +37,7 @@
         name: "internationalPhoneNumber",
         type: "tel",
         autocomplete: "tel",
-        classes: "govuk-!-width-two-thirds",
+        classes: "govuk-!-width-one-half",
         label: {
           text: 'pages.changePhoneNumber.internationalPhoneNumber.label' | translate
         },

--- a/src/components/common/mfa/tests/index.test.ts
+++ b/src/components/common/mfa/tests/index.test.ts
@@ -194,7 +194,7 @@ describe("generate input fields", () => {
     req = new RequestBuilder()
       .withBody({})
       .withSessionUserState({ changeAuthenticatorApp: {} })
-      .withTimestampT(sandbox.fake())
+      .withTranslate(sandbox.fake())
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -245,7 +245,7 @@
       "backup": {
         "title": "Add a back-up method",
         "sms": {
-          "message": "You can get security codes by text message as you back-up method.",
+          "message": "You can get security codes by text message as your back-up method.",
           "button": "Add a mobile phone number"
         }
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -245,7 +245,7 @@
       "backup": {
         "title": "Add a back-up method",
         "sms": {
-          "message": "You can get security codes by text message as you back-up method",
+          "message": "You can get security codes by text message as you back-up method.",
           "button": "Add a mobile phone number"
         }
       },
@@ -285,6 +285,8 @@
       "cancel": "Cancel and go back to Security"
     },
     "addBackupSms": {
+      "title": "Enter your mobile phone number",
+      "heading": "Enter your mobile phone number",
       "confirm": {
         "title": "Add back-up phone number",
         "heading": "You've added a back-up method for getting security codes",

--- a/src/utils/state-machine.ts
+++ b/src/utils/state-machine.ts
@@ -105,6 +105,9 @@ export const amStateMachine = createMachine({
         VERIFY_CODE_SENT: {
           target: "VERIFY_CODE",
         },
+        GO_BACK_TO_CHOOSE_BACKUP: {
+          target: "CHANGE_VALUE",
+        },
       },
     },
   },

--- a/test/unit/utils/state-machine.test.ts
+++ b/test/unit/utils/state-machine.test.ts
@@ -101,7 +101,10 @@ describe("state-machine", () => {
     it("should move state from CHANGE_VALUE state to SMS state when SELECTED_SMS action event ", () => {
       const nextState = getNextState("CHANGE_VALUE", EventType.SelectedSms);
       expect(nextState.value).to.equal("SMS");
-      expect(nextState.events).to.all.members([EventType.VerifyCodeSent]);
+      expect(nextState.events).to.all.members([
+        EventType.VerifyCodeSent,
+        EventType.GoBackToChooseBackup,
+      ]);
     });
 
     it("should move state from APP state to CONFIRMATION state when VALUE_UPDATED action event ", () => {
@@ -112,6 +115,18 @@ describe("state-machine", () => {
 
     it("should move state from APP state to CHANGE_VALUE state when GO_BACK_TO_CHOOSE_BACKUP action event ", () => {
       const nextState = getNextState("APP", EventType.GoBackToChooseBackup);
+      expect(nextState.value).to.equal("CHANGE_VALUE");
+      expect(nextState.events).to.all.members([
+        EventType.ValueUpdated,
+        EventType.VerifyCodeSent,
+        EventType.SelectedApp,
+        EventType.SelectedSms,
+        EventType.RemoveBackup,
+      ]);
+    });
+
+    it("should move state from SMS state to CHANGE_VALUE state when GO_BACK_TO_CHOOSE_BACKUP action event ", () => {
+      const nextState = getNextState("SMS", EventType.GoBackToChooseBackup);
       expect(nextState.value).to.equal("CHANGE_VALUE");
       expect(nextState.events).to.all.members([
         EventType.ValueUpdated,

--- a/test/utils/builders.ts
+++ b/test/utils/builders.ts
@@ -65,7 +65,7 @@ export class RequestBuilder {
     return this;
   }
 
-  withTimestampT(func: () => void): RequestBuilder {
+  withTranslate(func: () => void): RequestBuilder {
     this.t = func;
     return this;
   }


### PR DESCRIPTION
### What changed

- Added back link to enter phone number screen which goes back to the screen for choosing a backup method
- Renamed `addMfaAppMethodGoBackGet` to `addMfaMethodGoBackGet` to make it more generic
- Changed path `/back-from-set-up-auth-app` to `/back-from-set-up-method` to make it more generic
- Renamed `addMfaAppMethodConfirmationGet` in `src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts` to `addMfaSmsMethodConfirmationGet`
- Fix to ensure supporting text shows on screen for choosing SMS as a backup method
- Make inputs correct width on enter phone number screen
- Show correct page title and heading on enter phone number screen when adding SMS as a backup method
- Text corrections for supporting text shown on enter phone number screen
- In the test request builder renamed `withTimestampT` to `withTranslate` because `req.t` is a function for generating translations, not timestamps. Updated all uses of this function too.

### Related links

https://govukverify.atlassian.net/browse/OLH-2135

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

### Sign-offs
<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [x] Design updates have been signed off by a member of the UCD team