### PR TITLE
OLH-2584: Offboard Connect Families to Support and Manage Family Support services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5447,7 +5447,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#69d3d6c68f7d76366ea593e21be54fa77973547a",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#f80d450790436184f9485078a1bf48bd274a2fd3",
       "license": "ISC"
     },
     "node_modules/diff": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,6 +135,7 @@ export const getIdListFromFilter = memoize(
 
 export const getAllowedAccountListClientIDs = getIdListFromFilter({
   clientType: "account",
+  isOffboarded: false,
 });
 
 export const hmrcClientIds: string[] = getIdListFromFilter({ isHmrc: true });
@@ -148,6 +149,7 @@ export const activityLogAllowList: string[] = [
 
 export const getAllowedServiceListClientIDs = getIdListFromFilter({
   clientType: "service",
+  isOffboarded: false,
 });
 
 export const rsaAllowList = getIdListFromFilter({

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,8 +139,6 @@ export const getAllowedAccountListClientIDs = getIdListFromFilter({
 
 export const hmrcClientIds: string[] = getIdListFromFilter({ isHmrc: true });
 
-// TODO: Update di-account-management-rp-registry RPs with a activityLogAllowList flag
-// Update activityLogAllowList to retrieve list of IDs from RP registry instead
 export const activityLogAllowList: string[] = [
   STUB_RP_INTEGRATION,
   STUB_RP_PROD,


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Update to the latest version of the RP registry and filter the lists of allowed accounts and services to exclude offboarded services.

### Why did it change

We want to hide offboarded services from the service cards and on the 'delete your account' page, but not from the activity history.

The service cards and 'delete your account' pages both filter the list of services a user's accessed using the list of account and service RPs from the registry. The activity log doesn't do this filter - it just gets all the entries for that user from the table.

This means that updating the filter on these allow lists will stop offboarded services from appearing where we don't want them, but they'll still show and have the correct content in users' activity history.

### Related links

https://github.com/govuk-one-login/di-account-management-rp-registry/pull/71

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed