### PR TITLE
OLH-1704: Replace `csurf` with `csrf-sync`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "body-parser": "^2.2.0",
         "connect-dynamodb": "^3.0.5",
         "cookie-parser": "^1.4.7",
-        "csurf": "^1.11.0",
+        "csrf-sync": "^4.2.1",
         "di-account-management-rp-registry": "github:govuk-one-login/di-account-management-rp-registry#main",
         "dompurify": "^3.2.5",
         "express": "^5.1.0",
@@ -5212,17 +5212,13 @@
         "node": ">= 8"
       }
     },
-    "node_modules/csrf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
-      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+    "node_modules/csrf-sync": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/csrf-sync/-/csrf-sync-4.2.1.tgz",
+      "integrity": "sha512-+q9tlUSCi/kbwr1NYwn5+MeuNhwxz3wSv1yl42BgIWfIuErZ3HajRwzvZTkfiyIqt1PZT8lQSlffhSYjCneN7g==",
+      "license": "ISC",
       "dependencies": {
-        "rndm": "1.2.0",
-        "tsscmp": "1.0.6",
-        "uid-safe": "2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8"
+        "http-errors": "^2.0.0"
       }
     },
     "node_modules/css-select": {
@@ -5276,73 +5272,6 @@
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "license": "MIT"
-    },
-    "node_modules/csurf": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
-      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
-      "deprecated": "Please use another csrf package",
-      "dependencies": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "csrf": "3.1.0",
-        "http-errors": "~1.7.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/csurf/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/http-errors": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
-    "node_modules/csurf/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "engines": {
-        "node": ">=0.6"
-      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -9701,11 +9630,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rndm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
-      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw=="
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -10789,14 +10713,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "engines": {
-        "node": ">=0.6.x"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "body-parser": "^2.2.0",
     "connect-dynamodb": "^3.0.5",
     "cookie-parser": "^1.4.7",
-    "csurf": "^1.11.0",
+    "csrf-sync": "^4.2.1",
     "di-account-management-rp-registry": "github:govuk-one-login/di-account-management-rp-registry#main",
     "dompurify": "^3.2.5",
     "express": "^5.1.0",

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -1,12 +1,3 @@
-import { CookieOptions } from "csurf";
-
-export function getCSRFCookieOptions(isProdEnv: boolean): CookieOptions {
-  return {
-    httpOnly: isProdEnv,
-    secure: isProdEnv,
-  };
-}
-
 export function getSessionCookieOptions(
   isProdEnv: boolean,
   expiry: number,

--- a/src/config/csrf.ts
+++ b/src/config/csrf.ts
@@ -1,0 +1,9 @@
+import { csrfSync } from "csrf-sync";
+
+const { csrfSynchronisedProtection } = csrfSync({
+  getTokenFromRequest: (req) => {
+    return req.body["_csrf"];
+  },
+});
+
+export { csrfSynchronisedProtection };

--- a/test/unit/middleware/csrf-middleware.test.ts
+++ b/test/unit/middleware/csrf-middleware.test.ts
@@ -6,7 +6,8 @@ import { sinon } from "../../utils/test-utils";
 
 describe("CSRF middleware", () => {
   it("should add csrf token to request locals", () => {
-    const csrfTokenStub = sinon.fake();
+    const csrfToken = "a-csrf-token";
+    const csrfTokenStub = sinon.fake.returns(csrfToken);
     const req: any = { csrfToken: csrfTokenStub };
     const res: any = { locals: {} };
     const nextFunction: NextFunction = sinon.fake(() => {});
@@ -14,6 +15,7 @@ describe("CSRF middleware", () => {
     csrfMiddleware(req, res, nextFunction);
 
     expect(csrfTokenStub).to.have.been.called;
+    expect(res.locals.csrfToken).to.equal(csrfToken);
     expect(nextFunction).to.have.been.called;
   });
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

`csrf-sync` uses the [Synchroniser Token Pattern](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern) to do protection. It's mostly a drop in replacement for us.

It works by storing a token in the user's session. That's made available to the templates through `res.locals`. Any template that has a form has a hidden `_csrf` field which gets populated with that token. When the form is submitted the middleware checks for the token and validates that it matches the one in the session.

All that is exactly the same behaviour as before. The only difference is where the token is stored - in the session not in a cookie.

This is using one token per session, not one per request as can be configured. I tested using one per request but I was able to pretty easily get it to fail with aborting requests and then refreshing, It seems that I'd got through enough processing to generate a new token, but not enough for it to get saved into the DynamoDB session store by the time I ended the request. This will probably also be an issue with double submits or very slow page loads.

We had one token per session in the old implementation, so I don't see any issues with the same config here.

### Why did it change

This replaces our CSRF protection library as `csurf` has been deprecated.

### Related links

See other team's migrations - ([IPV](https://github.com/govuk-one-login/ipv-core-front/pull/1593) Core, [Auth](https://github.com/govuk-one-login/authentication-frontend/pull/2793))
## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Sign-offs
<!-- New Node.JS/NPM dependencies need to be approved by a Lead Developer or Lead SRE: https://govukverify.atlassian.net/wiki/spaces/DIWAY/pages/4335697997/Library+approval+process -->
<!-- Delete if changes do NOT include any new libraries -->
- [x] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE 

## How to review
Run the frontend locally, go to a page with form, mess with the hidden CSRF field and submit the form. If it's working, you'll get redirected back to the security page.
