### PR TITLE
OLH-1946: refactor GA4 OPL tracking code

### DIFF
--- a/src/components/activity-history/activity-history-controller.ts
+++ b/src/components/activity-history/activity-history-controller.ts
@@ -6,7 +6,7 @@ import {
   reportSuspiciousActivity,
   supportReportingForm,
 } from "../../config";
-import { PATH_DATA, HTTP_STATUS_CODES } from "../../app.constants";
+import { HTTP_STATUS_CODES, PATH_DATA } from "../../app.constants";
 import {
   generatePagination,
   formatActivityLogs,
@@ -16,6 +16,7 @@ import { serviceIsAvailableInWelsh } from "../../utils/yourServices";
 import { presentActivityHistory } from "../../utils/present-activity-history";
 import { logger } from "../../utils/logger";
 import { ActivityLogEntry, FormattedActivityLog } from "../../utils/types";
+import { setOplSettings } from "../../utils/opl";
 
 export async function activityHistoryGet(
   req: Request,
@@ -62,6 +63,13 @@ export async function activityHistoryGet(
     } else {
       logger.error("Activity history controller: user_id missing from session");
     }
+
+    setOplSettings(
+      {
+        contentId: "d61e09c3-5741-4cb9-aca6-d57f62fc3475",
+      },
+      res
+    );
 
     res.render("activity-history/index.njk", {
       data: formattedActivityLog,

--- a/src/components/activity-history/index.njk
+++ b/src/components/activity-history/index.njk
@@ -91,5 +91,4 @@
       }) if pagination.items }}
     </div>
   </div>
-  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"home", contentId:"d61e09c3-5741-4cb9-aca6-d57f62fc3475",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
@@ -20,21 +20,34 @@ import { BadRequestError } from "../../utils/errors";
 import { validationResult } from "express-validator";
 import { validationErrorFormatter } from "../../middleware/form-validation-middleware";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const ADD_MFA_METHOD_SMS_TEMPLATE = "add-mfa-method-sms/index.njk";
 
 const backLink = PATH_DATA.ADD_MFA_METHOD_GO_BACK.url;
 
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      taxonomyLevel2: "change phone number",
+    },
+    res
+  );
+};
+
 export async function addMfaSmsMethodGet(
   req: Request,
   res: Response
 ): Promise<void> {
+  setLocalOplSettings(res);
   res.render(ADD_MFA_METHOD_SMS_TEMPLATE, { backLink });
 }
 export function addMfaSmsMethodPost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
 ) {
   return async function (req: Request, res: Response): Promise<void> {
+    setLocalOplSettings(res);
+
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)
       .mapped();

--- a/src/components/change-default-method/change-default-method-controllers.ts
+++ b/src/components/change-default-method/change-default-method-controllers.ts
@@ -19,6 +19,7 @@ import { logger } from "../../utils/logger";
 import { validationResult } from "express-validator";
 import { validationErrorFormatter } from "../../middleware/form-validation-middleware";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const ADD_APP_TEMPLATE = "change-default-method/change-to-app.njk";
 const CHANGE_DEFAULT_METHOD_SMS_TEMPLATE =
@@ -65,10 +66,20 @@ export async function changeDefaultMethodAppGet(
   );
 }
 
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      taxonomyLevel2: "change phone number",
+    },
+    res
+  );
+};
+
 export async function changeDefaultMethodSmsGet(
   req: Request,
   res: Response
 ): Promise<void> {
+  setLocalOplSettings(res);
   return res.render(CHANGE_DEFAULT_METHOD_SMS_TEMPLATE, {
     backLink,
   });
@@ -78,6 +89,8 @@ export function changeDefaultMethodSmsPost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
 ) {
   return async function (req: Request, res: Response): Promise<void> {
+    setLocalOplSettings(res);
+
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)
       .mapped();

--- a/src/components/change-email/change-email-controller.ts
+++ b/src/components/change-email/change-email-controller.ts
@@ -9,9 +9,21 @@ import {
 import { ChangeEmailServiceInterface } from "./types";
 import { changeEmailService } from "./change-email-service";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
+
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "1f97b62b-a124-4d6a-ae51-8abd2611ec55",
+      taxonomyLevel2: "change email",
+    },
+    res
+  );
+};
 
 const TEMPLATE_NAME = "change-email/index.njk";
 export function changeEmailGet(req: Request, res: Response): void {
+  setLocalOplSettings(res);
   return res.render(TEMPLATE_NAME);
 }
 
@@ -21,6 +33,7 @@ function badRequest(req: Request, res: Response, errorMessage: string) {
     req.t(`pages.changeEmail.email.validationError.${errorMessage}`)
   );
 
+  setLocalOplSettings(res);
   return renderBadRequest(res, req, TEMPLATE_NAME, error);
 }
 

--- a/src/components/change-email/index.njk
+++ b/src/components/change-email/index.njk
@@ -38,5 +38,4 @@
 </p>
 
 </form>
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change email", contentId:"1f97b62b-a124-4d6a-ae51-8abd2611ec55",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/change-password/change-password-controller.ts
+++ b/src/components/change-password/change-password-controller.ts
@@ -10,10 +10,22 @@ import {
 } from "../../utils/validation";
 import { BadRequestError } from "../../utils/errors";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const changePasswordTemplate = "change-password/index.njk";
 
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "00ca6657-4139-43fa-979b-0eb3576fa94c",
+      taxonomyLevel2: "change password",
+    },
+    res
+  );
+};
+
 export function changePasswordGet(req: Request, res: Response): void {
+  setLocalOplSettings(res);
   res.render(changePasswordTemplate);
 }
 
@@ -21,6 +33,8 @@ export function changePasswordPost(
   service: ChangePasswordServiceInterface = changePasswordService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
+    setLocalOplSettings(res);
+
     const { email } = req.session.user;
 
     const newPassword = req.body.password as string;

--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -56,8 +56,3 @@
 <a href='{{ "SECURITY" | getPath }}' class="govuk-link govuk-body" rel="noreferrer noopener">{{'pages.changePassword.backLink' | translate }}</a>
 
 {% endblock %}
-
-{% block scripts %}
-    {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change password", contentId:"00ca6657-4139-43fa-979b-0eb3576fa94c",loggedInStatus:true,dynamic:true})}}
-{% endblock %}
-

--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -14,10 +14,22 @@ import { BadRequestError } from "../../utils/errors";
 import { validationResult } from "express-validator";
 import { validationErrorFormatter } from "../../middleware/form-validation-middleware";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const CHANGE_PHONE_NUMBER_TEMPLATE = "change-phone-number/index.njk";
 
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "39a31338-cadc-4e09-a74d-bd9f0dd68d2f",
+      taxonomyLevel2: "change phone number",
+    },
+    res
+  );
+};
+
 export function changePhoneNumberGet(req: Request, res: Response): void {
+  setLocalOplSettings(res);
   res.render(CHANGE_PHONE_NUMBER_TEMPLATE);
 }
 
@@ -25,6 +37,8 @@ export function changePhoneNumberPost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
+    setLocalOplSettings(res);
+
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)
       .mapped();

--- a/src/components/change-phone-number/index.njk
+++ b/src/components/change-phone-number/index.njk
@@ -1,3 +1,2 @@
 {% set formAction =  "CHANGE_PHONE_NUMBER" | getPath %}
-{% set contentId =  "39a31338-cadc-4e09-a74d-bd9f0dd68d2f" %}
 {% include "common/mfa/add-phone-number.njk" %}

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -12,10 +12,22 @@ import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/typ
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
 import { UpdateInformationInput } from "../../utils/types";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const TEMPLATE_NAME = "check-your-email/index.njk";
 
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "d5441a1e-28d1-455b-83fd-071cd876cd06",
+      taxonomyLevel2: "change email",
+    },
+    res
+  );
+};
+
 export function checkYourEmailGet(req: Request, res: Response): void {
+  setLocalOplSettings(res);
   res.render(TEMPLATE_NAME, {
     email: req.session.user.newEmailAddress,
   });
@@ -69,6 +81,7 @@ export function checkYourEmailPost(
       req.t("pages.checkYourEmail.code.validationError.invalidCode")
     );
 
+    setLocalOplSettings(res);
     renderBadRequest(res, req, TEMPLATE_NAME, error);
   };
 }

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -62,7 +62,6 @@
 }) }}
 
 </form>
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change email", contentId:"d5441a1e-28d1-455b-83fd-071cd876cd06",loggedInStatus:true,dynamic:true})}}
 {% endblock %}
 
 

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -34,8 +34,19 @@ import {
 } from "../../utils/mfaClient/types";
 import { containsNumbersOnly } from "../../utils/strings";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
+
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "fb69b162-9ddb-41db-a8fa-3cca7fea2fa9",
+      taxonomyLevel2: "change phone number",
+    },
+    res
+  );
+};
 
 const getRenderOptions = (req: Request, intent: Intent) => {
   const INTENT_TO_BACKLINK_MAP: Record<string, string> = {
@@ -70,6 +81,7 @@ const getRenderOptions = (req: Request, intent: Intent) => {
 
 export function checkYourPhoneGet(req: Request, res: Response): void {
   const intent = req.query.intent as Intent;
+  setLocalOplSettings(res);
   res.render(TEMPLATE_NAME, getRenderOptions(req, intent));
 }
 
@@ -79,6 +91,8 @@ export function checkYourPhonePost(
   return async function (req: Request, res: Response) {
     const { code } = req.body;
     const intent = req.body.intent as Intent;
+
+    setLocalOplSettings(res);
 
     if (!code) {
       const error = formatValidationError(

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -54,5 +54,4 @@
             html: detailsHTML
         }) }}
     </form>
-    {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change phone number", contentId:"fb69b162-9ddb-41db-a8fa-3cca7fea2fa9",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -21,5 +21,4 @@
       }) }}
     </div>
   </div>
-  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"404",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"undefined", contentId:"undefined",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/common/errors/500.njk
+++ b/src/components/common/errors/500.njk
@@ -9,5 +9,4 @@
       <p class="govuk-body">{{ 'error.error500.content.paragraph1' | translate }}</p>
     </div>
   </div>
-  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"500",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"undefined", contentId:"undefined",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/common/ga4-opl/template.njk
+++ b/src/components/common/ga4-opl/template.njk
@@ -6,6 +6,7 @@
                 englishPageTitle: '{{ params.englishPageTitle }}',
                 taxonomy_level1: '{{ params.taxonomyLevel1 }}',
                 taxonomy_level2: '{{ params.taxonomyLevel2 }}',
+                taxonomy_level3: '{{ params.taxonomyLevel3 }}',
                 content_id: '{{ params.contentId }}',
                 logged_in_status: {{ params.loggedInStatus }},
                 dynamic: {{ params.dynamic }}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -119,7 +119,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-    {% block scripts %}{% endblock %}
     <script type="module" src="/public/scripts/govuk-frontend.min.js" {% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}></script>
 
     <script type="module" {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
@@ -165,5 +164,19 @@
       import { setFingerprintCookie } from "{{'FINGERPRINT' | getPath }}/index.js";
       setFingerprintCookie("{{ fingerprintCookieDomain }}")
     </script>
+  {% endif %}
+
+  {% if opl %}
+    {{ ga4OnPageLoad({
+      nonce: scriptNonce,
+      englishPageTitle: pageTitleName,
+      statusCode: opl.statusCode,
+      taxonomyLevel1: opl.taxonomyLevel1,
+      taxonomyLevel2: opl.taxonomyLevel2,
+      taxonomyLevel3: opl.taxonomyLevel3,
+      contentId: opl.contentId,
+      loggedInStatus: opl.loggedInStatus,
+      dynamic: opl.dynamic
+    })}}
   {% endif %}
 {% endblock %}

--- a/src/components/common/mfa/add-phone-number.njk
+++ b/src/components/common/mfa/add-phone-number.njk
@@ -74,7 +74,6 @@
   <a href="{{"SECURITY" | getPath}}" class="govuk-link govuk-body">
     {{'pages.changePhoneNumber.info.backLink' | translate}}
   </a>
-  {{ ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change phone number", contentId:contentId,loggedInStatus:true,dynamic:true })}}
 {% endblock %}
 {% block scripts %}
   <script type="text/javascript" src="/public/scripts/international-phone.js" nonce='{{scriptNonce}}'></script>

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-controller.ts
@@ -11,6 +11,7 @@ import {
   getAccessibilityStatementUrl,
 } from "../../config";
 import { EVENT_NAME, PATH_DATA } from "../../app.constants";
+import { setOplSettings } from "../../utils/opl";
 
 const CONTACT_ONE_LOGIN_TEMPLATE = "contact-govuk-one-login/index.njk";
 
@@ -61,5 +62,12 @@ const render = (req: Request, res: Response): void => {
     nonce: res.locals.scriptNonce,
   };
 
+  setOplSettings(
+    {
+      contentId: "dbd37b91-5d9e-419e-b6e4-1ea5b40a99f6",
+      taxonomyLevel2: "contact gov uk",
+    },
+    res
+  );
   res.render(CONTACT_ONE_LOGIN_TEMPLATE, data);
 };

--- a/src/components/contact-govuk-one-login/index.njk
+++ b/src/components/contact-govuk-one-login/index.njk
@@ -248,5 +248,4 @@
     }, 10000)
   </script>
 {% endif %}
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"contact gov uk", contentId:"dbd37b91-5d9e-419e-b6e4-1ea5b40a99f6",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -11,11 +11,24 @@ import {
 import { handleLogout } from "../../utils/logout";
 import { LogoutState } from "../../app.constants";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { OplSettings, setOplSettings } from "../../utils/opl";
+
+const oplSettings: OplSettings = {
+  taxonomyLevel2: "delete account",
+};
 
 export async function deleteAccountGet(
   req: Request,
   res: Response
 ): Promise<void> {
+  setOplSettings(
+    {
+      ...oplSettings,
+      contentId: "7c0ae794-46ba-4abd-bf23-ebd70782a96b",
+    },
+    res
+  );
+
   const env = getAppEnv();
   const { user } = req.session;
   if (user?.subjectId) {
@@ -37,6 +50,17 @@ export async function deleteAccountGet(
       currentLngWelsh: req.i18n?.language === "cy",
       hasEnglishOnlyServices,
     };
+
+    if (services.length) {
+      setOplSettings(
+        {
+          ...oplSettings,
+          contentId: "0768fa94-3a7a-4f19-8bf5-a1d5afa49023",
+        },
+        res
+      );
+    }
+
     res.render("delete-account/index.njk", data);
   } else {
     const data = {

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -4,7 +4,6 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageTitleName = 'pages.deleteAccount.title' | translate %}
-{% set contentId = "0768fa94-3a7a-4f19-8bf5-a1d5afa49023" if services.length else "7c0ae794-46ba-4abd-bf23-ebd70782a96b" %}
 
 {% block pageContent %}
 
@@ -67,5 +66,4 @@
     {{ 'pages.deleteAccount.doNotDeleteAccount' | translate }}
   </a>
 {% endif %}
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"delete account", contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -16,6 +16,7 @@ import {
 import { supportChangeOnIntervention } from "../../config";
 import { handleLogout } from "../../utils/logout";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { EMPTY_OPL_SETTING_VALUE, setOplSettings } from "../../utils/opl";
 
 const TEMPLATE = "enter-password/index.njk";
 
@@ -77,9 +78,18 @@ const getRenderOptions = (req: Request, requestType: UserJourney) => {
   return {
     requestType,
     fromSecurity: req.query.from == "security",
-    oplValues: OPL_VALUES[requestType] || {},
     formAction: req.url,
   };
+};
+
+const setLocalOplSettings = (res: Response, requestType: UserJourney) => {
+  setOplSettings(
+    OPL_VALUES[requestType] ?? {
+      contentId: EMPTY_OPL_SETTING_VALUE,
+      taxonomyLevel2: EMPTY_OPL_SETTING_VALUE,
+    },
+    res
+  );
 };
 
 function renderPasswordError(
@@ -89,6 +99,8 @@ function renderPasswordError(
   errorMsgKey: string
 ) {
   const error = formatValidationError("password", req.t(errorMsgKey));
+
+  setLocalOplSettings(res, requestType);
   renderBadRequest(
     res,
     req,
@@ -105,6 +117,9 @@ export function enterPasswordGet(req: Request, res: Response): void {
     return;
   }
   req.session.user.state[requestType] = getInitialState();
+
+  setLocalOplSettings(res, requestType);
+
   res.render(TEMPLATE, getRenderOptions(req, requestType));
 }
 

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -49,9 +49,3 @@
     </form>
 
 {% endblock %}
-
-{% block scripts %}
-    {% set contentId = oplValues[requestType].contentId if oplValues[requestType] else "undefined" %}
-    {% set taxonomyLevel2Value = oplValues[requestType].taxonomyLevel2 if oplValues[requestType] else "undefined" %}
-    {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:taxonomyLevel2Value, contentId:contentId,loggedInStatus:true,dynamic:true})}}
-{% endblock %}

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -121,10 +121,6 @@ describe("enter password controller", () => {
       expect(res.render).to.have.been.calledWith("enter-password/index.njk", {
         requestType: "changeEmail",
         fromSecurity: true,
-        oplValues: {
-          contentId: "e00e882b-f54a-40d3-ac84-85737424471c",
-          taxonomyLevel2: "change email",
-        },
         formAction:
           "https://test.com/enter-password?from=security&edit=true&type=changeEmail",
         errors: { password: { text: undefined, href: "#password" } },
@@ -157,10 +153,6 @@ describe("enter password controller", () => {
       expect(res.render).to.have.been.calledWith("enter-password/index.njk", {
         requestType: "changeEmail",
         fromSecurity: false,
-        oplValues: {
-          contentId: "e00e882b-f54a-40d3-ac84-85737424471c",
-          taxonomyLevel2: "change email",
-        },
         formAction:
           "https://test.com/enter-password?edit=true&type=changeEmail",
         errors: { password: { text: undefined, href: "#password" } },

--- a/src/components/report-suspicious-activity/index.njk
+++ b/src/components/report-suspicious-activity/index.njk
@@ -17,9 +17,7 @@
       {# account for the possibility of users re-visiting the report page soon after reporting an event, before a report number is known #}
       <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.alreadyReported.noReportNo' | translate }}</p>
     {% endif %}
-    {%set contentId = "5f83e2b4-6c9d-4b98-b68e-43d4f6892b56"%}
   {% else %}
-   {% set contentId = "0252c1d4-c233-48c1-bf4b-a5b124ed8ec2"%}
     {# The event has not been reported yet – show report form #}
     <h1 class="govuk-heading-l">{{ 'pages.reportSuspiciousActivity.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.intro' | translate }}</p>
@@ -44,5 +42,4 @@
       }) }}
     </form>
   {% endif %}
-  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"activity", contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -17,6 +17,7 @@ import { snsService } from "../../utils/sns";
 import { getTxmaHeader } from "../../utils/txma-header";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { logger } from "../../utils/logger";
+import { setOplSettings } from "../../utils/opl";
 
 const activityLogDynamoDBRequest = (
   subjectId: string,
@@ -142,6 +143,16 @@ export async function reportSuspiciousActivityGet(
       homeClientId: getOIDCClientId(),
     };
 
+    setOplSettings(
+      {
+        contentId: data.alreadyReported
+          ? "5f83e2b4-6c9d-4b98-b68e-43d4f6892b56"
+          : "0252c1d4-c233-48c1-bf4b-a5b124ed8ec2",
+        taxonomyLevel2: "activity",
+      },
+      res
+    );
+
     res.render("report-suspicious-activity/index.njk", {
       ...data,
       ...activityLogDetails,
@@ -201,6 +212,14 @@ export async function reportSuspiciousActivityConfirmation(
     res.status(HTTP_STATUS_CODES.NOT_FOUND);
     res.render("common/errors/404.njk");
   } else {
+    setOplSettings(
+      {
+        contentId: "e047725a-f19a-448a-9f8d-1e9e08f5c21f",
+        taxonomyLevel2: "activity",
+      },
+      res
+    );
+
     res.render("report-suspicious-activity/success.njk", {
       backLink: `${PATH_DATA.SIGN_IN_HISTORY.url}?page=${req.query.page || 1}`,
       email: req.session.user.email,

--- a/src/components/report-suspicious-activity/success.njk
+++ b/src/components/report-suspicious-activity/success.njk
@@ -22,7 +22,4 @@
   <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.success.section2.paragraph1' | translate }}</p>
   <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.success.section2.paragraph2' | translate }}</p>
   <p class="govuk-body">{{ 'pages.reportSuspiciousActivity.success.section2.paragraph3' | translate }}</p>
-
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"activity", contentId:"e047725a-f19a-448a-9f8d-1e9e08f5c21f",loggedInStatus:true,dynamic:true})}}
-
 {% endblock %}

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -27,5 +27,4 @@
     }) }}
 
     </form>
-    {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change email", contentId:"24ad9e0f-9d6f-43d2-8828-5d8f2003c6fe",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -9,10 +9,22 @@ import {
   renderBadRequest,
 } from "../../utils/validation";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const TEMPLATE_NAME = "resend-email-code/index.njk";
 
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "24ad9e0f-9d6f-43d2-8828-5d8f2003c6fe",
+      taxonomyLevel2: "change email",
+    },
+    res
+  );
+};
+
 export function resendEmailCodeGet(req: Request, res: Response): void {
+  setLocalOplSettings(res);
   res.render(TEMPLATE_NAME, {
     emailAddress: req.session.user.newEmailAddress,
   });
@@ -23,6 +35,8 @@ function badRequest(req: Request, res: Response, errorMessage: string) {
     "email",
     req.t(`pages.changeEmail.email.validationError.${errorMessage}`)
   );
+
+  setLocalOplSettings(res);
 
   return renderBadRequest(res, req, TEMPLATE_NAME, error);
 }

--- a/src/components/resend-phone-code/index.njk
+++ b/src/components/resend-phone-code/index.njk
@@ -28,5 +28,4 @@
     <a href="{{"SECURITY" | getPath}}" class="govuk-link govuk-body">
         {{'pages.resendMfaCode.cancel' | translate}}
     </a>
-    {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"change phone number", contentId:"e92e3a80-ea97-4eae-bbff-903e89291765",loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -14,8 +14,19 @@ import {
 import { validationResult } from "express-validator";
 import { validationErrorFormatter } from "../../middleware/form-validation-middleware";
 import { getRequestConfigFromExpress } from "../../utils/http";
+import { setOplSettings } from "../../utils/opl";
 
 const TEMPLATE_NAME = "resend-phone-code/index.njk";
+
+const setLocalOplSettings = (res: Response) => {
+  setOplSettings(
+    {
+      contentId: "e92e3a80-ea97-4eae-bbff-903e89291765",
+      taxonomyLevel2: "change phone number",
+    },
+    res
+  );
+};
 
 const getRenderOptions = (req: Request) => {
   const intent = req.query.intent as string;
@@ -29,6 +40,7 @@ const getRenderOptions = (req: Request) => {
 };
 
 export function resendPhoneCodeGet(req: Request, res: Response): void {
+  setLocalOplSettings(res);
   res.render(TEMPLATE_NAME, getRenderOptions(req));
 }
 
@@ -36,6 +48,8 @@ export function resendPhoneCodePost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
+    setLocalOplSettings(res);
+
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)
       .mapped();

--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -1,7 +1,6 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% set pageTitleName = 'pages.security.title' | translate %}
-{% set contentId = "06b3a091-8595-45b7-832a-1b5f3632ad2e" if isPhoneNumberVerified else "caaccf0a-1dd3-441c-af20-01925c8f9cba" %}
 
 {% set accountDetailsSummaryList = {
   classes: 'govuk-summary-list--security',
@@ -147,5 +146,4 @@
       </div>
     </div>
   </div>
-  {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:"pages.security.title" | translate, taxonomyLevel1: "accounts", taxonomyLevel2:"home", contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -8,6 +8,7 @@ import { PATH_DATA } from "../../app.constants";
 import { hasAllowedActivityLogServices } from "../../middleware/check-allowed-services-list";
 import { getLastNDigits } from "../../utils/phone-number";
 import { MfaMethod } from "src/utils/mfaClient/types";
+import { setOplSettings } from "../../utils/opl";
 
 function handleSmsMethod(
   phoneNumber: string,
@@ -150,6 +151,13 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
   const denyChangeTypeofPrimary = Array.isArray(req.session.mfaMethods)
     ? supportChangeMfa() && canChangePrimaryMethod(req.session.mfaMethods)
     : false;
+
+  setOplSettings(
+    {
+      contentId: "caaccf0a-1dd3-441c-af20-01925c8f9cba",
+    },
+    res
+  );
 
   res.render("security/index.njk", {
     email,

--- a/src/components/session-expired/index.njk
+++ b/src/components/session-expired/index.njk
@@ -25,6 +25,5 @@
     <p class="govuk-body">
         <a href="{{'error.timeoutError.content.govUKHomepageLink' | translate }}" class="govuk-link">{{'error.timeoutError.content.govUKHomepageLinkText' | translate }}</a>
     </p>
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"undefined", contentId:"e7dc72c9-74e8-4924-bd0f-dc113f14db35",loggedInStatus:true,dynamic:true})}}
 {% endblock %}
 

--- a/src/components/session-expired/session-expired-controller.ts
+++ b/src/components/session-expired/session-expired-controller.ts
@@ -1,6 +1,16 @@
 import { Request, Response } from "express";
+import { EMPTY_OPL_SETTING_VALUE, setOplSettings } from "../../utils/opl";
 
 export function sessionExpiredGet(req: Request, res: Response): void {
   res.status(401);
+
+  setOplSettings(
+    {
+      contentId: "cb2b2652-caa0-4aca-9b41-53c8bf9e1cd1",
+      taxonomyLevel2: EMPTY_OPL_SETTING_VALUE,
+    },
+    res
+  );
+
   res.render("session-expired/index.njk", { hideAccountNavigation: true });
 }

--- a/src/components/signed-out/index.njk
+++ b/src/components/signed-out/index.njk
@@ -15,6 +15,5 @@
 <p class="govuk-body">
  {{'pages.signedOut.paragraph2' | translate}} <a href="{{'pages.signedOut.govukLinkHref' | translate}}" class="govuk-link">{{'pages.signedOut.govukLinkText' | translate}}</a>.
 </p>
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"undefined", contentId:"cb2b2652-caa0-4aca-9b41-53c8bf9e1cd1",loggedInStatus:true,dynamic:true})}}
 {% endblock %}
 

--- a/src/components/signed-out/signed-out-controller.ts
+++ b/src/components/signed-out/signed-out-controller.ts
@@ -1,8 +1,18 @@
 import { Request, Response } from "express";
 import { PATH_DATA } from "../../app.constants";
+import { EMPTY_OPL_SETTING_VALUE, setOplSettings } from "../../utils/opl";
 
 export function signedOutGet(req: Request, res: Response): void {
   res.status(200);
+
+  setOplSettings(
+    {
+      contentId: "e7dc72c9-74e8-4924-bd0f-dc113f14db35",
+      taxonomyLevel2: EMPTY_OPL_SETTING_VALUE,
+    },
+    res
+  );
+
   res.render("signed-out/index.njk", {
     signinLink: PATH_DATA.START.url,
     hideAccountNavigation: true,

--- a/src/components/signed-out/tests/signed-out-controller.test.ts
+++ b/src/components/signed-out/tests/signed-out-controller.test.ts
@@ -18,6 +18,7 @@ describe("signed out controller", () => {
     res = {
       render: sandbox.fake(),
       status: sandbox.fake(),
+      locals: {},
     };
   });
 

--- a/src/components/update-confirmation/index.njk
+++ b/src/components/update-confirmation/index.njk
@@ -4,7 +4,6 @@
 {% set pageTitleName = pageTitle %}
 {% set hideAccountNavigation = hideAccountNavigation %}
 {% set govUkLink = "https://www.gov.uk" %}
-{% set contentId = contentId %}
 {% set taxonomyLevel2 = taxonomyLevel2 %}
 
 {% block pageContent %}
@@ -36,5 +35,4 @@
   }
 }) }}
 {% endif %}
-{{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:taxonomyLevel2, contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -7,32 +7,20 @@ import {
 import { clearCookies } from "../../utils/session-store";
 import { logger } from "../../utils/logger";
 import { getLastNDigits } from "../../utils/phone-number";
-
-const oplValues = {
-  updateEmailConfirmation: {
-    contentId: "97c85664-bc62-468a-b5a8-a4eb1ede68dc",
-    taxonomyLevel2: "change email",
-  },
-  updatePasswordConfirmation: {
-    contentId: "6e223a74-7a80-4333-82b4-d44d972b3297",
-    taxonomyLevel2: "change password",
-  },
-  updatePhoneNumberConfirmation: {
-    contentId: "8641c8eb-b695-4c31-b78d-6c901111152b",
-    taxonomyLevel2: "change phone number",
-  },
-  deleteAccountConfirmation: {
-    contentId: "1a4650c5-3a00-4d9b-9487-4ace9c119a1b",
-    taxonomyLevel2: "delete account",
-  },
-};
+import { setOplSettings } from "../../utils/opl";
 
 export function updateEmailConfirmationGet(req: Request, res: Response): void {
   delete req.session.user.state.changeEmail;
 
+  setOplSettings(
+    {
+      contentId: "97c85664-bc62-468a-b5a8-a4eb1ede68dc",
+      taxonomyLevel2: "change email",
+    },
+    res
+  );
+
   res.render("update-confirmation/index.njk", {
-    contentId: oplValues.updateEmailConfirmation.contentId,
-    taxonomyLevel2: oplValues.updateEmailConfirmation.taxonomyLevel2,
     pageTitle: req.t("pages.updateEmailConfirmation.title"),
     panelText: req.t("pages.updateEmailConfirmation.panelText"),
     summaryText: req
@@ -48,6 +36,14 @@ export function updatePasswordConfirmationGet(
   delete req.session.user.state.changePassword;
   clearCookies(req, res, ["am"]);
 
+  setOplSettings(
+    {
+      contentId: "6e223a74-7a80-4333-82b4-d44d972b3297",
+      taxonomyLevel2: "change password",
+    },
+    res
+  );
+
   if (req.session) {
     req.session.destroy((error) => {
       if (error) {
@@ -57,8 +53,6 @@ export function updatePasswordConfirmationGet(
   }
 
   res.render("update-confirmation/index.njk", {
-    contentId: oplValues.updatePasswordConfirmation.contentId,
-    taxonomyLevel2: oplValues.updatePasswordConfirmation.taxonomyLevel2,
     pageTitle: req.t("pages.updatePasswordConfirmation.title"),
     panelText: req.t("pages.updatePasswordConfirmation.panelText"),
   });
@@ -70,9 +64,15 @@ export function updatePhoneNumberConfirmationGet(
 ): void {
   delete req.session.user.state.changePhoneNumber;
 
+  setOplSettings(
+    {
+      contentId: "8641c8eb-b695-4c31-b78d-6c901111152b",
+      taxonomyLevel2: "change phone number",
+    },
+    res
+  );
+
   res.render("update-confirmation/index.njk", {
-    contentId: oplValues.updatePhoneNumberConfirmation.contentId,
-    taxonomyLevel2: oplValues.updatePhoneNumberConfirmation.taxonomyLevel2,
     pageTitle: req.t("pages.updatePhoneNumberConfirmation.title"),
     panelText: req.t("pages.updatePhoneNumberConfirmation.panelText"),
     summaryText: req
@@ -98,9 +98,15 @@ export function deleteAccountConfirmationGet(
   req: Request,
   res: Response
 ): void {
+  setOplSettings(
+    {
+      contentId: "1a4650c5-3a00-4d9b-9487-4ace9c119a1b",
+      taxonomyLevel2: "delete account",
+    },
+    res
+  );
+
   res.render("update-confirmation/index.njk", {
-    contentId: oplValues.deleteAccountConfirmation.contentId,
-    taxonomyLevel2: oplValues.deleteAccountConfirmation.taxonomyLevel2,
     pageTitle: req.t("pages.deleteAccountConfirmation.title"),
     panelText: req.t("pages.deleteAccountConfirmation.panelText"),
     summaryText: req.t("pages.deleteAccountConfirmation.summaryText"),

--- a/src/components/your-services/index.njk
+++ b/src/components/your-services/index.njk
@@ -7,15 +7,6 @@
 {% set hasRPs = servicesList.length or accountsList.length %}
 {% set serviceListLink = 'pages.yourServices.informationBox.link' | translate | safe %}
 
-{% if not hasRPs %}
-    {% set contentId = "886900f6-178f-41e7-9051-c8428cca86dd" %}
-{% elif accountsList.length %}
-    {% set contentId = "74c08523-6bce-41da-bcdc-179d5e3784c8" %}
-{% elif servicesList.length %}
-    {% set contentId = "bfb16754-2768-47c9-a338-21405bc6a98a" %}
-{% else %}
-    {% set contentId = "04566d1b-d791-4e2a-9154-26787fb60516" %}
-{% endif %}
 {%- macro setKey(key, clientId) -%} 
   {{ ['clientRegistry.', env, '.', clientId, '.', key] | join }}
 {%- endmacro -%}
@@ -119,5 +110,4 @@
       </div>
     </div>
   </div>
-   {{ga4OnPageLoad({ nonce: scriptNonce,statusCode:"200",englishPageTitle:pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2:"home", contentId:contentId,loggedInStatus:true,dynamic:true})}}
 {% endblock %}

--- a/src/components/your-services/your-services-controller.ts
+++ b/src/components/your-services/your-services-controller.ts
@@ -1,11 +1,27 @@
 import { Request, Response } from "express";
 import { presentYourServices } from "../../utils/yourServices";
 import { getAppEnv } from "../../config";
+import { setOplSettings } from "../../utils/opl";
+
+const defaultContentId = "04566d1b-d791-4e2a-9154-26787fb60516";
+const contentIds: Record<string, string> = {
+  ACCOUNTS_false_SERVICES_false: "886900f6-178f-41e7-9051-c8428cca86dd",
+  ACCOUNTS_true_SERVICES_false: "74c08523-6bce-41da-bcdc-179d5e3784c8",
+  ACCOUNTS_true_SERVICES_true: "74c08523-6bce-41da-bcdc-179d5e3784c8",
+  ACCOUNTS_false_SERVICES_true: "bfb16754-2768-47c9-a338-21405bc6a98a",
+};
 
 export async function yourServicesGet(
   req: Request,
   res: Response
 ): Promise<void> {
+  setOplSettings(
+    {
+      contentId: defaultContentId,
+    },
+    res
+  );
+
   const { user } = req.session;
   const env = getAppEnv();
   const data = {
@@ -13,6 +29,7 @@ export async function yourServicesGet(
     env: env,
     currentLngWelsh: req.i18n?.language === "cy",
   };
+
   if (user?.subjectId) {
     const trace = res.locals.sessionId;
     const serviceData = await presentYourServices(
@@ -27,6 +44,16 @@ export async function yourServicesGet(
       serviceData.servicesList.some(
         (service) => service.isAvailableInWelsh === false
       );
+
+    setOplSettings(
+      {
+        contentId:
+          contentIds[
+            `ACCOUNTS_${Boolean(serviceData.accountsList.length)}_SERVICES_${Boolean(serviceData.servicesList.length)}`
+          ] ?? defaultContentId,
+      },
+      res
+    );
 
     res.render("your-services/index.njk", {
       ...data,

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { HTTP_STATUS_CODES, PATH_DATA } from "../app.constants";
+import { EMPTY_OPL_SETTING_VALUE, setOplSettings } from "../utils/opl";
 
 export function serverErrorHandler(
   err: any,
@@ -10,6 +11,14 @@ export function serverErrorHandler(
   if (res.headersSent) {
     return next(err);
   }
+
+  setOplSettings(
+    {
+      statusCode: 500,
+      taxonomyLevel2: EMPTY_OPL_SETTING_VALUE,
+    },
+    res
+  );
 
   if (
     res.statusCode === HTTP_STATUS_CODES.UNAUTHORIZED ||

--- a/src/handlers/page-not-found-handler.ts
+++ b/src/handlers/page-not-found-handler.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../app.constants";
+import { EMPTY_OPL_SETTING_VALUE, setOplSettings } from "../utils/opl";
 
 export function pageNotFoundHandler(
   req: Request,
@@ -9,6 +10,14 @@ export function pageNotFoundHandler(
   if (res.headersSent) {
     return next();
   }
+
+  setOplSettings(
+    {
+      statusCode: 404,
+      taxonomyLevel2: EMPTY_OPL_SETTING_VALUE,
+    },
+    res
+  );
 
   res.status(HTTP_STATUS_CODES.NOT_FOUND);
   res.render("common/errors/404.njk");

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -47,5 +47,7 @@ export async function setLocalVarsMiddleware(
   res.locals.trace =
     res.locals.persistentSessionId + "::" + res.locals.sessionId;
 
+  res.locals.opl = undefined;
+
   next();
 }

--- a/src/utils/opl.ts
+++ b/src/utils/opl.ts
@@ -1,0 +1,30 @@
+import { Response } from "express";
+
+export interface OplSettings {
+  contentId?: string;
+  taxonomyLevel1?: string;
+  taxonomyLevel2?: string;
+  taxonomyLevel3?: string;
+  statusCode?: number;
+  loggedInStatus?: boolean;
+  dynamic?: boolean;
+}
+
+export const EMPTY_OPL_SETTING_VALUE = "undefined";
+
+export const setOplSettings = (
+  settings: Partial<OplSettings>,
+  res: Response
+): void => {
+  const mergedSettings: OplSettings = {
+    statusCode: settings.statusCode ?? 200,
+    loggedInStatus: settings.loggedInStatus ?? true,
+    dynamic: settings.dynamic ?? true,
+    taxonomyLevel1: settings.taxonomyLevel1 ?? "accounts",
+    taxonomyLevel2: settings.taxonomyLevel2 ?? "home",
+    taxonomyLevel3: settings.taxonomyLevel3 ?? EMPTY_OPL_SETTING_VALUE,
+    contentId: settings.contentId ?? EMPTY_OPL_SETTING_VALUE,
+  };
+
+  res.locals.opl = mergedSettings;
+};

--- a/src/utils/test/opl.test.ts
+++ b/src/utils/test/opl.test.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { setOplSettings } from "../opl";
+import { Response } from "express";
+
+describe("setOplSettings", () => {
+  it("should set res.locals.opl with provided values", () => {
+    const res = {
+      locals: {},
+    } as Response;
+
+    setOplSettings(
+      {
+        contentId: "test_content_id",
+        dynamic: false,
+        loggedInStatus: false,
+        statusCode: 401,
+        taxonomyLevel1: "test_taxonomy_level1",
+        taxonomyLevel2: "test_taxonomy_level2",
+        taxonomyLevel3: "test_taxonomy_level3",
+      },
+      res
+    );
+
+    expect(res.locals.opl).to.deep.eq({
+      contentId: "test_content_id",
+      dynamic: false,
+      loggedInStatus: false,
+      statusCode: 401,
+      taxonomyLevel1: "test_taxonomy_level1",
+      taxonomyLevel2: "test_taxonomy_level2",
+      taxonomyLevel3: "test_taxonomy_level3",
+    });
+  });
+
+  it("should set res.locals.opl with default values", () => {
+    const res = {
+      locals: {},
+    } as Response;
+
+    setOplSettings({}, res);
+
+    expect(res.locals.opl).to.deep.eq({
+      contentId: "undefined",
+      dynamic: true,
+      loggedInStatus: true,
+      statusCode: 200,
+      taxonomyLevel1: "accounts",
+      taxonomyLevel2: "home",
+      taxonomyLevel3: "undefined",
+    });
+  });
+});

--- a/test/unit/error-handler.test.ts
+++ b/test/unit/error-handler.test.ts
@@ -19,6 +19,7 @@ describe("Error handlers", () => {
       render: sandbox.fake(),
       status: sandbox.fake(),
       redirect: sandbox.fake(() => {}),
+      locals: {},
     };
     next = sandbox.fake(() => {});
   });
@@ -31,6 +32,15 @@ describe("Error handlers", () => {
     it("should render 404 view", () => {
       pageNotFoundHandler(req as Request, res as Response, next);
 
+      expect(res.locals?.opl).to.deep.eq({
+        contentId: "undefined",
+        dynamic: true,
+        loggedInStatus: true,
+        statusCode: 404,
+        taxonomyLevel1: "accounts",
+        taxonomyLevel2: "undefined",
+        taxonomyLevel3: "undefined",
+      });
       expect(res.status).to.have.been.calledOnceWith(404);
       expect(res.render).to.have.been.calledOnceWith("common/errors/404.njk");
     });
@@ -43,6 +53,15 @@ describe("Error handlers", () => {
 
       serverErrorHandler(err, req as Request, res as Response, next);
 
+      expect(res.locals?.opl).to.deep.eq({
+        contentId: "undefined",
+        dynamic: true,
+        loggedInStatus: true,
+        statusCode: 500,
+        taxonomyLevel1: "accounts",
+        taxonomyLevel2: "undefined",
+        taxonomyLevel3: "undefined",
+      });
       expect(res.status).to.have.been.calledOnceWith(500);
       expect(res.render).to.have.been.calledOnceWith("common/errors/500.njk");
     });
@@ -52,6 +71,15 @@ describe("Error handlers", () => {
 
       serverErrorHandler(err, req as Request, res as Response, next);
 
+      expect(res.locals?.opl).to.deep.eq({
+        contentId: "undefined",
+        dynamic: true,
+        loggedInStatus: true,
+        statusCode: 500,
+        taxonomyLevel1: "accounts",
+        taxonomyLevel2: "undefined",
+        taxonomyLevel3: "undefined",
+      });
       expect(res.status).to.have.been.calledOnceWith(500);
       expect(res.render).to.have.been.calledOnceWith("common/errors/500.njk");
     });
@@ -62,6 +90,15 @@ describe("Error handlers", () => {
 
       serverErrorHandler(err, req as Request, res as Response, next);
 
+      expect(res.locals?.opl).to.deep.eq({
+        contentId: "undefined",
+        dynamic: true,
+        loggedInStatus: true,
+        statusCode: 500,
+        taxonomyLevel1: "accounts",
+        taxonomyLevel2: "undefined",
+        taxonomyLevel3: "undefined",
+      });
       expect(res.redirect).to.have.been.calledOnceWith(
         PATH_DATA.SESSION_EXPIRED.url
       );


### PR DESCRIPTION
### What changed

Refactor of the GA4 OPL tracking code.

There is now a single function called `setOplSettings` which can be called in controllers to set the OPL settings before rendering.

There is no need for duplicate use of the`ga4OnPageLoad` macro in templates as the macro is called in the base template.

These changes just refactor the existing code, they don't add any of the new MFA tracking.

### Why did it change

To make the GA4 OPL tracking code more consistent and easier to reason about.

### Related links

https://govukverify.atlassian.net/browse/OLH-1946

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

### Sign-offs
<!-- Delete if changes do NOT include any analytics updates -->
- [ ] Analytics updates have been signed off by a PA