### PR TITLE
OLH-2715: Enable testing of MFA in production

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -259,7 +259,11 @@ async function createApp(): Promise<express.Application> {
   if (supportTriagePage()) {
     app.use(contactRouter);
   }
-  if (supportChangeMfa()) {
+  if (
+    supportChangeMfa({
+      enable_mfa_for_qa: "1",
+    })
+  ) {
     app.use(chooseBackupRouter);
     app.use(addBackupAppRouter);
     app.use(addBackupSmsRouter);

--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
@@ -22,7 +22,7 @@ import { validationErrorFormatter } from "../../middleware/form-validation-middl
 import { getRequestConfigFromExpress } from "../../utils/http";
 import {
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
   setOplSettings,
 } from "../../utils/opl";
 import {
@@ -34,7 +34,7 @@ const ADD_MFA_METHOD_SMS_TEMPLATE = "add-mfa-method-sms/index.njk";
 
 const backLink = PATH_DATA.ADD_MFA_METHOD_GO_BACK.url;
 
-const ADD_MFA_SMS_METHOD_OPL_VALUES: Record<string, Partial<OplSettings>> = {
+const ADD_MFA_SMS_METHOD_OPL_VALUES: OplSettingsLookupObject = {
   [`${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]: {
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "f2dd366e-19b6-47c8-a0e0-48a659d4af07",
@@ -131,10 +131,7 @@ export function addMfaSmsMethodPost(
   };
 }
 
-const ADD_MFA_SMS_METHOD_CONFIRMATION_OPL_VALUES: Record<
-  string,
-  Partial<OplSettings>
-> = {
+const ADD_MFA_SMS_METHOD_CONFIRMATION_OPL_VALUES: OplSettingsLookupObject = {
   [`${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]: {
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "26dbe851-1c35-46e9-a9ee-8b4976126031",

--- a/src/components/change-default-method/change-default-method-controllers.ts
+++ b/src/components/change-default-method/change-default-method-controllers.ts
@@ -21,7 +21,8 @@ import { validationErrorFormatter } from "../../middleware/form-validation-middl
 import { getRequestConfigFromExpress } from "../../utils/http";
 import {
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
+  PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
   setOplSettings,
 } from "../../utils/opl";
 import {
@@ -36,7 +37,7 @@ const CHANGE_DEFAULT_METHOD_SMS_TEMPLATE =
 
 const backLink = PATH_DATA.CHANGE_DEFAULT_METHOD.url;
 
-const CHANGE_DEFAULT_METHOD_OPL_VALUES: Record<string, Partial<OplSettings>> = {
+const CHANGE_DEFAULT_METHOD_OPL_VALUES: OplSettingsLookupObject = {
   [`${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]: {
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "1c044729-69ca-488f-bf1f-40d6df909deb",
@@ -111,9 +112,7 @@ const setChangeDefaultMethodSmsOplSettings = (req: Request, res: Response) => {
           ...MFA_COMMON_OPL_SETTINGS,
           contentId: "e847d040-e59e-4a88-8f9c-1d00a840d0bd",
         }
-      : {
-          taxonomyLevel2: "change phone number",
-        },
+      : PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
     res
   );
 };

--- a/src/components/change-default-method/change-default-method-controllers.ts
+++ b/src/components/change-default-method/change-default-method-controllers.ts
@@ -104,9 +104,9 @@ export async function changeDefaultMethodAppGet(
   );
 }
 
-const setChangeDefaultMethodSmsOplSettings = (res: Response) => {
+const setChangeDefaultMethodSmsOplSettings = (req: Request, res: Response) => {
   setOplSettings(
-    supportMfaManagement()
+    supportMfaManagement(req.cookies)
       ? {
           ...MFA_COMMON_OPL_SETTINGS,
           contentId: "e847d040-e59e-4a88-8f9c-1d00a840d0bd",
@@ -122,7 +122,7 @@ export async function changeDefaultMethodSmsGet(
   req: Request,
   res: Response
 ): Promise<void> {
-  setChangeDefaultMethodSmsOplSettings(res);
+  setChangeDefaultMethodSmsOplSettings(req, res);
   return res.render(CHANGE_DEFAULT_METHOD_SMS_TEMPLATE, {
     backLink,
   });
@@ -132,7 +132,7 @@ export function changeDefaultMethodSmsPost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
 ) {
   return async function (req: Request, res: Response): Promise<void> {
-    setChangeDefaultMethodSmsOplSettings(res);
+    setChangeDefaultMethodSmsOplSettings(req, res);
 
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)

--- a/src/components/change-default-method/change-default-method-routes.ts
+++ b/src/components/change-default-method/change-default-method-routes.ts
@@ -9,7 +9,7 @@ import {
   changeDefaultMethodSmsGet,
   changeDefaultMethodSmsPost,
 } from "./change-default-method-controllers";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { validatePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
 import { changePhoneNumberService } from "../change-phone-number/change-phone-number-service";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
@@ -20,7 +20,7 @@ router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodGet)
 );
 
@@ -28,7 +28,7 @@ router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD_APP.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodAppGet)
 );
 
@@ -36,7 +36,7 @@ router.post(
   PATH_DATA.CHANGE_DEFAULT_METHOD_APP.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodAppPost)
 );
 
@@ -44,7 +44,7 @@ router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD_SMS.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodSmsGet)
 );
 
@@ -53,7 +53,7 @@ router.post(
   requiresAuthMiddleware,
   validateStateMiddleware,
   validatePhoneNumberRequest(),
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodSmsPost(changePhoneNumberService()))
 );
 

--- a/src/components/change-email/change-email-controller.ts
+++ b/src/components/change-email/change-email-controller.ts
@@ -9,13 +9,16 @@ import {
 import { ChangeEmailServiceInterface } from "./types";
 import { changeEmailService } from "./change-email-service";
 import { getRequestConfigFromExpress } from "../../utils/http";
-import { setOplSettings } from "../../utils/opl";
+import {
+  CHANGE_EMAIL_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl";
 
 const setLocalOplSettings = (res: Response) => {
   setOplSettings(
     {
+      ...CHANGE_EMAIL_COMMON_OPL_SETTINGS,
       contentId: "1f97b62b-a124-4d6a-ae51-8abd2611ec55",
-      taxonomyLevel2: "change email",
     },
     res
   );

--- a/src/components/change-password/change-password-controller.ts
+++ b/src/components/change-password/change-password-controller.ts
@@ -10,15 +10,18 @@ import {
 } from "../../utils/validation";
 import { BadRequestError } from "../../utils/errors";
 import { getRequestConfigFromExpress } from "../../utils/http";
-import { setOplSettings } from "../../utils/opl";
+import {
+  CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl";
 
 const changePasswordTemplate = "change-password/index.njk";
 
 const setLocalOplSettings = (res: Response) => {
   setOplSettings(
     {
+      ...CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
       contentId: "00ca6657-4139-43fa-979b-0eb3576fa94c",
-      taxonomyLevel2: "change password",
     },
     res
   );

--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -14,7 +14,11 @@ import { BadRequestError } from "../../utils/errors";
 import { validationResult } from "express-validator";
 import { validationErrorFormatter } from "../../middleware/form-validation-middleware";
 import { getRequestConfigFromExpress } from "../../utils/http";
-import { MFA_COMMON_OPL_SETTINGS, setOplSettings } from "../../utils/opl";
+import {
+  MFA_COMMON_OPL_SETTINGS,
+  PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl";
 import { supportMfaManagement } from "../../config";
 
 const CHANGE_PHONE_NUMBER_TEMPLATE = "change-phone-number/index.njk";
@@ -27,8 +31,8 @@ const setLocalOplSettings = (req: Request, res: Response) => {
           contentId: "a8d82f1b-c682-433b-8695-34343afb9666",
         }
       : {
+          ...PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
           contentId: "39a31338-cadc-4e09-a74d-bd9f0dd68d2f",
-          taxonomyLevel2: "change phone number",
         },
     res
   );

--- a/src/components/change-phone-number/change-phone-number-controller.ts
+++ b/src/components/change-phone-number/change-phone-number-controller.ts
@@ -19,9 +19,9 @@ import { supportMfaManagement } from "../../config";
 
 const CHANGE_PHONE_NUMBER_TEMPLATE = "change-phone-number/index.njk";
 
-const setLocalOplSettings = (res: Response) => {
+const setLocalOplSettings = (req: Request, res: Response) => {
   setOplSettings(
-    supportMfaManagement()
+    supportMfaManagement(req.cookies)
       ? {
           ...MFA_COMMON_OPL_SETTINGS,
           contentId: "a8d82f1b-c682-433b-8695-34343afb9666",
@@ -35,7 +35,7 @@ const setLocalOplSettings = (res: Response) => {
 };
 
 export function changePhoneNumberGet(req: Request, res: Response): void {
-  setLocalOplSettings(res);
+  setLocalOplSettings(req, res);
   res.render(CHANGE_PHONE_NUMBER_TEMPLATE);
 }
 
@@ -43,7 +43,7 @@ export function changePhoneNumberPost(
   service: ChangePhoneNumberServiceInterface = changePhoneNumberService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    setLocalOplSettings(res);
+    setLocalOplSettings(req, res);
 
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -12,15 +12,18 @@ import { GovUkPublishingServiceInterface } from "../common/gov-uk-publishing/typ
 import { govUkPublishingService } from "../common/gov-uk-publishing/gov-uk-publishing-service";
 import { UpdateInformationInput } from "../../utils/types";
 import { getRequestConfigFromExpress } from "../../utils/http";
-import { setOplSettings } from "../../utils/opl";
+import {
+  CHANGE_EMAIL_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl";
 
 const TEMPLATE_NAME = "check-your-email/index.njk";
 
 const setLocalOplSettings = (res: Response) => {
   setOplSettings(
     {
+      ...CHANGE_EMAIL_COMMON_OPL_SETTINGS,
       contentId: "d5441a1e-28d1-455b-83fd-071cd876cd06",
-      taxonomyLevel2: "change email",
     },
     res
   );

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -104,7 +104,7 @@ const setCheckYourPhoneOplSettings = (
   req: Request,
   res: Response
 ) => {
-  if (!supportMfaManagement()) {
+  if (!supportMfaManagement(req.cookies)) {
     setOplSettings(
       {
         contentId: "fb69b162-9ddb-41db-a8fa-3cca7fea2fa9",
@@ -205,7 +205,7 @@ export function checkYourPhonePost(
     let isPhoneNumberUpdated = false;
     let changePhoneNumberWithMfaApiErrorMessage: string | undefined = undefined;
 
-    if (supportChangeMfa()) {
+    if (supportChangeMfa(req.cookies)) {
       const mfaClient = createMfaClient(req, res);
       const changePhoneNumberResult = await changePhoneNumberwithMfaApi(
         mfaClient,

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -38,7 +38,8 @@ import { containsNumbersOnly } from "../../utils/strings";
 import { getRequestConfigFromExpress } from "../../utils/http";
 import {
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
+  PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
   setOplSettings,
 } from "../../utils/opl";
 
@@ -75,7 +76,7 @@ const getRenderOptions = (req: Request, intent: Intent) => {
   };
 };
 
-const OPL_VALUES: Record<string, Partial<OplSettings>> = {
+const OPL_VALUES: OplSettingsLookupObject = {
   [`${INTENT_ADD_BACKUP}_${mfaPriorityIdentifiers.default}_${mfaMethodTypes.sms}`]:
     {
       ...MFA_COMMON_OPL_SETTINGS,
@@ -107,8 +108,8 @@ const setCheckYourPhoneOplSettings = (
   if (!supportMfaManagement(req.cookies)) {
     setOplSettings(
       {
+        ...PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
         contentId: "fb69b162-9ddb-41db-a8fa-3cca7fea2fa9",
-        taxonomyLevel2: "change phone number",
       },
       res
     );

--- a/src/components/check-your-phone/check-your-phone-routes.ts
+++ b/src/components/check-your-phone/check-your-phone-routes.ts
@@ -9,7 +9,7 @@ import {
   requestNewOTPCodeGet,
 } from "./check-your-phone-controller";
 import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import {
   globalTryCatchAsync,
   globalTryCatch,
@@ -20,7 +20,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.CHECK_YOUR_PHONE.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatch(checkYourPhoneGet)
 );

--- a/src/components/choose-backup/choose-backup-controller.ts
+++ b/src/components/choose-backup/choose-backup-controller.ts
@@ -7,7 +7,7 @@ import {
 } from "../../utils/mfaClient/types";
 import {
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
   setOplSettings,
 } from "../../utils/opl";
 
@@ -19,7 +19,7 @@ enum MfaMethodType {
 const MAX_METHODS = 2;
 const ADD_METHOD_TEMPLATE = `choose-backup/index.njk`;
 
-const OPL_VALUES: Record<string, Partial<OplSettings>> = {
+const OPL_VALUES: OplSettingsLookupObject = {
   [`${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]: {
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "63f44ae6-46f1-46c3-a2e8-305fe2ddf27d",

--- a/src/components/choose-backup/choose-backup-routes.ts
+++ b/src/components/choose-backup/choose-backup-routes.ts
@@ -3,7 +3,7 @@ import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import { chooseBackupGet, chooseBackupPost } from "./choose-backup-controller";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { validateChooseBackupRequest } from "./choose-backup-validation";
 import { globalTryCatch } from "../../utils/global-try-catch";
 
@@ -12,7 +12,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.ADD_MFA_METHOD.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatch(chooseBackupGet)
 );

--- a/src/components/delete-account/delete-account-controller.ts
+++ b/src/components/delete-account/delete-account-controller.ts
@@ -11,11 +11,10 @@ import {
 import { handleLogout } from "../../utils/logout";
 import { LogoutState } from "../../app.constants";
 import { getRequestConfigFromExpress } from "../../utils/http";
-import { OplSettings, setOplSettings } from "../../utils/opl";
-
-const oplSettings: OplSettings = {
-  taxonomyLevel2: "delete account",
-};
+import {
+  DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl";
 
 export async function deleteAccountGet(
   req: Request,
@@ -23,7 +22,7 @@ export async function deleteAccountGet(
 ): Promise<void> {
   setOplSettings(
     {
-      ...oplSettings,
+      ...DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
       contentId: "7c0ae794-46ba-4abd-bf23-ebd70782a96b",
     },
     res
@@ -54,7 +53,7 @@ export async function deleteAccountGet(
     if (services.length) {
       setOplSettings(
         {
-          ...oplSettings,
+          ...DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
           contentId: "0768fa94-3a7a-4f19-8bf5-a1d5afa49023",
         },
         res

--- a/src/components/delete-mfa-method/delete-mfa-method-routes.ts
+++ b/src/components/delete-mfa-method/delete-mfa-method-routes.ts
@@ -1,7 +1,7 @@
 import * as express from "express";
 import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import {
   deleteMfaMethodGet,
   deleteMfaMethodPost,
@@ -14,7 +14,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.DELETE_MFA_METHOD.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(deleteMfaMethodGet)
 );
@@ -22,7 +22,7 @@ router.get(
 router.post(
   PATH_DATA.DELETE_MFA_METHOD.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(deleteMfaMethodPost)
 );

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -22,7 +22,11 @@ import { getRequestConfigFromExpress } from "../../utils/http";
 import {
   EMPTY_OPL_SETTING_VALUE,
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
+  CHANGE_EMAIL_COMMON_OPL_SETTINGS,
+  CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
+  PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
+  DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
   setOplSettings,
 } from "../../utils/opl";
 import {
@@ -44,14 +48,14 @@ const REDIRECT_PATHS: Record<UserJourney, string> = {
   [UserJourney.ChangeDefaultMethod]: PATH_DATA.CHANGE_DEFAULT_METHOD.url,
 };
 
-const getOplValues = (req: Request): Record<string, Partial<OplSettings>> => ({
+const getOplValues = (req: Request): OplSettingsLookupObject => ({
   [UserJourney.ChangeEmail]: {
+    ...CHANGE_EMAIL_COMMON_OPL_SETTINGS,
     contentId: "e00e882b-f54a-40d3-ac84-85737424471c",
-    taxonomyLevel2: "change email",
   },
   [UserJourney.ChangePassword]: {
+    ...CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
     contentId: "23d51dca-51ca-44ad-86e0-b7599ce14412",
-    taxonomyLevel2: "change password",
   },
   [UserJourney.ChangePhoneNumber]: supportMfaManagement(req.cookies)
     ? {
@@ -59,12 +63,12 @@ const getOplValues = (req: Request): Record<string, Partial<OplSettings>> => ({
         contentId: "e1cde140-d7e6-4221-90ca-0f2d131743cd",
       }
     : {
+        ...PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
         contentId: "2f5f174d-c650-4b28-96cf-365f4fb17af1",
-        taxonomyLevel2: "change phone number",
       },
   [UserJourney.DeleteAccount]: {
+    ...DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
     contentId: "c69af4c7-5496-4c11-9d22-97bd3d2e9349",
-    taxonomyLevel2: "delete account",
   },
   [`${UserJourney.addBackup}_${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]:
     {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -44,7 +44,7 @@ const REDIRECT_PATHS: Record<UserJourney, string> = {
   [UserJourney.ChangeDefaultMethod]: PATH_DATA.CHANGE_DEFAULT_METHOD.url,
 };
 
-const OPL_VALUES = ((): Record<string, Partial<OplSettings>> => ({
+const getOplValues = (req: Request): Record<string, Partial<OplSettings>> => ({
   [UserJourney.ChangeEmail]: {
     contentId: "e00e882b-f54a-40d3-ac84-85737424471c",
     taxonomyLevel2: "change email",
@@ -53,7 +53,7 @@ const OPL_VALUES = ((): Record<string, Partial<OplSettings>> => ({
     contentId: "23d51dca-51ca-44ad-86e0-b7599ce14412",
     taxonomyLevel2: "change password",
   },
-  [UserJourney.ChangePhoneNumber]: supportMfaManagement()
+  [UserJourney.ChangePhoneNumber]: supportMfaManagement(req.cookies)
     ? {
         ...MFA_COMMON_OPL_SETTINGS,
         contentId: "e1cde140-d7e6-4221-90ca-0f2d131743cd",
@@ -98,7 +98,7 @@ const OPL_VALUES = ((): Record<string, Partial<OplSettings>> => ({
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "acef67be-40e5-4ebf-83d6-b8bc8c414304",
   },
-}))();
+});
 
 const getRenderOptions = (req: Request, requestType: UserJourney) => {
   return {
@@ -116,6 +116,8 @@ const setLocalOplSettings = (
   const defaultMfaMethodType = req.session.mfaMethods?.find(
     (method) => method.priorityIdentifier === mfaPriorityIdentifiers.default
   )?.method.mfaMethodType;
+
+  const OPL_VALUES = getOplValues(req);
 
   setOplSettings(
     OPL_VALUES[

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -152,6 +152,26 @@ describe("Integration::enter password", () => {
     // exclude the account deletion flow, as the user will be logged out, so the usual tests wont work
     PATH_DATA.ACCOUNT_DELETED_CONFIRMATION,
     PATH_DATA.DELETE_ACCOUNT,
+
+    // don't test MFA Method routes in the feautre flag is off
+    ...(!supportChangeMfa({
+      enable_mfa_for_qa: "1",
+    })
+      ? [
+          PATH_DATA.ADD_MFA_METHOD,
+          PATH_DATA.ADD_MFA_METHOD_APP,
+          PATH_DATA.ADD_MFA_METHOD_APP_CONFIRMATION,
+          PATH_DATA.ADD_MFA_METHOD_GO_BACK,
+          PATH_DATA.ADD_MFA_METHOD_SMS,
+          PATH_DATA.ADD_MFA_METHOD_SMS_CONFIRMATION,
+          PATH_DATA.DELETE_MFA_METHOD,
+          PATH_DATA.SWITCH_BACKUP_METHOD,
+          PATH_DATA.CHANGE_DEFAULT_METHOD,
+          PATH_DATA.CHANGE_DEFAULT_METHOD_APP,
+          PATH_DATA.CHANGE_DEFAULT_METHOD_SMS,
+          PATH_DATA.CHANGE_AUTHENTICATOR_APP,
+        ]
+      : []),
   ];
 
   Object.entries(PATH_DATA)

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -152,24 +152,6 @@ describe("Integration::enter password", () => {
     // exclude the account deletion flow, as the user will be logged out, so the usual tests wont work
     PATH_DATA.ACCOUNT_DELETED_CONFIRMATION,
     PATH_DATA.DELETE_ACCOUNT,
-
-    // don't test MFA Method routes in the feautre flag is off
-    ...(!supportChangeMfa()
-      ? [
-          PATH_DATA.ADD_MFA_METHOD,
-          PATH_DATA.ADD_MFA_METHOD_APP,
-          PATH_DATA.ADD_MFA_METHOD_APP_CONFIRMATION,
-          PATH_DATA.ADD_MFA_METHOD_GO_BACK,
-          PATH_DATA.ADD_MFA_METHOD_SMS,
-          PATH_DATA.ADD_MFA_METHOD_SMS_CONFIRMATION,
-          PATH_DATA.DELETE_MFA_METHOD,
-          PATH_DATA.SWITCH_BACKUP_METHOD,
-          PATH_DATA.CHANGE_DEFAULT_METHOD,
-          PATH_DATA.CHANGE_DEFAULT_METHOD_APP,
-          PATH_DATA.CHANGE_DEFAULT_METHOD_SMS,
-          PATH_DATA.CHANGE_AUTHENTICATOR_APP,
-        ]
-      : []),
   ];
 
   Object.entries(PATH_DATA)

--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -17,7 +17,7 @@ import { snsService } from "../../utils/sns";
 import { getTxmaHeader } from "../../utils/txma-header";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { logger } from "../../utils/logger";
-import { setOplSettings } from "../../utils/opl";
+import { ACTIVITY_COMMON_OPL_SETTINGS, setOplSettings } from "../../utils/opl";
 
 const activityLogDynamoDBRequest = (
   subjectId: string,
@@ -145,10 +145,10 @@ export async function reportSuspiciousActivityGet(
 
     setOplSettings(
       {
+        ...ACTIVITY_COMMON_OPL_SETTINGS,
         contentId: data.alreadyReported
           ? "5f83e2b4-6c9d-4b98-b68e-43d4f6892b56"
           : "0252c1d4-c233-48c1-bf4b-a5b124ed8ec2",
-        taxonomyLevel2: "activity",
       },
       res
     );
@@ -214,8 +214,8 @@ export async function reportSuspiciousActivityConfirmation(
   } else {
     setOplSettings(
       {
+        ...ACTIVITY_COMMON_OPL_SETTINGS,
         contentId: "e047725a-f19a-448a-9f8d-1e9e08f5c21f",
-        taxonomyLevel2: "activity",
       },
       res
     );

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -9,15 +9,18 @@ import {
   renderBadRequest,
 } from "../../utils/validation";
 import { getRequestConfigFromExpress } from "../../utils/http";
-import { setOplSettings } from "../../utils/opl";
+import {
+  CHANGE_EMAIL_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl";
 
 const TEMPLATE_NAME = "resend-email-code/index.njk";
 
 const setLocalOplSettings = (res: Response) => {
   setOplSettings(
     {
+      ...CHANGE_EMAIL_COMMON_OPL_SETTINGS,
       contentId: "24ad9e0f-9d6f-43d2-8828-5d8f2003c6fe",
-      taxonomyLevel2: "change email",
     },
     res
   );

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -16,7 +16,8 @@ import { validationErrorFormatter } from "../../middleware/form-validation-middl
 import { getRequestConfigFromExpress } from "../../utils/http";
 import {
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
+  PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
   setOplSettings,
 } from "../../utils/opl";
 import {
@@ -33,7 +34,7 @@ import { supportMfaManagement } from "../../config";
 
 const TEMPLATE_NAME = "resend-phone-code/index.njk";
 
-const OPL_VALUES: Record<string, Partial<OplSettings>> = {
+const OPL_VALUES: OplSettingsLookupObject = {
   [`${INTENT_ADD_BACKUP}_${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]:
     {
       ...MFA_COMMON_OPL_SETTINGS,
@@ -60,8 +61,8 @@ const setLocalOplSettings = (intent: Intent, req: Request, res: Response) => {
   if (!supportMfaManagement(req.cookies)) {
     setOplSettings(
       {
+        ...PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
         contentId: "e92e3a80-ea97-4eae-bbff-903e89291765",
-        taxonomyLevel2: "change phone number",
       },
       res
     );

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -57,7 +57,7 @@ const OPL_VALUES: Record<string, Partial<OplSettings>> = {
 };
 
 const setLocalOplSettings = (intent: Intent, req: Request, res: Response) => {
-  if (!supportMfaManagement()) {
+  if (!supportMfaManagement(req.cookies)) {
     setOplSettings(
       {
         contentId: "e92e3a80-ea97-4eae-bbff-903e89291765",

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -133,8 +133,8 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
   const { email } = req.session.user;
   const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=security&edit=true`;
 
-  const supportMfaChange = supportChangeMfa();
-  const supportBackupMfa = supportAddBackupMfa();
+  const supportMfaChange = supportChangeMfa(req.cookies);
+  const supportBackupMfa = supportAddBackupMfa(req.cookies);
   const supportActivityLogFlag = supportActivityLog();
 
   const hasActivityLog = await hasAllowedActivityLogServices(req, res);
@@ -149,7 +149,8 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
     : [];
 
   const denyChangeTypeofPrimary = Array.isArray(req.session.mfaMethods)
-    ? supportChangeMfa() && canChangePrimaryMethod(req.session.mfaMethods)
+    ? supportChangeMfa(req.cookies) &&
+      canChangePrimaryMethod(req.session.mfaMethods)
     : false;
 
   setOplSettings(

--- a/src/components/security/security-routes.ts
+++ b/src/components/security/security-routes.ts
@@ -2,7 +2,7 @@ import * as express from "express";
 import { securityGet } from "./security-controller";
 import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { globalTryCatch } from "../../utils/global-try-catch";
 
 const router = express.Router();
@@ -10,7 +10,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.SECURITY.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatch(securityGet)
 );
 

--- a/src/components/switch-backup-method/switch-backup-method-routes.ts
+++ b/src/components/switch-backup-method/switch-backup-method-routes.ts
@@ -5,7 +5,7 @@ import {
   switchBackupMfaMethodGet,
   switchBackupMfaMethodPost,
 } from "./switch-backup-method-controller";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
 
@@ -14,7 +14,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.SWITCH_BACKUP_METHOD.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(switchBackupMfaMethodGet)
 );
@@ -22,7 +22,7 @@ router.get(
 router.post(
   PATH_DATA.SWITCH_BACKUP_METHOD.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(switchBackupMfaMethodPost)
 );

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -9,7 +9,11 @@ import { logger } from "../../utils/logger";
 import { getLastNDigits } from "../../utils/phone-number";
 import {
   MFA_COMMON_OPL_SETTINGS,
-  OplSettings,
+  OplSettingsLookupObject,
+  CHANGE_EMAIL_COMMON_OPL_SETTINGS,
+  CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
+  PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
+  DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
   setOplSettings,
 } from "../../utils/opl";
 import { supportMfaManagement } from "../../config";
@@ -21,8 +25,8 @@ import {
 export function updateEmailConfirmationGet(req: Request, res: Response): void {
   setOplSettings(
     {
+      ...CHANGE_EMAIL_COMMON_OPL_SETTINGS,
       contentId: "97c85664-bc62-468a-b5a8-a4eb1ede68dc",
-      taxonomyLevel2: "change email",
     },
     res
   );
@@ -44,8 +48,8 @@ export function updatePasswordConfirmationGet(
 ): void {
   setOplSettings(
     {
+      ...CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
       contentId: "6e223a74-7a80-4333-82b4-d44d972b3297",
-      taxonomyLevel2: "change password",
     },
     res
   );
@@ -78,8 +82,8 @@ export function updatePhoneNumberConfirmationGet(
           contentId: "670a63e1-94a5-4bec-9a5c-af36bd894ef6",
         }
       : {
+          ...PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS,
           contentId: "8641c8eb-b695-4c31-b78d-6c901111152b",
-          taxonomyLevel2: "change phone number",
         },
     res
   );
@@ -122,8 +126,8 @@ export function deleteAccountConfirmationGet(
 ): void {
   setOplSettings(
     {
+      ...DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
       contentId: "1a4650c5-3a00-4d9b-9487-4ace9c119a1b",
-      taxonomyLevel2: "delete account",
     },
     res
   );
@@ -244,10 +248,7 @@ export async function changeDefaultMfaMethodConfirmationGet(
   });
 }
 
-const CHANGE_DEFAULT_METHOD_CONFIRMATION_OPL_VALUES: Record<
-  string,
-  Partial<OplSettings>
-> = {
+const CHANGE_DEFAULT_METHOD_CONFIRMATION_OPL_VALUES: OplSettingsLookupObject = {
   [`${mfaPriorityIdentifiers.default}_${mfaMethodTypes.authApp}`]: {
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "87c95563-8fff-41d9-91a5-a34504d343a8",

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -72,7 +72,7 @@ export function updatePhoneNumberConfirmationGet(
   res: Response
 ): void {
   setOplSettings(
-    supportMfaManagement()
+    supportMfaManagement(req.cookies)
       ? {
           ...MFA_COMMON_OPL_SETTINGS,
           contentId: "670a63e1-94a5-4bec-9a5c-af36bd894ef6",

--- a/src/components/update-confirmation/update-confirmation-routes.ts
+++ b/src/components/update-confirmation/update-confirmation-routes.ts
@@ -14,7 +14,7 @@ import {
 } from "./update-confirmation-controller";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
-import { selectMfaMiddleware } from "../../middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import {
   globalTryCatchAsync,
   globalTryCatch,
@@ -68,7 +68,7 @@ router.get(
 router.get(
   PATH_DATA.SWITCH_BACKUP_METHOD_CONFIRMATION.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(changeDefaultMfaMethodConfirmationGet)
 );
@@ -76,7 +76,7 @@ router.get(
 router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD_CONFIRMATION.url,
   requiresAuthMiddleware,
-  selectMfaMiddleware(),
+  mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(changeDefaultMethodConfirmationGet)
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -219,8 +219,12 @@ export function getContactEmailServiceUrl(): string {
   return process.env.CONTACT_EMAIL_SERVICE_URL;
 }
 
-export function supportMfaManagement(): boolean {
-  return process.env.SUPPORT_METHOD_MANAGEMENT === "1";
+export function supportMfaManagement(cookies: Record<string, string>): boolean {
+  return (
+    process.env.SUPPORT_METHOD_MANAGEMENT === "1" ||
+    (process.env.SUPPORT_METHOD_MANAGEMENT === "qa" &&
+      cookies.enable_mfa_for_qa === "1")
+  );
 }
 
 export function googleAnalytics4GtmContainerId(): string {
@@ -243,12 +247,20 @@ export function getMfaServiceUrl(): string {
   return process.env.METHOD_MANAGEMENT_BASE_URL;
 }
 
-export function supportChangeMfa(): boolean {
-  return process.env.SUPPORT_CHANGE_MFA === "1";
+export function supportChangeMfa(cookies: Record<string, string>): boolean {
+  return (
+    process.env.SUPPORT_CHANGE_MFA === "1" ||
+    (process.env.SUPPORT_CHANGE_MFA === "qa" &&
+      cookies.enable_mfa_for_qa === "1")
+  );
 }
 
-export function supportAddBackupMfa(): boolean {
-  return process.env.SUPPORT_ADD_BACKUP_MFA === "1";
+export function supportAddBackupMfa(cookies: Record<string, string>): boolean {
+  return (
+    process.env.SUPPORT_ADD_BACKUP_MFA === "1" ||
+    (process.env.SUPPORT_ADD_BACKUP_MFA === "qa" &&
+      cookies.enable_mfa_for_qa === "1")
+  );
 }
 
 export function supportSearchableList(): boolean {

--- a/src/middleware/mfa-method-middleware.ts
+++ b/src/middleware/mfa-method-middleware.ts
@@ -1,11 +1,11 @@
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import { ERROR_MESSAGES } from "../app.constants";
 import { getMfaServiceUrl, supportMfaManagement } from "../config";
 import { logger } from "../utils/logger";
-import { legacyMfaMethodsMiddleware } from "./mfa-methods-legacy";
+import { runLegacyMfaMethodsMiddleware } from "./mfa-methods-legacy";
 import { createMfaClient, formatErrorMessage } from "../utils/mfaClient";
 
-export async function mfaMethodMiddleware(
+async function runMfaMethodMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
@@ -32,7 +32,11 @@ export async function mfaMethodMiddleware(
   }
 }
 
-const selectMfaMiddleware = (): RequestHandler => {
+export async function mfaMethodMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
   const mfaServiceUrlString = getMfaServiceUrl();
   let mfaServiceUrl: URL | null = null;
   if (mfaServiceUrlString) {
@@ -44,11 +48,9 @@ const selectMfaMiddleware = (): RequestHandler => {
     }
   }
 
-  if (supportMfaManagement() && mfaServiceUrl) {
-    return mfaMethodMiddleware;
+  if (supportMfaManagement(req.cookies) && mfaServiceUrl) {
+    await runMfaMethodMiddleware(req, res, next);
+  } else {
+    runLegacyMfaMethodsMiddleware(req, res, next);
   }
-
-  return legacyMfaMethodsMiddleware;
-};
-
-export { selectMfaMiddleware };
+}

--- a/src/middleware/mfa-methods-legacy.ts
+++ b/src/middleware/mfa-methods-legacy.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Response, Request } from "express";
 
-export function legacyMfaMethodsMiddleware(
+export function runLegacyMfaMethodsMiddleware(
   req: Request,
   res: Response,
   next: NextFunction

--- a/src/utils/opl.ts
+++ b/src/utils/opl.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 
-export interface OplSettings {
+interface OplSettings {
   contentId?: string;
   taxonomyLevel1?: string;
   taxonomyLevel2?: string;
@@ -10,10 +10,28 @@ export interface OplSettings {
   dynamic?: boolean;
 }
 
+export type OplSettingsLookupObject = Record<string, Partial<OplSettings>>;
+
 export const EMPTY_OPL_SETTING_VALUE = "undefined";
 
 export const MFA_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
   taxonomyLevel3: "MFA Method Management",
+};
+export const PRE_MFA_CHANGE_PHONE_NUMBER_COMMON_OPL_SETTINGS: Partial<OplSettings> =
+  {
+    taxonomyLevel2: "change phone number",
+  };
+export const CHANGE_EMAIL_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
+  taxonomyLevel2: "change email",
+};
+export const CHANGE_PASSWORD_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
+  taxonomyLevel2: "change password",
+};
+export const DELETE_ACCOUNT_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
+  taxonomyLevel2: "delete account",
+};
+export const ACTIVITY_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
+  taxonomyLevel2: "activity",
 };
 
 export const setOplSettings = (

--- a/test/unit/middleware/mfa-method-middleware.test.ts
+++ b/test/unit/middleware/mfa-method-middleware.test.ts
@@ -2,14 +2,10 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { NextFunction, Request, Response } from "express";
 import { sinon } from "../../utils/test-utils";
-import {
-  mfaMethodMiddleware,
-  selectMfaMiddleware,
-} from "../../../src/middleware/mfa-method-middleware";
+import { mfaMethodMiddleware } from "../../../src/middleware/mfa-method-middleware";
 import { ERROR_MESSAGES } from "../../../src/app.constants";
 import * as mfaClient from "../../../src/utils/mfaClient";
 import { MfaMethod } from "../../../src/utils/mfaClient/types";
-import { legacyMfaMethodsMiddleware } from "../../../src/middleware/mfa-methods-legacy";
 
 describe("mfaMethodMiddleware", () => {
   let req: Partial<Request>;
@@ -18,6 +14,7 @@ describe("mfaMethodMiddleware", () => {
   let mfaClientStub: sinon.SinonStubbedInstance<mfaClient.MfaClient>;
   const error: sinon.SinonSpy = sinon.spy();
   const configFuncs = require("../../../src/config");
+  const legacyMfaMiddleware = require("../../../src/middleware/mfa-methods-legacy");
   const sandbox = sinon.createSandbox();
 
   const mfaMethod: MfaMethod = {
@@ -92,22 +89,24 @@ describe("mfaMethodMiddleware", () => {
     expect(next).to.have.been.called;
   });
 
-  it("should use legacy mfa middleware if MFA service URL is invalid", () => {
+  it("should use legacy mfa middleware if MFA service URL is invalid", async () => {
     sandbox.stub(configFuncs, "getMfaServiceUrl").returns("not-a-valid-url");
-    sandbox.stub(configFuncs, "supportMfaManagement").returns(true);
-    const loggerModule = require("../../../src/utils/logger");
-    const warnStub = sandbox.stub(loggerModule.logger, "warn");
-    const middleware = selectMfaMiddleware();
-    expect(middleware).to.equal(legacyMfaMethodsMiddleware);
-    expect(warnStub).to.have.been.calledWithMatch("Invalid MFA service URL");
+    sandbox.stub(legacyMfaMiddleware, "runLegacyMfaMethodsMiddleware");
+    await mfaMethodMiddleware(req as Request, res as Response, next);
+    expect(
+      legacyMfaMiddleware.runLegacyMfaMethodsMiddleware
+    ).to.have.been.calledWith(req, res, next);
   });
 
-  it("should use legacy mfa middleware if supportMfaManagement returns false", () => {
+  it("should use legacy mfa middleware if supportMfaManagement returns false", async () => {
     sandbox
       .stub(configFuncs, "getMfaServiceUrl")
       .returns("https://method-management-v1-stub.home.build.account.gov.uk");
     sandbox.stub(configFuncs, "supportMfaManagement").returns(false);
-    const middleware = selectMfaMiddleware();
-    expect(middleware).to.equal(legacyMfaMethodsMiddleware);
+    sandbox.stub(legacyMfaMiddleware, "runLegacyMfaMethodsMiddleware");
+    await mfaMethodMiddleware(req as Request, res as Response, next);
+    expect(
+      legacyMfaMiddleware.runLegacyMfaMethodsMiddleware
+    ).to.have.been.calledWith(req, res, next);
   });
 });

--- a/test/unit/middleware/mfa-method-middleware.test.ts
+++ b/test/unit/middleware/mfa-method-middleware.test.ts
@@ -28,6 +28,10 @@ describe("mfaMethodMiddleware", () => {
   };
 
   beforeEach(() => {
+    sandbox.stub(configFuncs, "supportMfaManagement").returns(true);
+    sandbox
+      .stub(configFuncs, "getMfaServiceUrl")
+      .returns("https://method-management-v1-stub.home.build.account.gov.uk");
     next = sinon.fake(() => {});
     mfaClientStub = sinon.createStubInstance(mfaClient.MfaClient);
     sinon.stub(mfaClient, "createMfaClient").returns(mfaClientStub);
@@ -90,6 +94,7 @@ describe("mfaMethodMiddleware", () => {
   });
 
   it("should use legacy mfa middleware if MFA service URL is invalid", async () => {
+    configFuncs.getMfaServiceUrl.restore();
     sandbox.stub(configFuncs, "getMfaServiceUrl").returns("not-a-valid-url");
     sandbox.stub(legacyMfaMiddleware, "runLegacyMfaMethodsMiddleware");
     await mfaMethodMiddleware(req as Request, res as Response, next);
@@ -99,9 +104,7 @@ describe("mfaMethodMiddleware", () => {
   });
 
   it("should use legacy mfa middleware if supportMfaManagement returns false", async () => {
-    sandbox
-      .stub(configFuncs, "getMfaServiceUrl")
-      .returns("https://method-management-v1-stub.home.build.account.gov.uk");
+    configFuncs.supportMfaManagement.restore();
     sandbox.stub(configFuncs, "supportMfaManagement").returns(false);
     sandbox.stub(legacyMfaMiddleware, "runLegacyMfaMethodsMiddleware");
     await mfaMethodMiddleware(req as Request, res as Response, next);


### PR DESCRIPTION
### What changed and why

Makes it possible to test MFA in production. When we're ready to test MFA in production then the production environment variables `SUPPORT_METHOD_MANAGEMENT`, `SUPPORT_CHANGE_MFA` and `SUPPORT_ADD_BACKUP_MFA` should have their value set to `qa`.

MFA will still not be available at this point but if you set a cookie in dev tools called `enable_mfa_for_qa` with the value `1` then MFA will become enabled.

### Related links

https://govukverify.atlassian.net/browse/OLH-2715

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
