### PR TITLE
OLH-2592: Add `/v1` to the API base URL in staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -257,7 +257,7 @@ Mappings:
       SUPPORTSEARCHABLELIST: "1"
       SHOWCONTACTEMERGENCYMESSAGE: "0"
       CONTACTEMAILSERVICEURL: "https://signin.staging.account.gov.uk/contact-us-from-triage-page"
-      METHODMANAGEMENTBASEURL: "https://a3bnrbtiga-vpce-0c9ce65be09f99db7.execute-api.eu-west-2.amazonaws.com/staging"
+      METHODMANAGEMENTBASEURL: "https://a3bnrbtiga-vpce-0c9ce65be09f99db7.execute-api.eu-west-2.amazonaws.com/staging/v1"
       SUPPORTMETHODMANAGEMENT: "1"
       SUPPORTADDBACKUPMFA: "1"
       SUPPORTCHANGEMFA: "1"


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add `/v1` to the method management API base URL in staging

### Why did it change

The latest change to the Auth team's API include a version number in the URL. Add this in staging so our frontend can still reach the API.

### Related links

[See the planned update to the API spec.
](https://github.com/govuk-one-login/authentication-api/pull/6385/files#diff-2ac5c584bf7c5f5f231563c56e1a0e6dd0a48109b7c76cf5629cb3f5a2002fe3R69)
## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed
- [x] Application configuration is up-to-date
