### PR TITLE
OLH-2592: Change the payload when switching an MFA method to default

### DIFF
--- a/src/components/switch-backup-method/switch-backup-method-controller.ts
+++ b/src/components/switch-backup-method/switch-backup-method-controller.ts
@@ -72,7 +72,9 @@ export async function switchBackupMfaMethodPost(
 
   try {
     const mfaClient = createMfaClient(req, res);
-    const response = await mfaClient.makeDefault(newDefaultMethod);
+    const response = await mfaClient.makeDefault(
+      newDefaultMethod.mfaIdentifier
+    );
 
     if (!response.success) {
       res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);

--- a/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/change-default-method-controller.test.ts
@@ -129,7 +129,9 @@ describe("change default method", () => {
       //@ts-expect-error req and res aren't valid objects since they are mocked
       await switchBackupMfaMethodPost(req as Request, res as Response);
 
-      expect(mfaClientStub.makeDefault).to.be.calledWith(mfaMethod);
+      expect(mfaClientStub.makeDefault).to.be.calledWith(
+        mfaMethod.mfaIdentifier
+      );
       expect(redirectFn).to.be.calledWith("/switch-methods-confirmation");
     });
 

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -87,15 +87,14 @@ export class MfaClient implements MfaClientInterface {
     return buildResponse(response);
   }
 
-  async makeDefault(method: MfaMethod) {
-    const newMfaMethod: MfaMethod = {
-      mfaIdentifier: method.mfaIdentifier,
-      methodVerified: method.methodVerified,
-      priorityIdentifier: "DEFAULT",
-      method: method.method,
-    };
+  async makeDefault(mfaIdentifier: string) {
+    const response = await this.http.client.put<MfaMethod[]>(
+      `/mfa-methods/${this.publicSubjectId}/${mfaIdentifier}`,
+      { mfaMethod: { priorityIdentifier: "DEFAULT" } },
+      this.requestConfig
+    );
 
-    return this.update(newMfaMethod);
+    return buildResponse(response);
   }
 }
 

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -9,7 +9,7 @@ export interface MfaClientInterface {
     otp?: string
   ) => Promise<ApiResponse<MfaMethod[]>>;
   delete: (method: MfaMethod) => Promise<ApiResponse<any>>;
-  makeDefault: (method: MfaMethod) => Promise<ApiResponse<MfaMethod[]>>;
+  makeDefault: (mfaIdentifier: string) => Promise<ApiResponse<MfaMethod[]>>;
 }
 
 export interface MfaMethod {

--- a/test/unit/utils/mfaClient.test.ts
+++ b/test/unit/utils/mfaClient.test.ts
@@ -241,7 +241,7 @@ describe("MfaClient", () => {
       const putStub = sinon.stub().resolves({ data: [mfaMethod] });
       axiosStub.put = putStub;
 
-      const response = await client.makeDefault(mfaMethod);
+      const response = await client.makeDefault(mfaMethod.mfaIdentifier);
 
       expect(response.data.length).to.eq(1);
       expect(response.data[0]).to.eq(mfaMethod);
@@ -257,11 +257,11 @@ describe("MfaClient", () => {
         priorityIdentifier: "BACKUP",
       };
 
-      await client.makeDefault(backupMethod);
+      await client.makeDefault(backupMethod.mfaIdentifier);
 
       expect(putStub).to.have.been.calledWith(
         "/mfa-methods/publicSubjectId/1234",
-        { mfaMethod }
+        { mfaMethod: { priorityIdentifier: "DEFAULT" } }
       );
     });
   });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Change the payload when switching an MFA method to default.

NOTE: This will require a corresponding update to the validation logic in our stubs.

### Why did it change

The Auth team have decided to update the required payload when switching an MFA mthod from backup to default. This reduces the number of fields and will make it easier for them to validate the request.

The new format is
```
PUT /{publicSubjectId}/{mfaIdentifier}
{
  "mfaMethod": {
    "priorityIdentifier": "DEFAULT"
  }
}
```
### Related links

[Example payload from the updated API spec](https://github.com/govuk-one-login/authentication-api/pull/6385/files#diff-2ac5c584bf7c5f5f231563c56e1a0e6dd0a48109b7c76cf5629cb3f5a2002fe3R411-R412)
[Stubs update PR](https://github.com/govuk-one-login/account-management-stubs/pull/460)

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

