### PR TITLE
OLH-2557: Call the new headers function in production

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2076,10 +2076,7 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
           FunctionAssociations:
             - EventType: viewer-request
-              FunctionARN: !If
-                - IsProduction
-                - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersFunction"
-                - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersCloudFrontFunction"
+              FunctionARN: !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:function/TICFFraudHeadersCloudFrontFunction"
         Enabled: true
         HttpVersion: "http2"
         Logging:


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Call the new headers function from our frontend Cloudfront in production. This means we can also get rid of the conditional check.


### Why did it change

I've checked the data from integration and got the go-ahead from dev platform.

### Related links

#2142 

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
