### PR TITLE
OLH-2796: add button role to links styled as buttons

### DIFF
--- a/src/components/change-default-method/index.njk
+++ b/src/components/change-default-method/index.njk
@@ -1,4 +1,5 @@
 {% extends "common/layout/base-page.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'pages.changeDefaultMethod.title' | translate %}
 
@@ -8,18 +9,27 @@
   {% if currentMethodType == "SMS" %}
     <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsPhone" | translate | safe | replace("[phoneNumber]", phoneNumber) }}</p>
     <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToApp" | translate }}</p>
-    <a href='{{ "CHANGE_DEFAULT_METHOD_APP" | getPath }}' class="govuk-button" role="button" data-module="govuk-button">{{ "pages.changeDefaultMethod.setUpAppButton" | translate }}</a>
+    {{ govukButton({
+      text: "pages.changeDefaultMethod.setUpAppButton" | translate,
+      href: "CHANGE_DEFAULT_METHOD_APP" | getPath,
+      attributes: {
+        "data-nav": true,
+        "data-link": "CHANGE_DEFAULT_METHOD_APP" | getPath
+      }
+    }) }}
   {% endif %}
 
   {% if currentMethodType == "AUTH_APP" %}
     <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsApp" | translate }}</p>
     <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToPhone" | translate }}</p>
-    <a href='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}'
-      class="govuk-button"
-      role="button"
-      data-module="govuk-button"
-      data-nav="true"
-      data-link='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}'>{{ "pages.changeDefaultMethod.setUpPhoneButton" | translate }}</a>
+    {{ govukButton({
+      text: "pages.changeDefaultMethod.setUpPhoneButton" | translate,
+      href: "CHANGE_DEFAULT_METHOD_SMS" | getPath,
+      attributes: {
+        "data-nav": true,
+        "data-link": "CHANGE_DEFAULT_METHOD_SMS" | getPath
+      }
+    }) }}
   {% endif %}
 
   <p class="govuk-body">

--- a/src/components/change-default-method/index.njk
+++ b/src/components/change-default-method/index.njk
@@ -8,7 +8,7 @@
   {% if currentMethodType == "SMS" %}
     <p class="govuk-body">{{ "pages.changeDefaultMethod.currentIsPhone" | translate | safe | replace("[phoneNumber]", phoneNumber) }}</p>
     <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToApp" | translate }}</p>
-    <a href='{{ "CHANGE_DEFAULT_METHOD_APP" | getPath }}' class="govuk-button" data-module="govuk-button">{{ "pages.changeDefaultMethod.setUpAppButton" | translate }}</a>
+    <a href='{{ "CHANGE_DEFAULT_METHOD_APP" | getPath }}' class="govuk-button" role="button" data-module="govuk-button">{{ "pages.changeDefaultMethod.setUpAppButton" | translate }}</a>
   {% endif %}
 
   {% if currentMethodType == "AUTH_APP" %}
@@ -16,6 +16,7 @@
     <p class="govuk-body">{{ "pages.changeDefaultMethod.switchToPhone" | translate }}</p>
     <a href='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}'
       class="govuk-button"
+      role="button"
       data-module="govuk-button"
       data-nav="true"
       data-link='{{ "CHANGE_DEFAULT_METHOD_SMS" | getPath }}'>{{ "pages.changeDefaultMethod.setUpPhoneButton" | translate }}</a>

--- a/src/components/common/confirmation-page/confirmation.njk
+++ b/src/components/common/confirmation-page/confirmation.njk
@@ -7,5 +7,5 @@
         titleText: heading
     }) }}
     <p class='govuk-body'>{{ message | safe }}</p>
-    <p><a class='govuk-button' href='{{ backLink }}'>{{ backLinkText }}</a></p>
+    <p><a class='govuk-button' role='button' href='{{ backLink }}'>{{ backLinkText }}</a></p>
 {% endblock %}

--- a/src/components/common/confirmation-page/confirmation.njk
+++ b/src/components/common/confirmation-page/confirmation.njk
@@ -8,12 +8,12 @@
         titleText: heading
     }) }}
     <p class='govuk-body'>{{ message | safe }}</p>
-    <p>{{ govukButton({
+    {{ govukButton({
         text: backLinkText,
         href: backLink,
         attributes: {
             "data-nav": true,
             "data-link": backLink
         }
-    }) }}</p>
+    }) }}
 {% endblock %}

--- a/src/components/common/confirmation-page/confirmation.njk
+++ b/src/components/common/confirmation-page/confirmation.njk
@@ -1,5 +1,6 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% block backLinkBlock %}
 {% endblock %}
 {% block pageContent %}
@@ -7,5 +8,12 @@
         titleText: heading
     }) }}
     <p class='govuk-body'>{{ message | safe }}</p>
-    <p><a class='govuk-button' role='button' href='{{ backLink }}'>{{ backLinkText }}</a></p>
+    <p>{{ govukButton({
+        text: backLinkText,
+        href: backLink,
+        attributes: {
+            "data-nav": true,
+            "data-link": backLink
+        }
+    }) }}</p>
 {% endblock %}


### PR DESCRIPTION
### What changed

Use `govukButton` macro for link buttons to ensure they have the role `button`.

### Why did it change

To improve accessibility. When a link is styled as a button the user is likely to expect to be able to "click" the link using both the enter and space keys as is the case with HTML button elements. Without the `button` role links can only be "clicked" with the enter key. Adding the `button` role makes the link clickable with the space key too.

### Related links

https://govukverify.atlassian.net/browse/OLH-2796

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed