### PR TITLE
OLH-2809: prevent res redirect on intent from user passed variable

### DIFF
--- a/src/components/check-your-email/types.ts
+++ b/src/components/check-your-email/types.ts
@@ -13,7 +13,10 @@ export const INTENT_CHANGE_PHONE_NUMBER = UserJourney.ChangePhoneNumber;
 export const INTENT_ADD_BACKUP = UserJourney.addBackup;
 export const INTENT_CHANGE_DEFAULT_METHOD = UserJourney.ChangeDefaultMethod;
 
-export type Intent =
-  | typeof INTENT_CHANGE_PHONE_NUMBER
-  | typeof INTENT_ADD_BACKUP
-  | typeof INTENT_CHANGE_DEFAULT_METHOD;
+export const ALL_INTENTS = [
+  INTENT_CHANGE_PHONE_NUMBER,
+  INTENT_ADD_BACKUP,
+  INTENT_CHANGE_DEFAULT_METHOD,
+] as const;
+
+export type Intent = (typeof ALL_INTENTS)[number];

--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -25,6 +25,7 @@ import {
   mfaPriorityIdentifiers,
 } from "../../utils/mfaClient/types";
 import {
+  ALL_INTENTS,
   Intent,
   INTENT_ADD_BACKUP,
   INTENT_CHANGE_DEFAULT_METHOD,
@@ -132,7 +133,9 @@ export function resendPhoneCodePost(
         req.session.user.state.changePhoneNumber.value,
         EventType.VerifyCodeSent
       );
-
+      if (!Object.values(ALL_INTENTS).includes(intent)) {
+        throw new BadRequestError("Invalid intent", 400);
+      }
       return res.redirect(`${PATH_DATA.CHECK_YOUR_PHONE.url}?intent=${intent}`);
     }
 

--- a/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
@@ -97,6 +97,8 @@ describe("resend phone code controller", () => {
 
       try {
         await resendPhoneCodePost(fakeService)(req as Request, res as Response);
+        expect(fakeService.sendPhoneVerificationNotification).not.to.have.been
+          .called;
       } catch (err) {
         expect(err).to.be.instanceOf(BadRequestError);
       }

--- a/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-controller.test.ts
@@ -11,6 +11,7 @@ import {
   resendPhoneCodePost,
 } from "../resend-phone-code-controller";
 import { TXMA_AUDIT_ENCODED } from "../../../../test/utils/builders";
+import { BadRequestError } from "../../../utils/errors";
 
 describe("resend phone code controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -78,6 +79,27 @@ describe("resend phone code controller", () => {
       expect(res.redirect).to.have.calledWith(
         "/check-your-phone?intent=changePhoneNumber"
       );
+    });
+
+    it("should redirect to error /check-your-phone when invalid intent is passed", async () => {
+      const fakeService: ChangePhoneNumberServiceInterface = {
+        sendPhoneVerificationNotification: sandbox.fake.resolves({
+          success: true,
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      req.session.user.tokens = { accessToken: "token" } as any;
+      req.body.phoneNumber = "+33645453322";
+      req.body.intent = "unknown";
+      req.session.user.email = "test@test.com";
+      req.session.user.state = { changePhoneNumber: getInitialState() };
+
+      try {
+        await resendPhoneCodePost(fakeService)(req as Request, res as Response);
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestError);
+      }
     });
   });
 });

--- a/src/components/resend-phone-code/tests/resend-phone-code-integration.test.ts
+++ b/src/components/resend-phone-code/tests/resend-phone-code-integration.test.ts
@@ -13,6 +13,7 @@ import { checkFailedCSRFValidationBehaviour } from "../../../../test/utils/behav
 import * as cheerio from "cheerio";
 import { CURRENT_EMAIL } from "../../../../test/utils/builders";
 import { expect } from "chai";
+import { INTENT_CHANGE_PHONE_NUMBER } from "../../check-your-email/types";
 
 const PHONE_NUMBER = "07839490040";
 
@@ -136,7 +137,11 @@ describe("Integration:: request phone code", () => {
       .post(PATH_DATA.RESEND_PHONE_CODE.url)
       .type("form")
       .set("Cookie", cookies)
-      .send({ _csrf: token, phoneNumber: PHONE_NUMBER })
+      .send({
+        _csrf: token,
+        phoneNumber: PHONE_NUMBER,
+        intent: INTENT_CHANGE_PHONE_NUMBER,
+      })
       .expect(302);
 
     expect(phoneNumberRequestedToChangeTo).to.equal(PHONE_NUMBER);


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
<!-- Describe the changes in detail - the "what"-->
- Check intent before redirecting user
- Throw a badRequestError if a unknown intent is passed

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Prevent user controlled actions controlling the intent