### PR TITLE
OLH-2783: Use a session scoped session cookie

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,6 @@ OIDC_CLIENT_ID=
 OIDC_CLIENT_SCOPES=openid phone email am offline_access govuk-account
 AM_API_BASE_URL=https://am-stub.home.dev.account.gov.uk
 AM_YOUR_ACCOUNT_URL=http://localhost:6001
-SESSION_EXPIRY=1800000
 SESSION_SECRET=secret
 GOV_ACCOUNTS_PUBLISHING_API_URL=http://localhost:4444
 GOV_ACCOUNTS_PUBLISHING_API_TOKEN=token

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -169,7 +169,6 @@ Mappings:
       APIBASEURL: "https://oidc.staging.account.gov.uk"
       AMAPIBASEURL: "https://manage.staging.account.gov.uk"
       BASEURL: "home.dev.account.gov.uk"
-      SESSIONEXPIRY: "7200000"
       AMYOURACCOUNTURL: "https://www.staging.publishing.service.gov.uk/account/home"
       GOVACCOUNTSPUBLISHINGAPIURL: "https://account-api.staging.publishing.service.gov.uk"
       SUPPORTACTIVITYLOG: "1"
@@ -208,7 +207,6 @@ Mappings:
       APIBASEURL: "https://oidc.build.account.gov.uk"
       AMAPIBASEURL: "https://manage.build.account.gov.uk"
       BASEURL: "home.build.account.gov.uk"
-      SESSIONEXPIRY: "7200000"
       AMYOURACCOUNTURL: "https://www.staging.publishing.service.gov.uk/account/home"
       GOVACCOUNTSPUBLISHINGAPIURL: "https://account-api.staging.publishing.service.gov.uk"
       SUPPORTACTIVITYLOG: "1"
@@ -247,7 +245,6 @@ Mappings:
       APIBASEURL: "https://oidc.staging.account.gov.uk"
       AMAPIBASEURL: "https://manage.staging.account.gov.uk"
       BASEURL: "home.staging.account.gov.uk"
-      SESSIONEXPIRY: "7200000"
       AMYOURACCOUNTURL: "https://www.staging.publishing.service.gov.uk/account/home"
       GOVACCOUNTSPUBLISHINGAPIURL: "https://account-api.staging.publishing.service.gov.uk"
       SUPPORTACTIVITYLOG: "1"
@@ -286,7 +283,6 @@ Mappings:
       APIBASEURL: "https://oidc.integration.account.gov.uk"
       AMAPIBASEURL: "https://manage.integration.account.gov.uk"
       BASEURL: "home.integration.account.gov.uk"
-      SESSIONEXPIRY: "7200000"
       AMYOURACCOUNTURL: "https://www.integration.publishing.service.gov.uk/account/home"
       GOVACCOUNTSPUBLISHINGAPIURL: "https://account-api.integration.publishing.service.gov.uk"
       SUPPORTACTIVITYLOG: "1"
@@ -325,7 +321,6 @@ Mappings:
       APIBASEURL: "https://oidc.account.gov.uk"
       AMAPIBASEURL: "https://manage.account.gov.uk"
       BASEURL: "home.account.gov.uk"
-      SESSIONEXPIRY: "7200000"
       AMYOURACCOUNTURL: "https://www.gov.uk/account/home"
       GOVACCOUNTSPUBLISHINGAPIURL: "https://account-api.publishing.service.gov.uk"
       SUPPORTACTIVITYLOG: "1"
@@ -712,13 +707,6 @@ Resources:
               Value: !Sub "{{resolve:ssm:/${AWS::StackName}/Config/OIDC/Client/Id}}"
             - Name: "OIDC_CLIENT_SCOPES"
               Value: "openid phone email am offline_access govuk-account"
-            - Name: "SESSION_EXPIRY"
-              Value:
-                !FindInMap [
-                  EnvironmentVariables,
-                  !Ref Environment,
-                  SESSIONEXPIRY,
-                ]
             - Name: "SESSION_SECRET"
               Value: !Sub "{{resolve:secretsmanager:${SessionSecret}}}"
             - Name: "AM_YOUR_ACCOUNT_URL"

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,6 @@ import Backend from "i18next-fs-backend";
 import {
   getAppEnv,
   getNodeEnv,
-  getSessionExpiry,
   getSessionSecret,
   supportActivityLog,
   supportBrandRefresh,
@@ -144,11 +143,7 @@ async function createApp(): Promise<express.Application> {
       secret: getSessionSecret(),
       resave: false,
       unset: "destroy",
-      cookie: getSessionCookieOptions(
-        isProduction,
-        getSessionExpiry(),
-        getSessionSecret()
-      ),
+      cookie: getSessionCookieOptions(isProduction, getSessionSecret()),
     })
   );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,10 +50,6 @@ export function getGtmId(): string {
   return process.env.GTM_ID;
 }
 
-export function getSessionExpiry(): number {
-  return Number(process.env.SESSION_EXPIRY);
-}
-
 export function getSessionSecret(): string {
   return process.env.SESSION_SECRET;
 }

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -1,12 +1,11 @@
 export function getSessionCookieOptions(
   isProdEnv: boolean,
-  expiry: number,
   secret: string
 ): any {
   return {
     name: "ams",
     secret: secret,
-    maxAge: expiry,
     secure: isProdEnv,
+    maxAge: null,
   };
 }


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Remove the max age definition from our session cookie config. This means express-session won't set an `Expires` field on the cookie and therefore browsers will treat our session cookie as scoped to that browser session.

In practice, this means that we'll log users out when they close the last tab / window with Home open in it.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] Application configuration is up-to-date
- [x] Added to local startup config

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
