### PR TITLE
OLH-2680: Make it clear array is sorted in place

### DIFF
--- a/src/utils/present-activity-history.ts
+++ b/src/utils/present-activity-history.ts
@@ -7,10 +7,10 @@ export const presentActivityHistory = async (
 ): Promise<ActivityLogEntry[]> => {
   const activityLogEntry = await getActivityLogEntry(subjectId, trace);
   if (activityLogEntry) {
-    const sorted = activityLogEntry.sort((first, second) => {
+    activityLogEntry.sort((first, second) => {
       return second.timestamp - first.timestamp;
     });
-    return sorted;
+    return activityLogEntry;
   } else {
     return [];
   }


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

`Array.sort()` sorts the original array in place and also returns a reference to the same array. Assigning this reference to a new variable can be confusing if we ever needed to do anything else with the original variable, as it implies that the original hasn't been sorted.

There's no issues with that in the case, but we can make our intentions clear by not assigning the result of `.sort()` and returning the original variable.

We already have a unit test to check this function does sort the array.

### Why did it change

This addresses [a code smell in Sonar](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&types=CODE_SMELL&id=di-account-management-frontend).

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
