### PR TITLE
[OLH-2583] Contact page accessibility improvements when JavaScript is disabled

### DIFF
--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -156,7 +156,7 @@
           {% if listLinks.length %}
             <ul class="govuk-list govuk-list--bullet">
               {% for link in listLinks %}
-                <li><a class="govuk-link" href="{{link["href"]}}" target="_blank" rel="noreferrer noopener">{{link["text"]}}</a></li>
+                <li><a class="govuk-link" href="{{link["href"]}}" target="_blank" rel="noreferrer noopener">{{link["html"] | safe}}</a></li>
               {% endfor %}
             </ul>
           {% endif %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -555,27 +555,27 @@
               "troi JavaScript ymlaen yn eich porwr"
             ],
             "paragraphs2": [
-              "Gallwch ddilyn y cyfarwyddiadau i droi JavaScript ymlaen yn:"
+              "Gallwch ddilyn y cyfarwyddiadau i droi JavaScript ymlaen yn eich porwr (mae'r dolenni hyn yn agor mewn tab newydd):"
             ],
             "listLinks": [
               {
-                "text": "Chrome",
+                "html": "Chrome<span class=\"govuk-visually-hidden\"> (yn agor mewn tab newydd)</span>",
                 "href": "https://support.google.com/admanager/answer/12654?hl=en"
               },
               {
-                "text": "Edge",
+                "html": "Edge<span class=\"govuk-visually-hidden\"> (yn agor mewn tab newydd)</span>",
                 "href": "https://support.microsoft.com/en-gb/office/enable-javascript-7bb9ee74-6a9e-4dd1-babf-b0a1bb136361"
               },
               {
-                "text": "Firefox",
+                "html": "Firefox<span class=\"govuk-visually-hidden\"> (yn agor mewn tab newydd)</span>",
                 "href": "https://support.mozilla.org/en-US/kb/javascript-settings-for-interactive-web-pages"
               },
               {
-                "text": "Opera",
+                "html": "Opera<span class=\"govuk-visually-hidden\"> (yn agor mewn tab newydd)</span>",
                 "href": "https://help.opera.com/en/latest/web-preferences/#javaScript"
               },
               {
-                "text": "Safari",
+                "html": "Safari<span class=\"govuk-visually-hidden\"> (yn agor mewn tab newydd)</span>",
                 "href": "https://support.apple.com/en-gb/guide/safari/ibrw1074/mac"
               }
             ]

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -759,27 +759,27 @@
               "turn on JavaScript in your browser"
             ],
             "paragraphs2": [
-              "You can follow the instructions to turn on JavaScript in:"
+              "You can follow the instructions to turn on JavaScript in your browser (these links open in a new tab):"
             ],
             "listLinks": [
               {
-                "text": "Chrome",
+                "html": "Chrome<span class=\"govuk-visually-hidden\"> (opens in new tab)</span>",
                 "href": "https://support.google.com/admanager/answer/12654?hl=en"
               },
               {
-                "text": "Edge",
+                "html": "Edge<span class=\"govuk-visually-hidden\"> (opens in new tab)</span>",
                 "href": "https://support.microsoft.com/en-gb/office/enable-javascript-7bb9ee74-6a9e-4dd1-babf-b0a1bb136361"
               },
               {
-                "text": "Firefox",
+                "html": "Firefox<span class=\"govuk-visually-hidden\"> (opens in new tab)</span>",
                 "href": "https://support.mozilla.org/en-US/kb/javascript-settings-for-interactive-web-pages"
               },
               {
-                "text": "Opera",
+                "html": "Opera<span class=\"govuk-visually-hidden\"> (opens in new tab)</span>",
                 "href": "https://help.opera.com/en/latest/web-preferences/#javaScript"
               },
               {
-                "text": "Safari",
+                "html": "Safari<span class=\"govuk-visually-hidden\"> (opens in new tab)</span>",
                 "href": "https://support.apple.com/en-gb/guide/safari/ibrw1074/mac"
               }
             ]


### PR DESCRIPTION
### What changed

When JavaScript is disabled the text on contact page has a list of links to browser vendor websites explaining how to enable JavaScript. These changes make it clear to the user that these links will open in a new tab.

### Why did it change

So that users aren’t confused when they click a link and are taken to a new tab.

### Related links

https://govukverify.atlassian.net/browse/OLH-2583

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Sign-offs
<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [x] Design updates have been signed off by a member of the UCD team