### PR TITLE
OLH-2328: Resolve error message due to invalid MFA method URL 

### DIFF
--- a/src/middleware/mfa-method-middleware.ts
+++ b/src/middleware/mfa-method-middleware.ts
@@ -33,14 +33,21 @@ export async function mfaMethodMiddleware(
 }
 
 const selectMfaMiddleware = (): RequestHandler => {
-  try {
-    const mfaServiceUrl = new URL(getMfaServiceUrl());
-    if (supportMfaPage() && mfaServiceUrl) {
-      return mfaMethodMiddleware;
+  const mfaServiceUrlString = getMfaServiceUrl();
+  let mfaServiceUrl: URL | null = null;
+  if (mfaServiceUrlString) {
+    try {
+      mfaServiceUrl = new URL(mfaServiceUrlString);
+    } catch {
+      logger.warn(`Invalid MFA service URL: ${mfaServiceUrlString}`);
+      mfaServiceUrl = null;
     }
-  } catch (error) {
-    logger.error(`selectMfaMiddleware ${error.message}`);
   }
+
+  if (supportMfaPage() && mfaServiceUrl) {
+    return mfaMethodMiddleware;
+  }
+
   return legacyMfaMethodsMiddleware;
 };
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2328] resolve SelectMFAMethod error logs

### What changed
<!-- Describe the changes in detail - the "what"-->
In production the env var for method management is set to a empty string, this was being read and then changed into a URL. As it threw an error due to invalid URL, a error message was logged. Currently we don't have method management in production so this is valid, but we don't need the error message. This resolves this issue and now also checks if there is a valid URL passed in and warns us otherwise.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
To reduce the non critical errors we are logging.

[OLH-2328]: https://govukverify.atlassian.net/browse/OLH-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ