### PR TITLE
OLH-2534: Correct payload when creating or updating an SMS method

### DIFF
--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -66,7 +66,7 @@ export class MfaClient implements MfaClientInterface {
     };
 
     if (otp) {
-      payload.otp = otp;
+      payload.method.otp = otp;
     }
 
     const response = await this.http.client.put<MfaMethod[]>(

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -48,7 +48,7 @@ export class MfaClient implements MfaClientInterface {
       method: method,
     };
     if (otp) {
-      payload.otp = otp;
+      payload.method.otp = otp;
     }
     const response = await this.http.client.post<MfaMethod>(
       `/mfa-methods/${this.publicSubjectId}`,

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -40,7 +40,7 @@ export interface ApiResponse<T> {
 
 export interface CreateMfaPayload {
   priorityIdentifier: PriorityIdentifier;
-  method: SmsMethod | AuthAppMethod;
+  method: (SmsMethod | AuthAppMethod) & { otp?: string };
   otp?: string;
 }
 

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -41,15 +41,13 @@ export interface ApiResponse<T> {
 export interface CreateMfaPayload {
   priorityIdentifier: PriorityIdentifier;
   method: (SmsMethod | AuthAppMethod) & { otp?: string };
-  otp?: string;
 }
 
 export interface UpdateMfaPayload {
   mfaIdentifier: string;
   priorityIdentifier: PriorityIdentifier;
-  method: SmsMethod | AuthAppMethod;
+  method: (SmsMethod | AuthAppMethod) & { otp?: string };
   methodVerified?: boolean;
-  otp?: string;
 }
 
 export interface SimpleError {

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -3,7 +3,6 @@ import { describe } from "mocha";
 import sinon from "sinon";
 import { Request, Response } from "express";
 
-import { Http } from "../../../src/utils/http";
 import {
   MfaClient,
   buildResponse,
@@ -20,7 +19,7 @@ import {
   validateCreate,
   validateUpdate,
 } from "../../../src/utils/mfaClient/validate";
-import { getRequestConfig } from "../../../src/utils/http";
+import { getRequestConfig, Http } from "../../../src/utils/http";
 import { AxiosInstance, AxiosResponse } from "axios";
 
 const mfaMethod: MfaMethod = {
@@ -122,8 +121,8 @@ describe("MfaClient", () => {
             method: {
               mfaMethodType: "SMS",
               phoneNumber: "123456",
+              otp: "OTP",
             },
-            otp: "OTP",
           },
         },
         { headers: { Authorization: "Bearer token" }, proxy: false }


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Correct the payload when creating or updating an SMS method.

According to the spec[^1] the OTP should be at the same level as the method type and phone number, not at the level above like we had it.

```yaml
CreateSmsMethod:
  type: object
  properties:
    mfaMethodType:
      type: string
      enum:
        - SMS
    phoneNumber:
      type: string
    otp:
      type: string
```

[^1]: https://github.com/govuk-one-login/openapi-specs/blob/main/auth/account-management-api/account-management-with-mfa-method-management.yaml#L359-L369

### Why did it change

So the API calls work.

