### PR TITLE
OLH-2757: updated Temporary and Permenant Suspension pages

### DIFF
--- a/src/components/permanently-suspended/index.njk
+++ b/src/components/permanently-suspended/index.njk
@@ -8,11 +8,13 @@
     <p class="govuk-body">{{'pages.permanentlySuspendedScreen.section1.paragraph1' | translate }}</p>
 
     <h3 class="govuk-heading-m">
-          {{'pages.permanentlySuspendedScreen.section2.heading' | translate}}
-        </h3>
+        {{'pages.permanentlySuspendedScreen.section2.heading' | translate}}
+    </h3>
 
     <p class="govuk-body">{{'pages.permanentlySuspendedScreen.section2.paragraph1' | translate }}</p>
 
-    <p class="govuk-body">{{'pages.permanentlySuspendedScreen.section2.paragraph2' | translate }}</p>
+    <a href="{{'pages.permanentlySuspendedScreen.link.href' | translate}}" class="govuk-link govuk-body">
+    {{'pages.permanentlySuspendedScreen.link.text' | translate}}
+    </a>
 
 {% endblock %}

--- a/src/components/temporarily-suspended/index.njk
+++ b/src/components/temporarily-suspended/index.njk
@@ -8,12 +8,11 @@
 
     <p class="govuk-body">{{'pages.temporarilySuspendedPageScreen.section1.paragraph1' | translate }}</p>
 
-    <h3 class="govuk-heading-m">
-      {{'pages.temporarilySuspendedPageScreen.section2.heading' | translate}}
-    </h3>
+    <p class="govuk-body">{{'pages.temporarilySuspendedPageScreen.section2.paragraph1' | translate }}
+      <a href="{{"START" | getPath}}" class="govuk-link govuk-body">
+        {{'pages.temporarilySuspendedPageScreen.link.text' | translate}}
+      </a>.
+    </p>
 
-    <p class="govuk-body">{{'pages.temporarilySuspendedPageScreen.section2.paragraph1' | translate }}</p>
-
-    <p class="govuk-body">{{'pages.temporarilySuspendedPageScreen.section2.paragraph2' | translate }}</p>
 
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -675,8 +675,11 @@
       },
       "section2": {
         "heading": "Beth allwch chi ei wneud",
-        "paragraph1": "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK.",
-        "paragraph2": "Gallwch greu GOV.UK One Login newydd gyda chyfeiriad e-bost gwahanol."
+        "paragraph1": "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK."
+      },
+      "link": {
+        "href": "https://www.gov.uk/using-your-gov-uk-one-login/services",
+        "text": "Ewch i'r gwasanaeth sydd angen i chi ei ddefnyddio"
       }
     },
     "temporarilySuspendedPageScreen": {
@@ -686,9 +689,10 @@
         "paragraph1": "Nid yw eich GOV.UK One Login ar gael ar hyn o bryd."
       },
       "section2": {
-        "heading": "Beth allwch chi ei wneud",
-        "paragraph1": "Dewch yn ôl yn nes ymlaen. Dylai eich GOV.UK One Login fod ar gael eto mewn 3 diwrnod gwaith.",
-        "paragraph2": "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK."
+        "paragraph1": "Dewch yn ôl yn nes ymlaen. Dylai eich GOV.UK One Login fod ar gael eto mewn 3 diwrnod gwaith."
+      },
+      "link": {
+        "text": "Ceisiwch fewngofnodi yn nes ymlaen"
       }
     },
     "confirmaddBackup": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -819,24 +819,28 @@
       "title": "Your GOV.UK One Login has been permanently locked",
       "header": "Your GOV.UK One Login has been permanently locked",
       "section1": {
-        "paragraph1": "You cannot sign in and you cannot use your GOV.UK  One Login to access government services."
+        "paragraph1": "You've been signed out and you can no longer use your GOV.UK One Login."
       },
       "section2": {
         "heading": "What you can do",
-        "paragraph1": "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK  homepage.",
-        "paragraph2": "You can create a new GOV.UK  One Login with a different email address."
+        "paragraph1": "If you need a GOV.UK One Login to access a government service you can create a new one using a different email address."
+      },
+      "link": {
+        "href": "https://www.gov.uk/using-your-gov-uk-one-login/services",
+        "text": "Go to the service you need to use"
       }
     },
     "temporarilySuspendedPageScreen": {
       "title": "Sorry, there is a problem",
       "heading": "Sorry, there is a problem",
       "section1": {
-        "paragraph1": "Your GOV.UK  One Login is not available at the moment."
+        "paragraph1": "You've been signed out."
       },
       "section2": {
-        "heading": "What you can do",
-        "paragraph1": "Come back later. Your GOV.UK  One Login should be available again in 3 working days.",
-        "paragraph2": "You can also go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage."
+        "paragraph1": "Your GOV.UK One Login is not available at the moment."
+      },
+      "link": {
+        "text": "Try signing in later"
       }
     }
   }


### PR DESCRIPTION
## Proposed changes

Update versions of Account Intervention Screens

### What changed
Update versions of Account Intervention Screens, specifically:
- <account-home-url>/unavailable-permanent
- <account-home-url>/unavailable-temporary

### Why did it change
UCD updates after being reviewed by @mel4782gh & Fraud team

### Related links
- [OLH-2757](https://govukverify.atlassian.net/browse/OLH-2757)
- [OLH-2614](https://govukverify.atlassian.net/browse/OLH-2614)
- [OLH-2758](https://govukverify.atlassian.net/browse/OLH-2758)

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

### Testing

<!-- When working with feature flags, features that are flagged off should not be made available in production -->
<!-- Delete if changes do NOT include any feature flags -->
- [ ] Automated test coverage includes features that are flagged off

### Sign-offs
- [x] Design updates have been signed off by a member of the UCD team



## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
