### PR TITLE
Don't allow user to use phone number which is already in use

### DIFF
--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-routes.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-routes.ts
@@ -10,6 +10,7 @@ import {
 import { asyncHandler } from "../../utils/async";
 import { validatePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
+import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
 
 const router = express.Router();
 
@@ -23,6 +24,7 @@ router.get(
 router.post(
   PATH_DATA.ADD_MFA_METHOD_SMS.url,
   requiresAuthMiddleware,
+  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   validateStateMiddleware,
   globalTryCatchAsync(asyncHandler(addMfaSmsMethodPost()))

--- a/src/components/change-default-method/change-default-method-routes.ts
+++ b/src/components/change-default-method/change-default-method-routes.ts
@@ -52,6 +52,7 @@ router.post(
   PATH_DATA.CHANGE_DEFAULT_METHOD_SMS.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
+  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   selectMfaMiddleware(),
   globalTryCatchAsync(changeDefaultMethodSmsPost(changePhoneNumberService()))

--- a/src/components/change-phone-number/change-phone-number-routes.ts
+++ b/src/components/change-phone-number/change-phone-number-routes.ts
@@ -10,6 +10,7 @@ import {
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
+import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
 
 const router = express.Router();
 
@@ -24,6 +25,7 @@ router.post(
   PATH_DATA.CHANGE_PHONE_NUMBER.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
+  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   refreshTokenMiddleware(),
   globalTryCatchAsync(asyncHandler(changePhoneNumberPost()))

--- a/src/components/change-phone-number/change-phone-number-validation.ts
+++ b/src/components/change-phone-number/change-phone-number-validation.ts
@@ -5,6 +5,7 @@ import {
   containsLeadingPlusNumbersOrSpacesOnly,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
+  phoneNumberInUse,
 } from "../../utils/phone-number";
 
 export function validatePhoneNumberRequest(): ValidationChainFunc {
@@ -48,6 +49,16 @@ export function validatePhoneNumberRequest(): ValidationChainFunc {
           );
         }
         return true;
+      })
+      .custom((value, { req }) => {
+        if (phoneNumberInUse(value, req.session.mfaMethods)) {
+          throw new Error(
+            req.t(
+              "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
+            )
+          );
+        }
+        return true;
       }),
     body("internationalPhoneNumber")
       .if(body("hasInternationalPhoneNumber").notEmpty().equals("true"))
@@ -83,6 +94,16 @@ export function validatePhoneNumberRequest(): ValidationChainFunc {
           throw new Error(
             req.t(
               "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+            )
+          );
+        }
+        return true;
+      })
+      .custom((value, { req }) => {
+        if (phoneNumberInUse(value, req.session.mfaMethods)) {
+          throw new Error(
+            req.t(
+              "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
             )
           );
         }

--- a/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
@@ -56,7 +56,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.ukPhoneNumber.validationError.required"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when phone number contains invalid characters", async () => {
@@ -71,7 +71,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.ukPhoneNumber.validationError.plusNumericOnly"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when phone number is not long enough", async () => {
@@ -86,7 +86,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when phone number is too long", async () => {
@@ -101,7 +101,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when phone number is not a UK number", async () => {
@@ -116,7 +116,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.ukPhoneNumber.validationError.international"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when phone number is already in use", async () => {
@@ -132,7 +132,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when no international phone number is provided", async () => {
@@ -147,7 +147,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.internationalPhoneNumber.validationError.required"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when international phone number contains invalid characters", async () => {
@@ -162,7 +162,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.internationalPhoneNumber.validationError.plusNumericOnly"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when international phone number is not long enough", async () => {
@@ -177,7 +177,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when international phone number is too long", async () => {
@@ -192,7 +192,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when international phone number is not an international number", async () => {
@@ -207,7 +207,7 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 
   it("errors as expected when international phone number is already in use", async () => {
@@ -223,6 +223,6 @@ describe("validatePhoneNumberRequest", () => {
         req,
         "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
       )
-    ).to.not.throw;
+    ).to.not.throw();
   });
 });

--- a/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
@@ -1,0 +1,204 @@
+import { describe } from "mocha";
+import { validatePhoneNumberRequest } from "../change-phone-number-validation";
+import { RequestBuilder } from "../../../../test/utils/builders";
+import { Request } from "express";
+import { sinon } from "../../../../test/utils/test-utils";
+import { expect } from "chai";
+
+const expectErrorMessage = async (req: Partial<Request>, msg: string) => {
+  const validations = validatePhoneNumberRequest();
+  let messageFound = false;
+  const resultsArrays: any[] = [];
+
+  for (const validation of validations) {
+    // @ts-expect-error - 'run' doesn't exist error, but it does exist
+    const result = await validation.run(req);
+    const resultArray = result.array();
+    resultsArrays.push(resultArray);
+    messageFound = resultArray.some((res: any) => res.msg === msg);
+    if (messageFound) break;
+  }
+  expect(messageFound).to.eq(
+    true,
+    `
+  Expected to find error with message "${msg}" in one of the following arrays:
+  ${resultsArrays.reduce(
+    (append, resultArray) => `${append}
+    ${JSON.stringify(resultArray, null, 2)}`,
+    ""
+  )}
+  `.trim()
+  );
+};
+
+describe("validatePhoneNumberRequest", () => {
+  let sandbox: sinon.SinonSandbox;
+  let reqBuilder: RequestBuilder;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    reqBuilder = new RequestBuilder().withTranslate(sandbox.fake((id) => id));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("errors as expected when no phone number is provided", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "false",
+        phoneNumber: "",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.ukPhoneNumber.validationError.required"
+    );
+  });
+
+  it("errors as expected when phone number contains invalid characters", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "false",
+        phoneNumber: "@12345",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.ukPhoneNumber.validationError.plusNumericOnly"
+    );
+  });
+
+  it("errors as expected when phone number is not long enough", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "false",
+        phoneNumber: "123456789",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
+    );
+  });
+
+  it("errors as expected when phone number is too long", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "false",
+        phoneNumber: "123456789101112",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
+    );
+  });
+
+  it("errors as expected when phone number is not a UK number", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "false",
+        phoneNumber: "+33612345678",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.ukPhoneNumber.validationError.international"
+    );
+  });
+
+  it("errors as expected when phone number is already in use", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "false",
+        phoneNumber: "0123456789",
+      })
+      .withMfaMethods()
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
+    );
+  });
+
+  it("errors as expected when no international phone number is provided", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "true",
+        internationalPhoneNumber: "",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.internationalPhoneNumber.validationError.required"
+    );
+  });
+
+  it("errors as expected when international phone number contains invalid characters", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "true",
+        internationalPhoneNumber: "@12345",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.internationalPhoneNumber.validationError.plusNumericOnly"
+    );
+  });
+
+  it("errors as expected when international phone number is not long enough", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "true",
+        internationalPhoneNumber: "1234",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+    );
+  });
+
+  it("errors as expected when international phone number is too long", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "true",
+        internationalPhoneNumber: "123456789123456789123456789",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+    );
+  });
+
+  it("errors as expected when international phone number is not an international number", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "true",
+        internationalPhoneNumber: "07123456789",
+      })
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+    );
+  });
+
+  it("errors as expected when international phone number is already in use", async () => {
+    const req = reqBuilder
+      .withBody({
+        hasInternationalPhoneNumber: "true",
+        internationalPhoneNumber: "0123456789",
+      })
+      .withMfaMethods()
+      .build();
+    await expectErrorMessage(
+      req,
+      "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
+    );
+  });
+});

--- a/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
@@ -4,9 +4,9 @@ import { RequestBuilder } from "../../../../test/utils/builders";
 import { Request } from "express";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Assertion, expect } from "chai";
-
 declare global {
-  export namespace Chai {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Chai {
     interface Assertion {
       validationError(msg: string): Promise<void>;
     }

--- a/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
@@ -51,10 +51,12 @@ describe("validatePhoneNumberRequest", () => {
         phoneNumber: "",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.required"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.ukPhoneNumber.validationError.required"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when phone number contains invalid characters", async () => {
@@ -64,10 +66,12 @@ describe("validatePhoneNumberRequest", () => {
         phoneNumber: "@12345",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.plusNumericOnly"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.ukPhoneNumber.validationError.plusNumericOnly"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when phone number is not long enough", async () => {
@@ -77,10 +81,12 @@ describe("validatePhoneNumberRequest", () => {
         phoneNumber: "123456789",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when phone number is too long", async () => {
@@ -90,10 +96,12 @@ describe("validatePhoneNumberRequest", () => {
         phoneNumber: "123456789101112",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.ukPhoneNumber.validationError.length"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when phone number is not a UK number", async () => {
@@ -103,10 +111,12 @@ describe("validatePhoneNumberRequest", () => {
         phoneNumber: "+33612345678",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.international"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.ukPhoneNumber.validationError.international"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when phone number is already in use", async () => {
@@ -117,10 +127,12 @@ describe("validatePhoneNumberRequest", () => {
       })
       .withMfaMethods()
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when no international phone number is provided", async () => {
@@ -130,10 +142,12 @@ describe("validatePhoneNumberRequest", () => {
         internationalPhoneNumber: "",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.required"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.internationalPhoneNumber.validationError.required"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when international phone number contains invalid characters", async () => {
@@ -143,10 +157,12 @@ describe("validatePhoneNumberRequest", () => {
         internationalPhoneNumber: "@12345",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.plusNumericOnly"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.internationalPhoneNumber.validationError.plusNumericOnly"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when international phone number is not long enough", async () => {
@@ -156,10 +172,12 @@ describe("validatePhoneNumberRequest", () => {
         internationalPhoneNumber: "1234",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when international phone number is too long", async () => {
@@ -169,10 +187,12 @@ describe("validatePhoneNumberRequest", () => {
         internationalPhoneNumber: "123456789123456789123456789",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when international phone number is not an international number", async () => {
@@ -182,10 +202,12 @@ describe("validatePhoneNumberRequest", () => {
         internationalPhoneNumber: "07123456789",
       })
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+      )
+    ).to.not.throw;
   });
 
   it("errors as expected when international phone number is already in use", async () => {
@@ -196,9 +218,11 @@ describe("validatePhoneNumberRequest", () => {
       })
       .withMfaMethods()
       .build();
-    await expectErrorMessage(
-      req,
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
-    );
+    expect(
+      await expectErrorMessage(
+        req,
+        "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
+      )
+    ).to.not.throw;
   });
 });

--- a/src/components/resend-phone-code/resend-phone-code-routes.ts
+++ b/src/components/resend-phone-code/resend-phone-code-routes.ts
@@ -11,6 +11,7 @@ import { requiresAuthMiddleware } from "../../middleware/requires-auth-middlewar
 import { validatePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
+import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
 
 const router = express.Router();
 
@@ -25,6 +26,7 @@ router.post(
   PATH_DATA.RESEND_PHONE_CODE.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
+  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   refreshTokenMiddleware(),
   globalTryCatchAsync(asyncHandler(resendPhoneCodePost()))

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -638,7 +638,8 @@
         "validationError": {
           "required": "Enter a mobile phone number",
           "plusNumericOnly": "Enter a mobile phone number using only numbers or the + symbol",
-          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code"
+          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code",
+          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number"
         }
       }
     },

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -3,6 +3,7 @@ import {
   parsePhoneNumberWithError,
 } from "libphonenumber-js/mobile";
 import { logger } from "./logger";
+import { MfaMethod } from "./mfaClient/types";
 
 export function containsUKMobileNumber(value: string): boolean {
   try {
@@ -54,3 +55,17 @@ export function getLastNDigits(phoneNumber: string, n: number): string {
   }
   return phoneNumber.slice(-n);
 }
+
+export const phoneNumberInUse = (
+  value: string,
+  mfaMethods: MfaMethod[] = []
+) => {
+  if (mfaMethods) {
+    return mfaMethods.some(
+      (method) =>
+        method.method.mfaMethodType === "SMS" &&
+        method.method.phoneNumber === value
+    );
+  }
+  return false;
+};

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -60,12 +60,9 @@ export const phoneNumberInUse = (
   value: string,
   mfaMethods: MfaMethod[] = []
 ) => {
-  if (mfaMethods) {
-    return mfaMethods.some(
-      (method) =>
-        method.method.mfaMethodType === "SMS" &&
-        method.method.phoneNumber === value
-    );
-  }
-  return false;
+  return mfaMethods.some(
+    (method) =>
+      method.method.mfaMethodType === "SMS" &&
+      method.method.phoneNumber === value
+  );
 };

--- a/src/utils/test/phone-number.test.ts
+++ b/src/utils/test/phone-number.test.ts
@@ -20,6 +20,10 @@ describe("getLastNDigits", () => {
 });
 
 describe("phoneNumberInUse", () => {
+  it("should return false when there are no MFA methods", () => {
+    assert.equal(phoneNumberInUse("0123456789"), false);
+  });
+
   it("should return false when the phone numebr is not already in use", () => {
     assert.equal(
       phoneNumberInUse("0129384756", [

--- a/src/utils/test/phone-number.test.ts
+++ b/src/utils/test/phone-number.test.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import { describe } from "mocha";
-import { getLastNDigits } from "../phone-number";
+import { getLastNDigits, phoneNumberInUse } from "../phone-number";
+
 describe("getLastNDigits", () => {
   it("should return last n digits", () => {
     const phoneNumber = "1234567890";
@@ -15,5 +16,47 @@ describe("getLastNDigits", () => {
   it("should return null if n is less than 1", () => {
     const phoneNumber = "1234567890";
     assert.equal(getLastNDigits(phoneNumber, 0), "");
+  });
+});
+
+describe("phoneNumberInUse", () => {
+  it("should return false when the phone numebr is not already in use", () => {
+    assert.equal(
+      phoneNumberInUse("0129384756", [
+        {
+          mfaIdentifier: "1",
+          priorityIdentifier: "DEFAULT",
+          method: { mfaMethodType: "SMS", phoneNumber: "0123456789" },
+          methodVerified: true,
+        },
+        {
+          mfaIdentifier: "2",
+          priorityIdentifier: "BACKUP",
+          method: { mfaMethodType: "SMS", phoneNumber: "99940850934" },
+          methodVerified: true,
+        },
+      ]),
+      false
+    );
+  });
+
+  it("should return true when the phone numebr is already in use", () => {
+    assert.equal(
+      phoneNumberInUse("99940850934", [
+        {
+          mfaIdentifier: "1",
+          priorityIdentifier: "DEFAULT",
+          method: { mfaMethodType: "SMS", phoneNumber: "0123456789" },
+          methodVerified: true,
+        },
+        {
+          mfaIdentifier: "2",
+          priorityIdentifier: "BACKUP",
+          method: { mfaMethodType: "SMS", phoneNumber: "99940850934" },
+          methodVerified: true,
+        },
+      ]),
+      true
+    );
   });
 });


### PR DESCRIPTION
### What changed

Adds validation to prevent the user from entering a phone number they're already using when they're adding/updating an SMS MFA method.

This required adding test coverage for `src/components/change-phone-number/tests/change-phone-number-validation.ts` to satisfy SonarCloud.

### Why did it change

To ensure the user journeys match those required by the designs.

### Related links

https://govukverify.atlassian.net/browse/OLH-2612

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
