### PR TITLE
OLH-2721: Check if language selected is supported or fallback to en

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -30,7 +30,7 @@ declare module "express-serve-static-core" {
     i18n?: {
       language?: string;
     };
-    language?: string;
+    language?: LOCALE;
     t?: (string) => string;
     csrfToken?: () => string;
     oidc?: Client;

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,11 +1,11 @@
-import { ENVIRONMENT_NAME, LOCALE } from "../app.constants";
-import { getNodeEnv, getServiceDomain } from "../config";
+import { LOCALE } from "../app.constants";
+import { getServiceDomain } from "../config";
 import type { InitOptions } from "i18next/typescript/options";
 
 export function i18nextConfigurationOptions(): InitOptions {
   return {
     debug: false,
-    fallbackLng: getNodeEnv() === ENVIRONMENT_NAME.TEST ? LOCALE.EN : "",
+    fallbackLng: LOCALE.EN,
     preload: [LOCALE.EN],
     supportedLngs: [LOCALE.EN, LOCALE.CY],
     detection: {

--- a/src/config/nunjucks.ts
+++ b/src/config/nunjucks.ts
@@ -17,12 +17,18 @@ export function configureNunjucks(
     noCache: true,
   });
 
-  nunjucksEnv.addFilter("translate", function (key: string, options?: any) {
-    const currentLanguage = this.ctx?.i18n?.language ?? LOCALE.EN;
-    const translate: TFunction<"translation", undefined> =
-      i18next.getFixedT(currentLanguage);
-    return safeTranslate(translate, key, currentLanguage, options);
-  });
+  nunjucksEnv.addFilter(
+    "translate",
+    function (key: string, options?: Record<string, unknown>) {
+      const currLang = this.ctx?.i18n?.language;
+      const selectedLanguage = Object.values(LOCALE).includes(currLang)
+        ? currLang
+        : LOCALE.EN;
+      const translate: TFunction<"translation", undefined> =
+        i18next.getFixedT(selectedLanguage);
+      return safeTranslate(translate, key, selectedLanguage, options);
+    }
+  );
 
   nunjucksEnv.addGlobal("addLanguageParam", addLanguageParam);
   nunjucksEnv.addGlobal("govukRebrand", supportBrandRefresh());

--- a/src/utils/safeTranslate.ts
+++ b/src/utils/safeTranslate.ts
@@ -11,7 +11,7 @@ export type translateResult =
 export const safeTranslate = (
   translate: TFunction<"translation", undefined>,
   key: string,
-  requestedLanguage: string,
+  requestedLanguage: LOCALE,
   options?: Record<string, any>
 ): translateResult => {
   const result: translateResult = translate(key, options);

--- a/test/unit/config/nunjucks.test.ts
+++ b/test/unit/config/nunjucks.test.ts
@@ -65,6 +65,25 @@ describe("configureNunjucks", () => {
       expect(result).to.equal(undefined);
       expect(fixedTStub.calledWith("test_key")).to.be.true;
     });
+
+    it("should translate fallback to en if false lang is passed", () => {
+      const fixedTStub = sinon
+        .stub()
+        .returns("translated_value") as unknown as MyStubType;
+      const getFixedTStub = sinon
+        .stub(i18next, "getFixedT")
+        .returns(fixedTStub);
+
+      const translateFilter = nunjucksEnv.getFilter("translate");
+      const result = translateFilter.call(
+        { ctx: { i18n: { language: "" } } },
+        "test_key"
+      );
+
+      expect(result).to.equal("translated_value");
+      expect(getFixedTStub.firstCall.args[0]).to.equal("en");
+      expect(fixedTStub.calledWith("test_key")).to.be.true;
+    });
   });
 
   describe("rebrand flag", () => {

--- a/test/unit/utils/safeTranslate.test.ts
+++ b/test/unit/utils/safeTranslate.test.ts
@@ -5,11 +5,12 @@ import { TFunction } from "i18next";
 import { logger } from "../../../src/utils/logger";
 
 import { safeTranslate } from "../../../src/utils/safeTranslate";
+import { LOCALE } from "../../../src/app.constants";
 
 describe("safeTranslate", () => {
   let translate: sinon.SinonStub<[string, any?], string>;
   let logErrorSpy: sinon.SinonSpy;
-  const requestedLanguage = "cy";
+  const requestedLanguage = LOCALE.CY;
 
   beforeEach(() => {
     translate = sinon.stub();


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2721] Check if language selected is supported or fallback to en

### What changed
<!-- Describe the changes in detail - the "what"-->
Check language selection matches our supported options (en, cy) if not fallback to cy.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Some users are passing a lng value of "" which is interpreted as an unknown language. As this value is not nullish it is not picked up by ?? and is passed to safeTranslate.  We could have changed it to || but with this change we now check against our list of supported languages.

### Related links
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
https://govukverify.atlassian.net/browse/OLH-2721

[OLH-2721]: https://govukverify.atlassian.net/browse/OLH-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ