### PR TITLE
BAU: Bump govuk-frontend to 5.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "express-session": "^1.18.1",
         "express-validator": "^7.2.1",
         "fast-memoize": "^2.5.2",
-        "govuk-frontend": "^5.7.0",
+        "govuk-frontend": "^5.9.0",
         "helmet": "8.1.0",
         "i18next": "^24.2.3",
         "i18next-fs-backend": "^2.6.0",
@@ -6727,9 +6727,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.0.tgz",
-      "integrity": "sha512-kAaJbOCAJMYT30UN7rVHIWzQUvNjFq5Mw+FSIH2SM6xuCdCwyUcl+WYqxvYRqltWh6ZuAlzND0Rxr61lUoCGJA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",
     "fast-memoize": "^2.5.2",
-    "govuk-frontend": "^5.7.0",
+    "govuk-frontend": "^5.9.0",
     "helmet": "8.1.0",
     "i18next": "^24.2.3",
     "i18next-fs-backend": "^2.6.0",

--- a/src/components/change-email/index.njk
+++ b/src/components/change-email/index.njk
@@ -19,7 +19,6 @@
     label: {
         text: 'pages.changeEmail.email.label' | translate
     },
-    id: "email",
     name: "email",
     value: email,
     errorMessage: {

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -32,7 +32,6 @@
         text: 'pages.checkYourEmail.code.label' | translate
     },
     classes:"govuk-input--width-5",
-    id: "code",
     name: "code",
     inputmode: "numeric",
     spellcheck: false,

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -30,7 +30,6 @@
                 text: 'pages.checkYourPhone.code.label' | translate
             },
             classes:"govuk-input--width-5",
-            id: "code",
             name: "code",
             inputmode: "numeric",
             spellcheck: false,

--- a/src/components/common/mfa/add-auth-app.njk
+++ b/src/components/common/mfa/add-auth-app.njk
@@ -48,7 +48,6 @@
             text: 'pages.addBackupApp.step4.hint' | translate
           },
           classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-          id: "code",
           name: "code",
           inputmode: "numeric",
           spellcheck: false,

--- a/src/components/common/mfa/add-phone-number.njk
+++ b/src/components/common/mfa/add-phone-number.njk
@@ -21,7 +21,6 @@
       text: 'pages.changePhoneNumber.ukPhoneNumber.label' | translate
       },
       classes: "govuk-input--width-20",
-      id: "phoneNumber",
       name: "phoneNumber",
       type: "tel",
       autocomplete: "tel",
@@ -33,7 +32,6 @@
 
     {% set internationalNumberHtml %}
       {{ govukInput({
-        id: "internationalPhoneNumber",
         name: "internationalPhoneNumber",
         type: "tel",
         autocomplete: "tel",

--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -5,7 +5,6 @@
       label: {
         text: settings.label
       },
-      id: settings.id,
       name: settings.id,
       type: "password",
       spellcheck: false,


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Update the version of govuk-frontend from `5.7.0` to `5.9.0`. 
Form control components no longer require an ID attribute, and automatically use the value of the `name` parameter for their id. The `name` parameters have been removed from input components where the `id` and `name` had the same value, seeing as the `id` param is now redundant in those instances.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
This is the most recent working version. 
The next big release is likely to be the brand update. It's sensible to bring our FE in line with the latest stable version of the package in anticipation of that.
<!-- Describe the reason these changes were made - the "why" -->

## How to review
Please sanity check the release notes from `5.7.0` to `5.9.0` to confirm there is nothing that has the potential to break functionality on account management frontend  https://github.com/alphagov/govuk-frontend/releases
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
