### PR TITLE
OLH-2642: Navigation tweaks

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -127,6 +127,10 @@
 
 .account-navigation {
   background-color: govuk-colour("light-grey");
+  .govuk-template--rebranded & {
+    background-color: $_govuk-rebrand-template-background-colour;
+    border-bottom: 1px solid $_govuk-rebrand-border-colour-on-blue-tint-95;
+  }
   border-bottom: 1px solid $govuk-border-colour;
   position: relative;
 }
@@ -211,7 +215,6 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
 .account-navigation__link {
   @extend .govuk-link;
   display: inline-block;
-  font-weight: bold;
   padding: $nav-link-padding-left 0 govuk-spacing(2);
   margin-top: $nav-link-outline-thickness;
 


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Make internal OL Home navigation a closer match for the DS secondary navigation from a visual perspective, while maintaining its current behaviour on mobile.

This is still not a perfect match (note height is different) however the team is considering removing the nav altogether in the near future in favour of a different navigation structure, so it might not be worth dedicating too much time implementing CSS tweaks right now.

### OLH nav vs DS service nav on different viewport sizes (pre and post brand updates)

<img width="1671" alt="Screenshot 2025-05-22 at 13 15 42" src="https://github.com/user-attachments/assets/c7e50eb2-dc30-4dc7-bd4d-529fdfe79293" />

------
<img width="1026" alt="Screenshot 2025-05-22 at 13 16 18" src="https://github.com/user-attachments/assets/f8fdef2a-101e-49b2-b20a-737c7b107bd7" />

-----

<img width="1676" alt="Screenshot 2025-05-22 at 13 18 55" src="https://github.com/user-attachments/assets/a16d026e-e32a-40b7-8f89-25004ed102bb" />

-----
<img width="1027" alt="Screenshot 2025-05-22 at 13 19 57" src="https://github.com/user-attachments/assets/466f5533-7c0a-4f18-a604-dbe2b3374515" />

-----


<!-- Describe the changes in detail - the "what"-->

### Why did it change
The subject of secondary navigation came up at the internal rebrand kickoff, where the team were asked whether it was on our roadmap to swap out our custom OLH nav implementation for the Design System Service Navigation.

After discussions with the UCD team, we determined the current design of the navigation bar on OLH suits our needs better: specifically, the custom nav on OLH should not turn into a dropdown menu on mobile, instead the links should remain inline; additionally, we've determined the font size and spacing we are currently using for mobile is more user friendly.

We did agree, however, to make some tweaks to current styling to make the OLH nav look more similar to the DS component, namely:
- tweaking font weight
- ensuring background colour and border changes with the rebrand flag

NOTE: The sass variables referenced are actually private ones (denoted by the `$_` prefix) so we'll have to keep an eye out in case they are removed and/or replaced with public ones in future releases of `govuk-frontend`.


<!-- Describe the reason these changes were made - the "why" -->



### Sign-offs

<!-- Delete if changes do NOT include any design updates -->
- [x] Design updates have been signed off by a member of the UCD team
☝️  Verbal confirmation on screenshots [shared on slack](https://gds.slack.com/archives/C01H13E9YP8/p1747917682771229)

## How to review
Run app locally for visual check. Test with `govukRebrand` flag on and off
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
