### PR TITLE
OLH-2691: Send AUTH_MFA_METHOD_ADD_STARTED event

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -312,6 +312,7 @@ export const ENVIRONMENT_NAME = {
 export const enum EventName {
   HOME_TRIAGE_PAGE_VISIT = "HOME_TRIAGE_PAGE_VISIT",
   HOME_TRIAGE_PAGE_EMAIL = "HOME_TRIAGE_PAGE_EMAIL",
+  AUTH_MFA_METHOD_ADD_STARTED = "AUTH_MFA_METHOD_ADD_STARTED",
 }
 export interface QueryParameters {
   fromURL?: string;

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -10,6 +10,7 @@ import { EnterPasswordServiceInterface } from "../types";
 import { HTTP_STATUS_CODES, PATH_DATA } from "../../../app.constants";
 import { TXMA_AUDIT_ENCODED } from "../../../../test/utils/builders";
 import * as logout from "../../../utils/logout";
+import { UserJourney } from "../../../utils/state-machine";
 
 describe("enter password controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -52,10 +53,10 @@ describe("enter password controller", () => {
   });
 
   describe("enterPasswordGet", () => {
-    it("should render enter password view with query param", () => {
+    it("should render enter password view with query param", async () => {
       req.query.type = "changePassword";
 
-      enterPasswordGet(req as Request, res as Response);
+      await enterPasswordGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("enter-password/index.njk");
     });
@@ -65,6 +66,56 @@ describe("enter password controller", () => {
 
       expect(res.render).not.to.have.been.called;
       expect(res.redirect).to.have.calledWith(PATH_DATA.SETTINGS.url);
+    });
+
+    it("should send an audit event when journey type is addBackup", async () => {
+      req.query.type = UserJourney.addBackup;
+
+      const mockEventService = {
+        buildAuditEvent: sandbox.fake.returns({ event: "test-event" }),
+        send: sandbox.fake(),
+      };
+
+      const eventServiceStub = sandbox.stub().returns(mockEventService);
+
+      const eventServiceModule = await import(
+        "../../../services/event-service"
+      );
+      sandbox
+        .stub(eventServiceModule, "eventService")
+        .get(() => eventServiceStub);
+
+      await enterPasswordGet(req as Request, res as Response);
+
+      expect(mockEventService.buildAuditEvent).to.have.been.calledWith(
+        req,
+        res,
+        "AUTH_MFA_METHOD_ADD_STARTED"
+      );
+      expect(mockEventService.send).to.have.been.calledOnce;
+      expect(res.render).to.have.calledWith("enter-password/index.njk");
+    });
+
+    it("should not send an audit event when journey type is change password", async () => {
+      req.query.type = UserJourney.ChangePassword;
+
+      const mockEventService = {
+        buildAuditEvent: sandbox.fake.returns({ event: "test-event" }),
+        send: sandbox.fake(),
+      };
+
+      const eventServiceStub = sandbox.stub().returns(mockEventService);
+
+      const eventServiceModule = await import(
+        "../../../services/event-service"
+      );
+      sandbox
+        .stub(eventServiceModule, "eventService")
+        .get(() => eventServiceStub);
+
+      await enterPasswordGet(req as Request, res as Response);
+      expect(mockEventService.send).not.to.have.been.called;
+      expect(res.render).to.have.calledWith("enter-password/index.njk");
     });
   });
 

--- a/src/services/event-service.test.ts
+++ b/src/services/event-service.test.ts
@@ -32,7 +32,7 @@ describe("eventService", () => {
       clock.restore();
     });
 
-    it("should build an audit event correctly", () => {
+    it("should build a HOME_TRIAGE_PAGE_EMAIL audit event correctly", () => {
       const service = eventService(sqs);
 
       const mockReq: any = {
@@ -79,9 +79,6 @@ describe("eventService", () => {
       expect(result.extensions.app_error_code).to.equal("test-error-code");
       expect(result.extensions.app_session_id).to.equal("test-app-session-id");
       expect(result.extensions.reference_code).to.equal("test-reference-code");
-      expect(result.extensions.is_signed_in).to.equal(true);
-      expect(result.extensions.is_signed_in).to.equal(true);
-      expect(result.extensions.is_signed_in).to.equal(true);
       expect(result.extensions.is_signed_in).to.equal(true);
       expect(result.event_timestamp_ms).to.equal(1726099200000);
       expect(result.event_timestamp_ms_formatted).to.equal(
@@ -150,6 +147,112 @@ describe("eventService", () => {
         MISSING_APP_SESSION_ID_SPECIAL_CASE
       );
       expect(result.restricted).to.be.undefined;
+    });
+
+    it("should build a HOME_TRIAGE_PAGE_VISIT event correctly", () => {
+      const service = eventService(sqs);
+
+      const mockReq: any = {
+        headers: {
+          "user-agent": "test-user-agent",
+          "txma-audit-encoded": btoa("test-txma-header"),
+        },
+        session: {
+          queryParameters: {
+            fromURL: "test-from-url",
+            appErrorCode: "test-error-code",
+            appSessionId: "test-app-session-id",
+          },
+          referenceCode: "test-reference-code",
+          user_id: "test-user-id",
+          user: {
+            isAuthenticated: true,
+          },
+        },
+      };
+
+      const mockRes: any = {
+        locals: {
+          sessionId: "test-session-id",
+          persistentSessionId: "test-persistent-session-id",
+        },
+      };
+
+      const result = service.buildAuditEvent(
+        mockReq,
+        mockRes,
+        EventName.HOME_TRIAGE_PAGE_VISIT
+      );
+
+      expect(result.component_id).to.equal("HOME");
+      expect(result.event_name).to.equal("HOME_TRIAGE_PAGE_VISIT");
+      expect(result.user.session_id).to.equal("test-session-id");
+      expect(result.user.persistent_session_id).to.equal(
+        "test-persistent-session-id"
+      );
+      expect(result.user.user_id).to.equal("test-user-id");
+      expect(result.platform.user_agent).to.equal("test-user-agent");
+      expect(result.extensions.from_url).to.equal("test-from-url");
+      expect(result.extensions.app_error_code).to.equal("test-error-code");
+      expect(result.extensions.app_session_id).to.equal("test-app-session-id");
+      expect(result.extensions.reference_code).to.equal("test-reference-code");
+      expect(result.extensions.is_signed_in).to.equal(true);
+      expect(result.event_timestamp_ms).to.equal(1726099200000);
+      expect(result.event_timestamp_ms_formatted).to.equal(
+        "2024-09-12T00:00:00.000Z"
+      );
+      expect(result.timestamp).to.equal(1726099200);
+      expect(atob(result.restricted.device_information.encoded)).to.equal(
+        "test-txma-header"
+      );
+    });
+
+    it("should build an AUTH_MFA_METHOD_ADD_STARTED event correctly", () => {
+      const service = eventService(sqs);
+
+      const mockReq: any = {
+        headers: {
+          "user-agent": "test-user-agent",
+          "txma-audit-encoded": btoa("test-txma-header"),
+        },
+        session: {
+          user_id: "test-user-id",
+          user: {
+            isAuthenticated: true,
+          },
+        },
+      };
+
+      const mockRes: any = {
+        locals: {
+          sessionId: "test-session-id",
+          persistentSessionId: "test-persistent-session-id",
+        },
+      };
+
+      const result = service.buildAuditEvent(
+        mockReq,
+        mockRes,
+        EventName.AUTH_MFA_METHOD_ADD_STARTED
+      );
+
+      expect(result.component_id).to.equal("HOME");
+      expect(result.event_name).to.equal("AUTH_MFA_METHOD_ADD_STARTED");
+      expect(result.user.session_id).to.equal("test-session-id");
+      expect(result.user.persistent_session_id).to.equal(
+        "test-persistent-session-id"
+      );
+      expect(result.user.user_id).to.equal("test-user-id");
+      expect(result.platform.user_agent).to.equal("test-user-agent");
+      expect(result.extensions["journey-type"]).to.equal("ACCOUNT_MANAGEMENT");
+      expect(result.event_timestamp_ms).to.equal(1726099200000);
+      expect(result.event_timestamp_ms_formatted).to.equal(
+        "2024-09-12T00:00:00.000Z"
+      );
+      expect(result.timestamp).to.equal(1726099200);
+      expect(atob(result.restricted.device_information.encoded)).to.equal(
+        "test-txma-header"
+      );
     });
   });
 

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -115,6 +115,12 @@ export function eventService(
         };
         break;
 
+      case EventName.AUTH_MFA_METHOD_ADD_STARTED:
+        baseEvent.extensions = {
+          "journey-type": "ACCOUNT_MANAGEMENT",
+        };
+        break;
+
       default: {
         throw new Error(`Unknown event name: ${eventName}`);
       }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -43,11 +43,12 @@ export interface Platform {
 }
 
 export interface Extensions {
-  from_url: string;
-  app_session_id: string;
-  app_error_code: string;
-  reference_code: string;
+  from_url?: string;
+  app_session_id?: string;
+  app_error_code?: string;
+  reference_code?: string;
   is_signed_in?: boolean;
+  "journey-type"?: string;
 }
 
 export interface CurrentTimeDescriptor {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Refactor the audit event service to allow different fields in the audit events, then send the new `AUTH_MFA_METHOD_ADD_STARTED` event when a user gets to the 'Enter your password' page.

This journey can't be reached in production as the feature flag is off, so this is safe to merge to all environments. Once we've added the other new audit events I'll be able to do an end-to-end test in staging.

### Why did it change

Currently the event service builds all audit events with the same fields and data. That made sense when we only had events related to the contact page, but we're about to add several new ones for the MFA work and they'll need different fields and logic.

This structure allows for that while keeping the same simple interface for the service's API. If the logic in each branch of the statement starts to get very complex we can move it all out into a separate builder class, but we're not at that point yet.

We send this new audit event when a user comes to the 'Enter your password' page after clicking to add a new backup MFA. This is done on the GET request as that's as close as we can get to the start of the journey - unless the user's on a really bad connection it's functionally the same as them clicking the link to 'Add a backup'.
## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### How to review

Please check the required fields on the [event catalogue entry for this event](https://event-catalogue.internal.account.gov.uk/events/AUTH_MFA_METHOD_ADD_STARTED/) are all present. 
