### PR TITLE
OLH-2562: Use Firewall Manager in integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -131,6 +131,7 @@ Conditions:
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
 
 Mappings:
   ElasticLoadBalancerAccountIds:
@@ -148,7 +149,7 @@ Mappings:
       FMSGlobalCustomPolicyName: cloudfront
     integration:
       FMSGlobalCustomPolicy: true
-      FMSGlobalCustomPolicyName: platforms
+      FMSGlobalCustomPolicyName: cloudfront
     production:
       FMSGlobalCustomPolicy: true
       FMSGlobalCustomPolicyName: platforms

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -152,7 +152,7 @@ Mappings:
       FMSGlobalCustomPolicyName: cloudfront
     production:
       FMSGlobalCustomPolicy: true
-      FMSGlobalCustomPolicyName: platforms
+      FMSGlobalCustomPolicyName: cloudfront
   Container:
     dev:
       CPU: 1024

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -140,7 +140,7 @@ Mappings:
   FirewallTags:
     dev:
       FMSGlobalCustomPolicy: true
-      FMSGlobalCustomPolicyName: platforms
+      FMSGlobalCustomPolicyName: cloudfront
     build:
       FMSGlobalCustomPolicy: true
       FMSGlobalCustomPolicyName: cloudfront


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Enable Firewall Manager in integration. 

This PR also updates the policy names for dev and production. The new policy in dev has all the same rules as the old one, but the name now matches all other environments. We also know what the name will be for production, so we can set it now even though we're not using it.

### Why did it change

We're replacing our custom WAF rules with centrally managed ones. 

### Related links

#2129 
#2130 

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed