### PR TITLE
OLH-2718 Use a different name for cloudfront log bucket

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2223,9 +2223,8 @@ Resources:
         - "-"
         - - !Ref AWS::StackName
           - cloudfront
-          - pre-dev-platform
           - Fn::Select:
-              - 4
+              - 0
               - Fn::Split:
                   - "-"
                   - Fn::Select:


### PR DESCRIPTION
## Proposed changes

Change the bucket name for cloudfront logs to fix deployment issues due to multiple cloudformation templates creating the 

### What changed

Change the bucket name for cloudfront logs to fix deployment issues due to multiple cloudf ormation templates creating the bucket, the same. bucket name already existed and a different cloudfoormation attempted to create the bucket although it already existed. 


### Why did it change

So that we can deploy account-management-frontend with our non dev platform stack and also with the dev platform stack and have different bucket names for each

### Related links

https://govukverify.atlassian.net/browse/OLH-2718

## Checklists

### Environment variables or secrets


### Testing

Confirm deployment to dev environment was successful using this branch.


## How to review
