### PR TITLE
OLH-2631: Reenable previously failing post-deploy tests

### DIFF
--- a/post-deploy-tests/tests/features/@contact-govuk-one-login.feature
+++ b/post-deploy-tests/tests/features/@contact-govuk-one-login.feature
@@ -1,12 +1,5 @@
 Feature: Contact GOV.UK One Login
 
-  # intermittently failing in build pipeline with errors like:
-  #{
-  #  msg: Failed to load resource: net::ERR_SOCKET_NOT_CONNECTED,
-  #  type: 'error',
-  #  location: 'https://uat-chat-loader-hgsgds.smartagent.app/loader/main.js:0:0'
-  #}
-  @fixme
   Scenario: Visiting the contact page
     Given I visit the contact page
     Then the page should have status code 200
@@ -18,13 +11,6 @@ Feature: Contact GOV.UK One Login
     Then the page should have status code 200
     And the page should display the expected webchat content
 
-  # intermittently failing in build pipeline with errors like:
-  #{
-  #  msg: Failed to load resource: net::ERR_SOCKET_NOT_CONNECTED,
-  #  type: 'error',
-  #  location: 'https://uat-chat-loader-hgsgds.smartagent.app/loader/main.js:0:0'
-  #}
-  @fixme
   Scenario: Accessing webchat via the inline button
     Given I am not testing against a local deployment
     And I visit the contact page
@@ -34,13 +20,6 @@ Feature: Contact GOV.UK One Login
     Given I click on the minimise webchat button
     Then the webchat disappears
 
-  # intermittently failing in build pipeline with errors like:
-  #{
-  #  msg: Failed to load resource: net::ERR_SOCKET_NOT_CONNECTED,
-  #  type: 'error',
-  #  location: 'https://uat-chat-loader-hgsgds.smartagent.app/loader/main.js:0:0'
-  #}
-  @fixme
   Scenario: Accessing webchat via the floating button
     Given I am not testing against a local deployment
     Given I visit the contact page


### PR DESCRIPTION
### What changed

Reenables previously failing post-deploy tests to see if they now pass.

### Related links

https://govukverify.atlassian.net/browse/OLH-2631

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
