### PR TITLE
OLH 2707: Signed out page should return 200 status code

### DIFF
--- a/src/components/signed-out/signed-out-controller.ts
+++ b/src/components/signed-out/signed-out-controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { PATH_DATA } from "../../app.constants";
 
 export function signedOutGet(req: Request, res: Response): void {
-  res.status(401);
+  res.status(200);
   res.render("signed-out/index.njk", {
     signinLink: PATH_DATA.START.url,
     hideAccountNavigation: true,

--- a/src/components/signed-out/tests/signed-out-controller.test.ts
+++ b/src/components/signed-out/tests/signed-out-controller.test.ts
@@ -30,7 +30,7 @@ describe("signed out controller", () => {
       signedOutGet(req as Request, res as Response);
 
       expect(res.render).to.have.been.calledWith("signed-out/index.njk");
-      expect(res.status).to.have.be.calledWith(401);
+      expect(res.status).to.have.be.calledWith(200);
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH 2707] Signed out page should return 200 status code

### What changed
<!-- Describe the changes in detail - the "what"-->
Signed-Out page returns status code 200 instead of 401. 

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Performance tests were failing as they were expecting status 200 but got 401. This was due to the logout redirect changes where we have stopped using auths sign out page. 