### PR TITLE
OLH-2809: Check page number is valid before adding

### DIFF
--- a/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
+++ b/src/components/report-suspicious-activity/report-suspicious-activity-controller.ts
@@ -193,7 +193,13 @@ export async function reportSuspiciousActivityPost(
       return next(error);
     }
 
-    const pageUrlParam = req.body.page ? `?page=${req.body.page}` : "";
+    let pageUrlParam = "";
+    if (req.body.page !== undefined) {
+      const pageNum = parseInt(req.body.page, 10);
+      if (Number.isInteger(pageNum) && pageNum > 0) {
+        pageUrlParam = `?page=${pageNum}`;
+      }
+    }
 
     res.redirect(
       PATH_DATA.REPORT_SUSPICIOUS_ACTIVITY.url + "/done" + pageUrlParam

--- a/src/components/report-suspicious-activity/tests/report-suspicious-activity-controller.test.ts
+++ b/src/components/report-suspicious-activity/tests/report-suspicious-activity-controller.test.ts
@@ -298,6 +298,29 @@ describe("report suspicious activity controller", () => {
       });
     });
 
+    it("should send event to SNS without page information", async () => {
+      // Arrange
+      req.body.page = "AAA";
+      req.headers = {};
+
+      const configFuncs = require("../../../config");
+      sandbox.stub(configFuncs, "reportSuspiciousActivity").callsFake(() => {
+        return true;
+      });
+
+      // Act
+      await reportSuspiciousActivityPost(
+        req as Request,
+        res as Response,
+        () => {}
+      );
+
+      // Assert
+      expect(res.redirect).to.have.been.calledWith(
+        "/activity-history/report-activity/done"
+      );
+    });
+
     it("Should render 404 in POST view when report suspicious activity is false", async () => {
       const configFuncs = require("../../../config");
       sandbox.stub(configFuncs, "reportSuspiciousActivity").callsFake(() => {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
- Validate page number is a number before redirecting user

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Prevent user controlling the redirect