### PR TITLE
OLH-2679: use regex literal not RegExp constructor

### DIFF
--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -3,9 +3,7 @@ import { randomBytes } from "crypto";
 
 import { logger } from "./logger";
 
-const lowerAndUpperCaseLettersAndNumbersMax50 = new RegExp(
-  "^[a-zA-Z0-9_-]{1,50}$"
-);
+const lowerAndUpperCaseLettersAndNumbersMax50 = /^[a-zA-Z0-9_-]{1,50}$/;
 
 export function containsNumber(value: string): boolean {
   return value ? /\d/.test(value) : false;


### PR DESCRIPTION
### What changed

Use regex literal not RegExp constructor

### Why did it change

To fix Sonar code smell warning

### Related links

https://govukverify.atlassian.net/browse/OLH-2679

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed