### PR TITLE
OLH-2652: Don't validate MFA same phone number

### DIFF
--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
@@ -92,9 +92,7 @@ export function addMfaSmsMethodPost(
 
       const error = formatValidationError(
         href,
-        req.t(
-          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-        )
+        req.t("pages.changePhoneNumber.validationError.samePhoneNumber")
       );
       return renderBadRequest(res, req, ADD_MFA_METHOD_SMS_TEMPLATE, error, {
         backLink,

--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-routes.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-routes.ts
@@ -10,7 +10,6 @@ import {
 import { asyncHandler } from "../../utils/async";
 import { validatePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
 
 const router = express.Router();
 
@@ -24,7 +23,6 @@ router.get(
 router.post(
   PATH_DATA.ADD_MFA_METHOD_SMS.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   validateStateMiddleware,
   globalTryCatchAsync(asyncHandler(addMfaSmsMethodPost()))

--- a/src/components/add-mfa-method-sms/tests/add-mfa-method-sms-controller.test.ts
+++ b/src/components/add-mfa-method-sms/tests/add-mfa-method-sms-controller.test.ts
@@ -67,13 +67,13 @@ describe("addMfaSmsMethodPost", () => {
     expect(res.render).to.be.calledWith("add-mfa-method-sms/index.njk", {
       errors: {
         phoneNumber: {
-          text: "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber",
+          text: "pages.changePhoneNumber.validationError.samePhoneNumber",
           href: "#phoneNumber",
         },
       },
       errorList: [
         {
-          text: "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber",
+          text: "pages.changePhoneNumber.validationError.samePhoneNumber",
           href: "#phoneNumber",
         },
       ],

--- a/src/components/change-default-method/change-default-method-controllers.ts
+++ b/src/components/change-default-method/change-default-method-controllers.ts
@@ -137,9 +137,7 @@ export function changeDefaultMethodSmsPost(
 
       const error = formatValidationError(
         href,
-        req.t(
-          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-        )
+        req.t("pages.changePhoneNumber.validationError.samePhoneNumber")
       );
       return renderBadRequest(
         res,

--- a/src/components/change-default-method/change-default-method-routes.ts
+++ b/src/components/change-default-method/change-default-method-routes.ts
@@ -52,7 +52,6 @@ router.post(
   PATH_DATA.CHANGE_DEFAULT_METHOD_SMS.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   selectMfaMiddleware(),
   globalTryCatchAsync(changeDefaultMethodSmsPost(changePhoneNumberService()))

--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -80,9 +80,7 @@ export function changePhoneNumberPost(
 
       const error = formatValidationError(
         href,
-        req.t(
-          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-        )
+        req.t("pages.changePhoneNumber.validationError.samePhoneNumber")
       );
       return renderBadRequest(res, req, CHANGE_PHONE_NUMBER_TEMPLATE, error);
     } else {

--- a/src/components/change-phone-number/change-phone-number-routes.ts
+++ b/src/components/change-phone-number/change-phone-number-routes.ts
@@ -10,7 +10,6 @@ import {
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
 
 const router = express.Router();
 
@@ -25,7 +24,6 @@ router.post(
   PATH_DATA.CHANGE_PHONE_NUMBER.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   refreshTokenMiddleware(),
   globalTryCatchAsync(asyncHandler(changePhoneNumberPost()))

--- a/src/components/change-phone-number/change-phone-number-validation.ts
+++ b/src/components/change-phone-number/change-phone-number-validation.ts
@@ -5,7 +5,6 @@ import {
   containsLeadingPlusNumbersOrSpacesOnly,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
-  phoneNumberInUse,
 } from "../../utils/phone-number";
 
 export function validatePhoneNumberRequest(): ValidationChainFunc {
@@ -49,16 +48,6 @@ export function validatePhoneNumberRequest(): ValidationChainFunc {
           );
         }
         return true;
-      })
-      .custom((value, { req }) => {
-        if (phoneNumberInUse(value, req.session.mfaMethods)) {
-          throw new Error(
-            req.t(
-              "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-            )
-          );
-        }
-        return true;
       }),
     body("internationalPhoneNumber")
       .if(body("hasInternationalPhoneNumber").notEmpty().equals("true"))
@@ -94,16 +83,6 @@ export function validatePhoneNumberRequest(): ValidationChainFunc {
           throw new Error(
             req.t(
               "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
-            )
-          );
-        }
-        return true;
-      })
-      .custom((value, { req }) => {
-        if (phoneNumberInUse(value, req.session.mfaMethods)) {
-          throw new Error(
-            req.t(
-              "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
             )
           );
         }

--- a/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-validation.test.ts
@@ -121,19 +121,6 @@ describe("validatePhoneNumberRequest", () => {
     );
   });
 
-  it("errors as expected when phone number is already in use", async () => {
-    const req = reqBuilder
-      .withBody({
-        hasInternationalPhoneNumber: "false",
-        phoneNumber: "0123456789",
-      })
-      .withMfaMethods()
-      .build();
-    expect(await validate(req)).to.have.validationError(
-      "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-    );
-  });
-
   it("errors as expected when no international phone number is provided", async () => {
     const req = reqBuilder
       .withBody({
@@ -191,19 +178,6 @@ describe("validatePhoneNumberRequest", () => {
       .build();
     expect(await validate(req)).to.have.validationError(
       "pages.changePhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
-    );
-  });
-
-  it("errors as expected when international phone number is already in use", async () => {
-    const req = reqBuilder
-      .withBody({
-        hasInternationalPhoneNumber: "true",
-        internationalPhoneNumber: "0123456789",
-      })
-      .withMfaMethods()
-      .build();
-    expect(await validate(req)).to.have.validationError(
-      "pages.changePhoneNumber.internationalPhoneNumber.validationError.samePhoneNumber"
     );
   });
 });

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -81,9 +81,7 @@ export function resendPhoneCodePost(
     if (response.code === ERROR_CODES.NEW_PHONE_NUMBER_SAME_AS_EXISTING) {
       const error = formatValidationError(
         "phoneNumber",
-        req.t(
-          "pages.changePhoneNumber.ukPhoneNumber.validationError.samePhoneNumber"
-        )
+        req.t("pages.changePhoneNumber.validationError.samePhoneNumber")
       );
       return renderBadRequest(
         res,

--- a/src/components/resend-phone-code/resend-phone-code-routes.ts
+++ b/src/components/resend-phone-code/resend-phone-code-routes.ts
@@ -11,7 +11,6 @@ import { requiresAuthMiddleware } from "../../middleware/requires-auth-middlewar
 import { validatePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
 
 const router = express.Router();
 
@@ -26,7 +25,6 @@ router.post(
   PATH_DATA.RESEND_PHONE_CODE.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
   validatePhoneNumberRequest(),
   refreshTokenMiddleware(),
   globalTryCatchAsync(asyncHandler(resendPhoneCodePost()))

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -433,14 +433,16 @@
         "paragraph1": "Byddwn yn anfon cod diogelwch 6 digid i’r rhif rydych yn ei roi i ni.",
         "backLink": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch"
       },
+      "validationError": {
+        "samePhoneNumber": "Rydych eisoes yn defnyddio'r rhif ffôn hwnnw. Rhowch rif ffôn gwahanol."
+      },
       "ukPhoneNumber": {
         "label": "Rhif ffôn symudol y DU",
         "validationError": {
           "required": "Rhowch rif ffôn symudol y DU",
           "international": "Rhowch rif ffôn symudol y DU",
           "length": "Rhowch rif ffôn symudol yn y DU, fel 07700 900000",
-          "plusNumericOnly": "Rhowch rif ffôn symudol yn y DU gan ddefnyddio rhifau yn unig neu’r symbol +",
-          "samePhoneNumber": "Rydych eisoes yn defnyddio'r rhif ffôn hwnnw. Rhowch rif ffôn gwahanol."
+          "plusNumericOnly": "Rhowch rif ffôn symudol yn y DU gan ddefnyddio rhifau yn unig neu’r symbol +"
         }
       },
       "internationalPhoneNumber": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -621,14 +621,16 @@
         "paragraph1": "We will send a 6 digit security code to the number you give us.",
         "backLink": "Cancel and go back to Security"
       },
+      "validationError": {
+        "samePhoneNumber": "You’re already using that phone number. Enter a different phone number"
+      },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
         "validationError": {
           "required": "Enter a UK mobile phone number",
           "international": "Enter a UK mobile phone number",
           "length": "Enter a UK mobile phone number, like 07700 900000",
-          "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol",
-          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number"
+          "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol"
         }
       },
       "internationalPhoneNumber": {
@@ -638,8 +640,7 @@
         "validationError": {
           "required": "Enter a mobile phone number",
           "plusNumericOnly": "Enter a mobile phone number using only numbers or the + symbol",
-          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code",
-          "samePhoneNumber": "You’re already using that phone number. Enter a different phone number"
+          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code"
         }
       }
     },

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -55,14 +55,3 @@ export function getLastNDigits(phoneNumber: string, n: number): string {
   }
   return phoneNumber.slice(-n);
 }
-
-export const phoneNumberInUse = (
-  value: string,
-  mfaMethods: MfaMethod[] = []
-) => {
-  return mfaMethods.some(
-    (method) =>
-      method.method.mfaMethodType === "SMS" &&
-      method.method.phoneNumber === value
-  );
-};

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -3,7 +3,6 @@ import {
   parsePhoneNumberWithError,
 } from "libphonenumber-js/mobile";
 import { logger } from "./logger";
-import { MfaMethod } from "./mfaClient/types";
 
 export function containsUKMobileNumber(value: string): boolean {
   try {

--- a/src/utils/test/phone-number.test.ts
+++ b/src/utils/test/phone-number.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { describe } from "mocha";
-import { getLastNDigits, phoneNumberInUse } from "../phone-number";
+import { getLastNDigits } from "../phone-number";
 
 describe("getLastNDigits", () => {
   it("should return last n digits", () => {
@@ -16,51 +16,5 @@ describe("getLastNDigits", () => {
   it("should return null if n is less than 1", () => {
     const phoneNumber = "1234567890";
     assert.equal(getLastNDigits(phoneNumber, 0), "");
-  });
-});
-
-describe("phoneNumberInUse", () => {
-  it("should return false when there are no MFA methods", () => {
-    assert.equal(phoneNumberInUse("0123456789"), false);
-  });
-
-  it("should return false when the phone numebr is not already in use", () => {
-    assert.equal(
-      phoneNumberInUse("0129384756", [
-        {
-          mfaIdentifier: "1",
-          priorityIdentifier: "DEFAULT",
-          method: { mfaMethodType: "SMS", phoneNumber: "0123456789" },
-          methodVerified: true,
-        },
-        {
-          mfaIdentifier: "2",
-          priorityIdentifier: "BACKUP",
-          method: { mfaMethodType: "SMS", phoneNumber: "99940850934" },
-          methodVerified: true,
-        },
-      ]),
-      false
-    );
-  });
-
-  it("should return true when the phone numebr is already in use", () => {
-    assert.equal(
-      phoneNumberInUse("99940850934", [
-        {
-          mfaIdentifier: "1",
-          priorityIdentifier: "DEFAULT",
-          method: { mfaMethodType: "SMS", phoneNumber: "0123456789" },
-          methodVerified: true,
-        },
-        {
-          mfaIdentifier: "2",
-          priorityIdentifier: "BACKUP",
-          method: { mfaMethodType: "SMS", phoneNumber: "99940850934" },
-          methodVerified: true,
-        },
-      ]),
-      true
-    );
   });
 });


### PR DESCRIPTION
### What changed

Remove validation which checks if the user provided phone number is the same as any of their existing MFA phone numbers.

### Why did it change

Rather than validating this in the frontend we will rely on receiving a 400 response with the error code `1044` when sending requests to `/send-otp-notification`.

### Related links

https://govukverify.atlassian.net/browse/OLH-2652

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed