### PR TITLE
OLH-2671: replace || with ?? to fix code smell warnings

### DIFF
--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -32,11 +32,11 @@ export function eventService(
       : MISSING_SESSION_ID_SPECIAL_CASE;
 
   const getPersistentSessionId = (res: Response): string =>
-    res.locals.persistentSessionId ||
+    res.locals.persistentSessionId ??
     MISSING_PERSISTENT_SESSION_ID_SPECIAL_CASE;
 
   const getUserId = (session: Session): string =>
-    session.user_id || MISSING_USER_ID_SPECIAL_CASE;
+    session.user_id ?? MISSING_USER_ID_SPECIAL_CASE;
 
   const getAppSessionId = (session: Session): string =>
     userHasComeFromTheApp(session)
@@ -44,7 +44,7 @@ export function eventService(
       : MISSING_APP_SESSION_ID_SPECIAL_CASE;
 
   const isSignedIn = (session: Session): boolean =>
-    session.user?.isAuthenticated || false;
+    session.user?.isAuthenticated ?? false;
 
   /**
    * A function for calculating and returning an object containing the current timestamp.


### PR DESCRIPTION
### What changed

Replaces `||` with `??`

### Why did it change

To fix code smell warnings in Sonar

### Related links

https://govukverify.atlassian.net/browse/OLH-2671

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed