### PR TITLE
BAU: add missing script block

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -119,6 +119,7 @@
 {% endblock %}
 
 {% block bodyEnd %}
+    {% block scripts %}{% endblock %}
     <script type="module" src="/public/scripts/govuk-frontend.min.js" {% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}></script>
 
     <script type="module" {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
I was investigating something else and accidentally realised the `international-phone` script was no longer loading on the "Enter your new mobile phone number" template.
I traced this back to the fact that the scripts block in `base.njk` went missing, so the script was no longer being appended to `bodyEnd`. 
That being said it might be worth reassessing our use of `scripts` seeing as other than webchat, `international-phone` might be the only page-specific script remaining.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
On the `/change-phone-number page`, when "I do not have a UK mobile number" is selected, the UK mobile phone number input box should be deactivated. This was a request from interaction design. 
This stopped working as the script was missing, but it should work again now. 
<!-- Describe the reason these changes were made - the "why" -->


## How to review
Verify the behaviour described under **Why did it change**.
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
