### PR TITLE
Serve favicon.ico and revert unneeded robots.txt changes

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1421,11 +1421,7 @@ Resources:
               - IsProduction
               - |
                 User-agent: *
-                Allow: /contact-gov-uk-one-login$
-                Allow: /contact-gov-uk-one-login?lng=cy$
-                Allow: /assets/
-                Allow: /public/
-                Disallow: /
+                Disallow:
               - |
                 User-agent: *
                 Disallow: /

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,7 @@ import {
   getSessionExpiry,
   getSessionSecret,
   supportActivityLog,
+  supportBrandRefresh,
   supportChangeMfa,
   supportSearchableList,
   supportTriagePage,
@@ -109,6 +110,13 @@ async function createApp(): Promise<express.Application> {
     express.static(
       path.resolve("node_modules/govuk-frontend/dist/govuk/assets")
     )
+  );
+  app.get("/favicon.ico", (req, res) =>
+    res.sendFile("favicon.ico", {
+      root: supportBrandRefresh()
+        ? "node_modules/govuk-frontend/dist/govuk/assets/rebrand/images"
+        : "node_modules/govuk-frontend/dist/govuk/assets/images",
+    })
   );
 
   app.use(


### PR DESCRIPTION
### What changed

- Serve favicon.ico
- Revert robots.txt changes which were unsuccessful at fixing search results icon issue

### Why did it change

To try and get the favicon to show in search results

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed