### PR TITLE
a user can only have a default or backup method. On the frontend the …

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -114,7 +114,9 @@ async function changePhoneNumberwithMfaApi(
 
     case INTENT_CHANGE_PHONE_NUMBER: {
       const smsMFAMethod = currentMfaMethods.find(
-        (mfa) => mfa.method.mfaMethodType === "SMS"
+        (mfa) =>
+          mfa.method.mfaMethodType === "SMS" &&
+          mfa.priorityIdentifier === "DEFAULT"
       );
 
       if (!smsMFAMethod) {


### PR DESCRIPTION
…user can only change their default sms method phone number. When a user has a default SMS and a backup SMS it was just the first one to return that get's updated.

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

<!-- Describe the changes in detail - the "what"-->
A user can only have a default or backup method. On the frontend the user can only change their default sms method phone number. When a user has a default SMS and a backup SMS it was just the first one to return that get's updated. This ensure's that it is the default SMS method that gets updated. If a user wants to change their backup SMS they will have to remove it and then add it again. This has been raised with Ben and Sam.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Potential to update backup SMS method when trying to change default phone number.