### PR TITLE
BAU: Bump govuk-frontend to 5.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "di-account-management-frontend",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@aws-crypto/client-node": "^4.2.1",
@@ -33,7 +32,7 @@
         "express-session": "^1.18.1",
         "express-validator": "^7.2.1",
         "fast-memoize": "^2.5.2",
-        "govuk-frontend": "^5.10.0",
+        "govuk-frontend": "^5.10.2",
         "helmet": "8.1.0",
         "i18next": "^24.2.3",
         "i18next-fs-backend": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",
     "fast-memoize": "^2.5.2",
-    "govuk-frontend": "^5.10.0",
+    "govuk-frontend": "^5.10.2",
     "helmet": "8.1.0",
     "i18next": "^24.2.3",
     "i18next-fs-backend": "^2.6.0",


### PR DESCRIPTION
Bump the Design System library to receive the fixes outlined in the release notes https://github.com/alphagov/govuk-frontend/releases.

