### PR TITLE
Disallow everything except specific paths in robots.txt

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1409,7 +1409,10 @@ Resources:
               - IsProduction
               - |
                 User-agent: *
-                Disallow:
+                Allow: /contact-gov-uk-one-login$
+                Allow: /assets/
+                Allow: /public/
+                Disallow: /
               - |
                 User-agent: *
                 Disallow: /

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1410,6 +1410,7 @@ Resources:
               - |
                 User-agent: *
                 Allow: /contact-gov-uk-one-login$
+                Allow: /contact-gov-uk-one-login?lng=cy$
                 Allow: /assets/
                 Allow: /public/
                 Disallow: /


### PR DESCRIPTION
### What changed

Rather than allowing everything in robots.txt it has been changed to only allow crawling of the contact page and things in the `public` and `assets` folders.

### Why did it change

To try and get Google to display nicer search results for the contact page, which is the only page we want to be crawled and indexed.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed