### PR TITLE
OLH-2722: Handle all auth callback errors

### DIFF
--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -4,11 +4,7 @@ import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 import { oidcAuthCallbackGet } from "../call-back-controller";
-import {
-  HTTP_STATUS_CODES,
-  PATH_DATA,
-  VECTORS_OF_TRUST,
-} from "../../../app.constants";
+import { PATH_DATA, VECTORS_OF_TRUST } from "../../../app.constants";
 import { ClientAssertionServiceInterface } from "../../../utils/types";
 import { logger } from "../../../utils/logger";
 
@@ -46,6 +42,13 @@ describe("callback controller", () => {
         issuer: {
           metadata: {},
         } as any,
+      } as any,
+      app: {
+        locals: {
+          sessionStore: {
+            destroy: sandbox.fake(),
+          },
+        },
       } as any,
     };
     res = {
@@ -133,7 +136,7 @@ describe("callback controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_DATA.START.url);
     });
 
-    it("response status code should be 403 when access denied error occurs", async () => {
+    it("response status code should be 401 when access denied error occurs", async () => {
       req.oidc.callbackParams = sandbox.fake.returns({
         error: "access_denied",
         state: "m0H_2VvrhKR0qA",
@@ -142,7 +145,19 @@ describe("callback controller", () => {
         generateAssertionJwt: sandbox.fake.resolves("testassert"),
       };
       await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
-      expect(res.status).to.have.calledWith(HTTP_STATUS_CODES.FORBIDDEN);
+      expect(res.redirect).to.have.calledWith(PATH_DATA.SESSION_EXPIRED.url);
+    });
+
+    it("response status code should be 401 when any error occurs", async () => {
+      req.oidc.callbackParams = sandbox.fake.returns({
+        error: "server_error",
+        error_description: "Unexpected server error",
+      });
+      const fakeService: ClientAssertionServiceInterface = {
+        generateAssertionJwt: sandbox.fake.resolves("testassert"),
+      };
+      await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
+      expect(res.redirect).to.have.calledWith(PATH_DATA.SESSION_EXPIRED.url);
     });
 
     it("should populate req.session.authSessionIds", async () => {

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -136,7 +136,7 @@ describe("callback controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_DATA.START.url);
     });
 
-    it("response status code should be 401 when access denied error occurs", async () => {
+    it("redirect to session expired when access denied error received", async () => {
       req.oidc.callbackParams = sandbox.fake.returns({
         error: "access_denied",
         state: "m0H_2VvrhKR0qA",
@@ -148,7 +148,7 @@ describe("callback controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_DATA.SESSION_EXPIRED.url);
     });
 
-    it("response status code should be 401 when any error occurs", async () => {
+    it("redirect to session expired when any error occurs", async () => {
       req.oidc.callbackParams = sandbox.fake.returns({
         error: "server_error",
         error_description: "Unexpected server error",

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -88,7 +88,7 @@ async function deleteAllUserSessionsFromSessionStore(
   }
 }
 
-async function deleteExpressSession(req: Request) {
+export async function deleteExpressSession(req: Request) {
   req.session?.destroy((err) => {
     if (err) {
       logger.error(ERROR_MESSAGES.FAILED_TO_DESTROY_SESSION(err));


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2722] Handle Auth Callback Errors

### What changed
<!-- Describe the changes in detail - the "what"-->
Redirect the user to /session expired if the auth callback contains an error 

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
We noticed a few error on the oidc.callback end point as the query params contained an error that we did not handle e.g.  /auth/callback?error=server_error&error_description=Unexpected+server+error&state=xxxx

On auth side we found that as the user was coming from another RP to home there were multiple requests to recreate the session in a split second causing miss match of the state param. This is happening to other's as well, not just home. Ultimately this request returned a server error that is returned to home.

In this instance we want to redirect the user to sign in again to ensure they get valid tokens. 

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
https://govukverify.atlassian.net/jira/software/c/projects/OLH/boards/195?selectedIssue=OLH-2722

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

[OLH-2722]: https://govukverify.atlassian.net/browse/OLH-2722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ