### PR TITLE
OLH-2328: Keep original from url and log invalid from URL

### DIFF
--- a/src/middleware/outbound-contact-us-links-middleware.ts
+++ b/src/middleware/outbound-contact-us-links-middleware.ts
@@ -2,7 +2,12 @@ import { NextFunction, Request, Response } from "express";
 import { PATH_DATA } from "../app.constants";
 
 export function buildUrlFromRequest(req: Request): string {
-  return `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+  const url = new URL(`${req.protocol}://${req.get("host")}${req.originalUrl}`);
+  const fromURLParam = url.searchParams.get("fromURL");
+  if (fromURLParam) {
+    return fromURLParam;
+  }
+  return url.toString();
 }
 
 export function appendFromUrlWhenTriagePageUrl(
@@ -13,7 +18,6 @@ export function appendFromUrlWhenTriagePageUrl(
 
   if (triagePageUrlRegEx.test(contactUsLinkUrl)) {
     const encodedFromUrl = encodeURIComponent(fromUrl);
-
     contactUsLinkUrl = `${contactUsLinkUrl}?fromURL=${encodedFromUrl}`;
   }
 

--- a/src/middleware/update-session-middleware.ts
+++ b/src/middleware/update-session-middleware.ts
@@ -40,7 +40,8 @@ export const updateSessionMiddleware = (
   } else {
     logger.warn(
       { trace: trace },
-      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+      "fromURL in request query for contact-govuk-one-login page did not pass validation:",
+      fromURL
     );
   }
 

--- a/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
+++ b/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
@@ -103,6 +103,15 @@ describe("Middleware", () => {
       const builtUrl = buildUrlFromRequest(req);
       expect(builtUrl).to.equal("https://signin.account.gov.uk/security");
     });
+
+    it("should handle fromURL with encoded nested fromURL to return first fromURL", () => {
+      req.originalUrl =
+        "/contact-gov-uk-one-login?fromURL=https%3A%2F%2Fsignin.account.gov.uk%2Fsecurity%3FfromURL%3Dhttps%253A%252F%252Ffoo";
+      const builtUrl = buildUrlFromRequest(req);
+      expect(builtUrl).to.equal(
+        "https://signin.account.gov.uk/security?fromURL=https%3A%2F%2Ffoo"
+      );
+    });
   });
 
   describe("appendFromUrlWhenTriagePageUrl", () => {

--- a/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
+++ b/test/unit/middleware/outbound-contact-us-links-middleware.test.ts
@@ -91,12 +91,17 @@ describe("Middleware", () => {
       } as any;
     });
 
-    it("should build the fromUrl as expected", () => {
+    it("should build the fromUrl as expected when fromURL is not present", () => {
       const builtUrl = buildUrlFromRequest(req),
         expectedUrl = "https://home.account.gov.uk/contact-gov-uk-one-login";
-
       expect(builtUrl).to.equal(expectedUrl);
-      buildUrlFromRequest(req);
+    });
+
+    it("should return the decoded fromURL if present in the query", () => {
+      req.originalUrl =
+        "/contact-gov-uk-one-login?fromURL=https%3A%2F%2Fsignin.account.gov.uk%2Fsecurity";
+      const builtUrl = buildUrlFromRequest(req);
+      expect(builtUrl).to.equal("https://signin.account.gov.uk/security");
     });
   });
 

--- a/test/unit/middleware/update-session-middleware.test.ts
+++ b/test/unit/middleware/update-session-middleware.test.ts
@@ -59,7 +59,8 @@ describe("updateSessionMiddleware", () => {
     expect(loggerWarnSpy).to.be.calledWith({ url: "invalid-url" });
     expect(loggerWarnSpy).to.be.calledWith(
       { trace: mockResponse.locals.sessionId },
-      "fromURL in request query for contact-govuk-one-login page did not pass validation"
+      "fromURL in request query for contact-govuk-one-login page did not pass validation:",
+      "invalid-url"
     );
     expect(mockRequest.session.queryParameters.fromURL).to.be.undefined;
   });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2328] Adjust fromURL logic

### What changed
<!-- Describe the changes in detail - the "what"-->
- Adjusted from URL logic to keep the original fromURL to prevent infinite depth fromURLs
- Changed the logger.warn for invalid fromURLs to include the invalid URL

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
- Reduce bot traffic which is spamming the contact us page due to different URLs caused by fromURLs
- Better understand why we have a significant number of invalid URL errors in production

### How to review
Are there any issues with logging the from URL?

[OLH-2328]: https://govukverify.atlassian.net/browse/OLH-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ