### PR TITLE
OLH-2628: Update webchat URL for integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -295,7 +295,7 @@ Mappings:
       SERVICEDOMAIN: "integration.account.gov.uk"
       LOGSLEVEL: "info"
       SUPPORTTRIAGEPAGE: "1"
-      WEBCHATSOURCEURL: "https://uat-chat-loader-hgsgds.smartagent.app"
+      WEBCHATSOURCEURL: "https://chat-loader-hgsgds.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
       SUPPORTPHONECONTACT: "1"
       SHOWCONTACTGUIDANCE: "1"


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Temporarily update the webchat URL for integration to point to the new prod webchat infrastructure. This is being done for testing purposes and should be reverted once webchat is confirmed to be working.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
We've confirmed the dev and uat versions of the "new" webchat are working.
The next step in the testing plan is to test the production version in our integration environment.
The supplier have confirmed that integration has been allowlisted for use with their Prod environment. 

<!-- Describe the reason these changes were made - the "why" -->


## How to review
Check that the URL matches the one provided for prod on the description of [the ticket](https://govukverify.atlassian.net/browse/OLH-2628).
We should be able to perform a manual test once this commit makes it to integration. 
Once it's been confirmed to be working, this change should be reverted. 
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
