### PR TITLE
OLH-2664: create a logout return route to handle redirects after calling OIDC end session

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -332,7 +332,6 @@ export const PERSISTENT_SESSION_ID_UNKNOWN = "persistent-session-id-unknown";
 export const LogoutState = {
   Suspended: "suspended",
   Blocked: "blocked",
-  ManualLogout: "manualLogout",
   AccountDeletion: "accountDeletion",
   Default: "default",
 } as const;
@@ -345,9 +344,6 @@ export const LogoutRedirect = {
   },
   [LogoutState.Blocked]: {
     url: getBaseUrl() + PATH_DATA.UNAVAILABLE_PERMANENT.url,
-  },
-  [LogoutState.ManualLogout]: {
-    url: getBaseUrl() + PATH_DATA.SIGN_OUT.url,
   },
   [LogoutState.AccountDeletion]: {
     url: getBaseUrl() + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -1,3 +1,4 @@
+import { getBaseUrl } from "./config";
 import { EventType, UserJourney } from "./utils/state-machine";
 
 export const PATH_DATA: Record<
@@ -185,6 +186,9 @@ export const PATH_DATA: Record<
   UNAVAILABLE_TEMPORARY: {
     url: "/unavailable-temporary",
   },
+  LOGOUT_REDIRECT: {
+    url: "/logout-redirect",
+  },
 };
 
 export const MFA_METHODS = {
@@ -324,3 +328,31 @@ export const OIDC_ERRORS = {
 export const SESSION_ID_UNKNOWN = "session-id-unknown";
 export const CLIENT_SESSION_ID_UNKNOWN = "client-session-id-unknown";
 export const PERSISTENT_SESSION_ID_UNKNOWN = "persistent-session-id-unknown";
+
+export const LogoutState = {
+  Suspended: "suspended",
+  Blocked: "blocked",
+  ManualLogout: "manualLogout",
+  AccountDeletion: "accountDeletion",
+  Default: "default",
+} as const;
+
+export type LogoutStateType = (typeof LogoutState)[keyof typeof LogoutState];
+
+export const LogoutRedirect = {
+  [LogoutState.Suspended]: {
+    url: getBaseUrl() + PATH_DATA.UNAVAILABLE_TEMPORARY.url,
+  },
+  [LogoutState.Blocked]: {
+    url: getBaseUrl() + PATH_DATA.UNAVAILABLE_PERMANENT.url,
+  },
+  [LogoutState.ManualLogout]: {
+    url: getBaseUrl() + PATH_DATA.SIGN_OUT.url,
+  },
+  [LogoutState.AccountDeletion]: {
+    url: getBaseUrl() + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url,
+  },
+  [LogoutState.Default]: {
+    url: getBaseUrl() + PATH_DATA.USER_SIGNED_OUT.url,
+  },
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -76,6 +76,7 @@ import { addBackupSmsRouter } from "./components/add-mfa-method-sms/add-mfa-meth
 import { deleteMfaMethodRouter } from "./components/delete-mfa-method/delete-mfa-method-routes";
 import { switchBackupMethodRouter } from "./components/switch-backup-method/switch-backup-method-routes";
 import { changeDefaultMethodRouter } from "./components/change-default-method/change-default-method-routes";
+import { logoutRedirectRouter } from "./components/logout-redirect/logout-redirect-routes";
 import { isUserLoggedInMiddleware } from "./middleware/is-user-logged-in-middleware";
 import { applyOverloadProtection } from "./middleware/overload-protection-middleware";
 import { getOIDCClient } from "./utils/oidc";
@@ -229,6 +230,7 @@ async function createApp(): Promise<express.Application> {
   app.use(yourServicesRouter);
   app.use(oidcAuthCallbackRouter);
   app.use(startRouter);
+  app.use(logoutRedirectRouter);
   app.use(logoutRouter);
   app.use(isUserLoggedInMiddleware);
   app.use(enterPasswordRouter);

--- a/src/components/delete-account/tests/delete-account-integration.test.ts
+++ b/src/components/delete-account/tests/delete-account-integration.test.ts
@@ -193,7 +193,7 @@ describe("Integration:: delete account", () => {
     );
   });
 
-  it("post should redirect to end session endpoint", (done) => {
+  it("post should redirect to end session endpoint", async () => {
     nock(baseApi).post(API_ENDPOINTS.DELETE_ACCOUNT).once().reply(204);
     nock(govUkPublishingBaseApi)
       .delete(`${API_ENDPOINTS.ALPHA_GOV_ACCOUNT}${TEST_SUBJECT_ID}`)
@@ -213,9 +213,9 @@ describe("Integration:: delete account", () => {
       .expect(
         "Location",
         `${opApi}/logout?id_token_hint=${idToken}&post_logout_redirect_uri=${encodeURIComponent(
-          `${baseUrl}${PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url}`
-        )}`
+          `${baseUrl}${PATH_DATA.LOGOUT_REDIRECT.url}`
+        )}&state=accountDeletion`
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { EnterPasswordServiceInterface } from "./types";
 import { enterPasswordService } from "./enter-password-service";
 import { ExpressRouteFunc } from "../../types";
-import { PATH_DATA } from "../../app.constants";
+import { PATH_DATA, LogoutState } from "../../app.constants";
 import {
   formatValidationError,
   renderBadRequest,
@@ -168,10 +168,10 @@ async function handleIntervention(
 ): Promise<void> {
   switch (intervention) {
     case "BLOCKED":
-      await handleLogout(req, res, PATH_DATA.UNAVAILABLE_PERMANENT.url);
+      await handleLogout(req, res, LogoutState.Blocked);
       break;
     case "SUSPENDED":
-      await handleLogout(req, res, PATH_DATA.UNAVAILABLE_TEMPORARY.url);
+      await handleLogout(req, res, LogoutState.Suspended);
       break;
     default:
       renderPasswordError(

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -1,9 +1,7 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
-
 import {
   enterPasswordGet,
   enterPasswordPost,
@@ -146,11 +144,7 @@ describe("enter password controller", () => {
 
       await enterPasswordPost(fakeService)(req as Request, res as Response);
 
-      expect(handleLogoutStub).to.have.been.calledWith(
-        req,
-        res,
-        PATH_DATA.UNAVAILABLE_PERMANENT.url
-      );
+      expect(handleLogoutStub).to.have.been.calledWith(req, res, "blocked");
     });
 
     it("should logout and redirect to unavailable temporary when intervention is SUSPENDED", async () => {
@@ -175,11 +169,7 @@ describe("enter password controller", () => {
 
       await enterPasswordPost(fakeService)(req as Request, res as Response);
 
-      expect(handleLogoutStub).to.have.been.calledWith(
-        req,
-        res,
-        PATH_DATA.UNAVAILABLE_TEMPORARY.url
-      );
+      expect(handleLogoutStub).to.have.been.calledWith(req, res, "suspended");
     });
   });
 });

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -280,9 +280,10 @@ describe("Integration::enter password", () => {
       .undefined;
     expect(res.headers.location).to.contain("/oidc/logout");
     expect(res.headers.location).to.contain(
-      `post_logout_redirect_uri=${encodeURIComponent(getBaseUrl() + PATH_DATA.UNAVAILABLE_PERMANENT.url)}`
+      `post_logout_redirect_uri=${encodeURIComponent(getBaseUrl() + PATH_DATA.LOGOUT_REDIRECT.url)}`
     );
     await setTokenAndCookies();
+    expect(res.headers.location).to.contain(`state=blocked`);
   });
 
   it("should redirect to unavailable temporary when intervention SUSPENDED", async () => {
@@ -306,9 +307,10 @@ describe("Integration::enter password", () => {
       .undefined;
     expect(res.headers.location).to.contain("/oidc/logout");
     expect(res.headers.location).to.contain(
-      `post_logout_redirect_uri=${encodeURIComponent(getBaseUrl() + PATH_DATA.UNAVAILABLE_TEMPORARY.url)}`
+      `post_logout_redirect_uri=${encodeURIComponent(getBaseUrl() + PATH_DATA.LOGOUT_REDIRECT.url)}`
     );
     await setTokenAndCookies();
+    expect(res.headers.location).to.contain(`state=suspended`);
   });
 
   it("should show incorrect password error for unknown intervention", async () => {

--- a/src/components/logout-redirect/logout-redirect-controller.ts
+++ b/src/components/logout-redirect/logout-redirect-controller.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from "express";
+import { LogoutRedirect, LogoutState } from "../../app.constants";
+
+export async function logoutRedirectGet(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const state = req.query?.state;
+
+  if (state === LogoutState.Suspended) {
+    res.redirect(LogoutRedirect[LogoutState.Suspended].url);
+  } else if (state === LogoutState.Blocked) {
+    res.redirect(LogoutRedirect[LogoutState.Blocked].url);
+  } else if (state === LogoutState.AccountDeletion) {
+    res.redirect(LogoutRedirect[LogoutState.AccountDeletion].url);
+  } else {
+    res.redirect(LogoutRedirect[LogoutState.Default].url);
+  }
+}

--- a/src/components/logout-redirect/logout-redirect-routes.ts
+++ b/src/components/logout-redirect/logout-redirect-routes.ts
@@ -1,0 +1,13 @@
+import * as express from "express";
+import { logoutRedirectGet } from "./logout-redirect-controller";
+import { PATH_DATA } from "../../app.constants";
+import { globalTryCatchAsync } from "../../utils/global-try-catch";
+
+const router = express.Router();
+
+router.get(
+  PATH_DATA.LOGOUT_REDIRECT.url,
+  globalTryCatchAsync(logoutRedirectGet)
+);
+
+export { router as logoutRedirectRouter };

--- a/src/components/logout-redirect/tests/logout-redirect-controller.test.ts
+++ b/src/components/logout-redirect/tests/logout-redirect-controller.test.ts
@@ -6,7 +6,6 @@ import { logoutRedirectGet } from "../logout-redirect-controller";
 import {
   RequestBuilder,
   ResponseBuilder,
-  TXMA_AUDIT_ENCODED,
 } from "../../../../test/utils/builders";
 import { LogoutState, PATH_DATA } from "../../../app.constants";
 import { getBaseUrl } from "../../../config";
@@ -16,18 +15,9 @@ describe("logout redirect controller", () => {
   let res: any;
 
   beforeEach(() => {
-    req = new RequestBuilder()
-      .withBody({})
-      .withSessionUserState({ changeAuthApp: {} })
-      .withTranslate(sinon.fake())
-      .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
-      .build();
+    req = new RequestBuilder().build();
 
-    res = new ResponseBuilder()
-      .withRender(sinon.fake())
-      .withRedirect(sinon.fake(() => {}))
-      .withStatus(sinon.fake())
-      .build();
+    res = new ResponseBuilder().withRedirect(sinon.fake(() => {})).build();
   });
 
   afterEach(() => {
@@ -36,7 +26,6 @@ describe("logout redirect controller", () => {
 
   it("should redirect to suspended", async () => {
     req.query = { state: LogoutState.Suspended };
-    req.session.destroy = sinon.fake();
 
     await logoutRedirectGet(req, res);
 
@@ -47,7 +36,6 @@ describe("logout redirect controller", () => {
 
   it("should redirect to blocked", async () => {
     req.query = { state: LogoutState.Blocked };
-    req.session.destroy = sinon.fake();
 
     await logoutRedirectGet(req, res);
 
@@ -58,7 +46,6 @@ describe("logout redirect controller", () => {
 
   it("should redirect to account deletion", async () => {
     req.query = { state: LogoutState.AccountDeletion };
-    req.session.destroy = sinon.fake();
 
     await logoutRedirectGet(req, res);
 
@@ -69,7 +56,6 @@ describe("logout redirect controller", () => {
 
   it("should redirect to default if state is not set", async () => {
     req.query = {};
-    req.session.destroy = sinon.fake();
 
     await logoutRedirectGet(req, res);
 

--- a/src/components/logout-redirect/tests/logout-redirect-controller.test.ts
+++ b/src/components/logout-redirect/tests/logout-redirect-controller.test.ts
@@ -1,0 +1,80 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import { logoutRedirectGet } from "../logout-redirect-controller";
+
+import {
+  RequestBuilder,
+  ResponseBuilder,
+  TXMA_AUDIT_ENCODED,
+} from "../../../../test/utils/builders";
+import { LogoutState, PATH_DATA } from "../../../app.constants";
+import { getBaseUrl } from "../../../config";
+
+describe("logout redirect controller", () => {
+  let req: any;
+  let res: any;
+
+  beforeEach(() => {
+    req = new RequestBuilder()
+      .withBody({})
+      .withSessionUserState({ changeAuthApp: {} })
+      .withTranslate(sinon.fake())
+      .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
+      .build();
+
+    res = new ResponseBuilder()
+      .withRender(sinon.fake())
+      .withRedirect(sinon.fake(() => {}))
+      .withStatus(sinon.fake())
+      .build();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should redirect to suspended", async () => {
+    req.query = { state: LogoutState.Suspended };
+    req.session.destroy = sinon.fake();
+
+    await logoutRedirectGet(req, res);
+
+    expect(res.redirect).to.have.calledWith(
+      `${getBaseUrl() + PATH_DATA.UNAVAILABLE_TEMPORARY.url}`
+    );
+  });
+
+  it("should redirect to blocked", async () => {
+    req.query = { state: LogoutState.Blocked };
+    req.session.destroy = sinon.fake();
+
+    await logoutRedirectGet(req, res);
+
+    expect(res.redirect).to.have.calledWith(
+      `${getBaseUrl() + PATH_DATA.UNAVAILABLE_PERMANENT.url}`
+    );
+  });
+
+  it("should redirect to account deletion", async () => {
+    req.query = { state: LogoutState.AccountDeletion };
+    req.session.destroy = sinon.fake();
+
+    await logoutRedirectGet(req, res);
+
+    expect(res.redirect).to.have.calledWith(
+      `${getBaseUrl() + PATH_DATA.ACCOUNT_DELETED_CONFIRMATION.url}`
+    );
+  });
+
+  it("should redirect to default if state is not set", async () => {
+    req.query = {};
+    req.session.destroy = sinon.fake();
+
+    await logoutRedirectGet(req, res);
+
+    expect(res.redirect).to.have.calledWith(
+      `${getBaseUrl() + PATH_DATA.USER_SIGNED_OUT.url}`
+    );
+  });
+});

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -3,5 +3,5 @@ import { handleLogout } from "../../utils/logout";
 import { LogoutState } from "../../app.constants";
 
 export async function logoutPost(req: Request, res: Response): Promise<void> {
-  await handleLogout(req, res, LogoutState.ManualLogout);
+  await handleLogout(req, res, LogoutState.Default);
 }

--- a/src/components/logout/logout-controller.ts
+++ b/src/components/logout/logout-controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { handleLogout } from "../../utils/logout";
+import { LogoutState } from "../../app.constants";
 
 export async function logoutPost(req: Request, res: Response): Promise<void> {
-  await handleLogout(req, res);
+  await handleLogout(req, res, LogoutState.ManualLogout);
 }

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -1,25 +1,40 @@
 import { Request, Response } from "express";
-import { destroyUserSessions } from "./session-store";
+import { clearCookies, destroyUserSessions } from "./session-store";
 import { getBaseUrl } from "../config";
+import {
+  HTTP_STATUS_CODES,
+  LogoutState,
+  LogoutStateType,
+  PATH_DATA,
+} from "../app.constants";
+import { EndSessionParameters } from "openid-client";
 
 export async function handleLogout(
   req: Request,
   res: Response,
-  post_logout_redirect_uri?: string
+  state: LogoutStateType
 ): Promise<void> {
-  const idToken = req.session.user.tokens.idToken;
-  await destroyUserSessions(
-    req,
-    req.session.user.subjectId,
-    req.app.locals.sessionStore
-  );
-  res.cookie("lo", "true");
+  try {
+    const { idToken } = req.session.user.tokens;
+    const { subjectId } = req.session.user;
+    await destroyUserSessions(req, subjectId, req.app.locals.sessionStore);
 
-  const endSessionParams: any = { id_token_hint: idToken };
-  if (post_logout_redirect_uri) {
-    endSessionParams.post_logout_redirect_uri = `${getBaseUrl()}${post_logout_redirect_uri}}`;
+    if (state === LogoutState.AccountDeletion) {
+      clearCookies(req, res, ["am"]);
+    } else {
+      res.cookie("lo", "true");
+    }
+
+    const endSessionParams: EndSessionParameters = {
+      id_token_hint: idToken,
+      post_logout_redirect_uri: `${getBaseUrl()}${PATH_DATA.LOGOUT_REDIRECT.url}`,
+      state: state,
+    };
+
+    const redirectUrl = req.oidc.endSessionUrl(endSessionParams);
+    res.redirect(redirectUrl);
+  } catch {
+    res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+    res.render("common/errors/500.njk");
   }
-
-  const redirectUrl = req.oidc.endSessionUrl(endSessionParams);
-  res.redirect(redirectUrl);
 }

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -1,12 +1,7 @@
 import { Request, Response } from "express";
 import { clearCookies, destroyUserSessions } from "./session-store";
 import { getBaseUrl } from "../config";
-import {
-  HTTP_STATUS_CODES,
-  LogoutState,
-  LogoutStateType,
-  PATH_DATA,
-} from "../app.constants";
+import { LogoutState, LogoutStateType, PATH_DATA } from "../app.constants";
 import { EndSessionParameters } from "openid-client";
 
 export async function handleLogout(
@@ -14,27 +9,22 @@ export async function handleLogout(
   res: Response,
   state: LogoutStateType
 ): Promise<void> {
-  try {
-    const { idToken } = req.session.user.tokens;
-    const { subjectId } = req.session.user;
-    await destroyUserSessions(req, subjectId, req.app.locals.sessionStore);
+  const { idToken } = req.session.user.tokens;
+  const { subjectId } = req.session.user;
+  await destroyUserSessions(req, subjectId, req.app.locals.sessionStore);
 
-    if (state === LogoutState.AccountDeletion) {
-      clearCookies(req, res, ["am"]);
-    } else {
-      res.cookie("lo", "true");
-    }
-
-    const endSessionParams: EndSessionParameters = {
-      id_token_hint: idToken,
-      post_logout_redirect_uri: `${getBaseUrl()}${PATH_DATA.LOGOUT_REDIRECT.url}`,
-      state: state,
-    };
-
-    const redirectUrl = req.oidc.endSessionUrl(endSessionParams);
-    res.redirect(redirectUrl);
-  } catch {
-    res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
-    res.render("common/errors/500.njk");
+  if (state === LogoutState.AccountDeletion) {
+    clearCookies(req, res, ["am"]);
+  } else {
+    res.cookie("lo", "true");
   }
+
+  const endSessionParams: EndSessionParameters = {
+    id_token_hint: idToken,
+    post_logout_redirect_uri: `${getBaseUrl()}${PATH_DATA.LOGOUT_REDIRECT.url}`,
+    state: state,
+  };
+
+  const redirectUrl = req.oidc.endSessionUrl(endSessionParams);
+  res.redirect(redirectUrl);
 }


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2664] Create a logout return route to handle redirects after calling OIDC end session
### What changed
<!-- Describe the changes in detail - the "what"-->
Created a new logout-redirect route which the oidc will redirect to. We will then use the state to redirect the user somewhere in home. Currently supported redirects are: temp suspended, perm blocked, account deleted, and default

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Adding post logout redirects requires support from another team which is adding overhead. With this implementation we will only require one url and can use the state value to redirect within home. The state is validated our side and defaults to sign out.

### Testing
Tested locally with temp suspended, perm suspended, account deletion and normal logout.

[OLH-2664]: https://govukverify.atlassian.net/browse/OLH-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Awaiting OIDC changes before merge.