### PR TITLE
OLH-2557: Use the new headers function up to integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2076,7 +2076,10 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           FunctionAssociations:
             - EventType: viewer-request
-              FunctionARN: !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersFunction"
+              FunctionARN: !If
+                - IsProduction
+                - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersFunction"
+                - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersCloudFrontFunction"
         Enabled: true
         HttpVersion: "http2"
         Logging:


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update our Cloudfront distribution to call the new version of the headers function in all environments except production. I'll then let the dev platform team know and they can verify the function is being called.

Once we get the ok there, I'll release to prod.

### Why did it change

There was an issue with some AWS accounts not being part of the correct Organisational Unit in Control Tower which meant the dev platform team had to deploy a new version of the headers function to update it with the new device intelligence requirements.

### Related links

See the equivalent parameter in the [dev platform team's Cloudfront template](https://github.com/govuk-one-login/devplatform-deploy/blob/main/cloudfront-distribution/template.yaml#L22).

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
