### PR TITLE
Olh 2506: searchable list updates

### DIFF
--- a/src/components/search-services/index.njk
+++ b/src/components/search-services/index.njk
@@ -45,7 +45,7 @@
           classes: "govuk-!-margin-bottom-3"
         },
         id: "search_box",
-        type: "search",
+        type: "text",
         name: "q",
         classes: "search-services__input",
         value: query

--- a/src/components/search-services/index.njk
+++ b/src/components/search-services/index.njk
@@ -2,7 +2,11 @@
 {% set hideAccountNavigation = true %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% set pageTitleName = 'pages.searchServices.heading' | translate %}
+{% set pageTitleName = 'pages.searchServices.title' | translate %}
+{% if query %}
+  {% set pageTitleName = [query, " - ", 'pages.searchServices.title' | translate ] | join %}
+{% endif %}
+
 {% set resultsCountText %}
   {% if resultsCount === 1 %}
     {{ "pages.searchServices.oneResult" | translate }}
@@ -37,7 +41,8 @@
           classes: "govuk-!-font-weight-bold"
         },
         formGroup: {
-          afterInput: { html: submitButton}
+          afterInput: { html: submitButton},
+          classes: "govuk-!-margin-bottom-3"
         },
         id: "search_box",
         type: "search",
@@ -46,12 +51,15 @@
         value: query
       }) }}
 
-      {# {% if hasSearch %}  #}
+      {% if hasSearch %} 
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ "SEARCH_SERVICES" | getPath }}">{{ "pages.searchServices.clearSearch" | translate }}</a>
+      </p>
+      {% endif %}
       <div class="search-results__filter-panel">
         <span class="govuk-body">{{ "pages.searchServices.sortedText" | translate }}</span>
         <span class="govuk-body">{{ resultsCountText }}</span>
       </div>
-      {# {% endif %} #}
     </form>
     {% if (resultsCount > 0) %}
     <ul class="govuk-list search-results">
@@ -66,11 +74,11 @@
     {% else %}
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-3">
       <h2 class="govuk-heading-s">{{ "pages.searchServices.noResultsBlock.heading" | translate }}</h2>
-      <p class="govuk-body">{{ "pages.searchServices.noResultsBlock.paragraph1" | translate }}</h2>
+      <p class="govuk-body">{{ "pages.searchServices.noResultsBlock.paragraph1" | translate }}</p>
       <ul class="govuk-list govuk-list--bullet">
         {% set suggestionsList =  "pages.searchServices.noResultsBlock.suggestionsList" | translate({ returnObjects: true }) %}
         {% for item in suggestionsList %}
-          <li class="">{{ item }}</li>
+          <li>{{ item }}</li>
         {% endfor %}
       </ul>
       {% if isWelsh %}

--- a/src/components/search-services/index.njk
+++ b/src/components/search-services/index.njk
@@ -53,7 +53,7 @@
 
       {% if hasSearch %} 
       <p class="govuk-body">
-        <a class="govuk-link" href="{{ "SEARCH_SERVICES" | getPath }}">{{ "pages.searchServices.clearSearch" | translate }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ "SEARCH_SERVICES" | getPath }}">{{ "pages.searchServices.clearSearch" | translate }}</a>
       </p>
       {% endif %}
       <div class="search-results__filter-panel">

--- a/src/components/search-services/search-services-controller.ts
+++ b/src/components/search-services/search-services-controller.ts
@@ -37,6 +37,7 @@ export function searchServicesGet(req: Request, res: Response): void {
 
   const url = new URL(req.originalUrl, "http://example.com");
   url.searchParams.set("lng", LOCALE.EN);
+  url.searchParams.delete("q");
   const englishLanguageLink = url.pathname + url.search;
 
   res.render(TEMPLATE_NAME, {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -136,6 +136,32 @@
     }
   },
   "pages": {
+    "searchServices": {
+      "title": "Chwilio",
+      "heading": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login",
+      "paragraphs": [
+        "Ar hyn o bryd gallwch ond ei ddefnyddio i gael mynediad i rai gwasanaethau'r llywodraeth.",
+        "Yn y dyfodol, byddwch yn gallu ei ddefnyddio i gael mynediad i bob gwasanaeth ar GOV.UK."
+      ],
+      "searchLabel": "Chwilio am wasanaeth yn Gymraeg",
+      "searchButton": "Chwilio am wasanaethau sy'n defnyddio GOV.UK One Login sydd ar gael yn Gymraeg",
+      "oneResult": "1 o ganlyniadau",
+      "manyResults": "[count] o ganlyniadau",
+      "noResults": "0 o ganlyniadau",
+      "sortedText": "Trefnwyd o A i Z",
+      "noResultsBlock": {
+        "heading": "Dim canlyniadau yn cyfateb",
+        "paragraph1": "Gallwch wella eich canlyniadau chwilio drwy:",
+        "suggestionsList": [
+          "edrych dros eich sillafu",
+          "defnyddio llai o eiriau allweddol",
+          "chwilio am rywbeth llai penodol"
+        ],
+        "welshDisclaimer": "Os nad oes canlyniadau yn cyfateb o hyd, efallai nad yw'r gwasanaeth ar gael yn Gymraeg. <a class='govuk-link' href='[ENGLISH_LINK]'>Ewch i'r dudalen Saesneg i ddod o hyd i wasanaeth yn Saesneg</a>."
+      },
+      "welshDisclaimer": "Dim ond gwasanaethau sydd ar gael yn Gymraeg fydd yn ymddangos yn y canlyniadau. <a class='govuk-link' href='[ENGLISH_LINK]'>Ewch i'r dudalen Saesneg i ddod o hyd i wasanaeth yn Saesneg</a>.",
+      "clearSearch": "Clirio chwiliad"
+    },
     "security": {
       "title": "Diogelwch",
       "header": "Diogelwch",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -145,9 +145,9 @@
       ],
       "searchLabel": "Chwilio am wasanaeth yn Gymraeg",
       "searchButton": "Chwilio am wasanaethau sy'n defnyddio GOV.UK One Login sydd ar gael yn Gymraeg",
-      "oneResult": "1 o ganlyniadau",
-      "manyResults": "[count] o ganlyniadau",
-      "noResults": "0 o ganlyniadau",
+      "oneResult": "1 canlyniad",
+      "manyResults": "[count] canlyniad",
+      "noResults": "0 canlyniad",
       "sortedText": "Trefnwyd o A i Z",
       "noResultsBlock": {
         "heading": "Dim canlyniadau yn cyfateb",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -137,7 +137,7 @@
   },
   "pages": {
     "searchServices": {
-      "title": "Search Services",
+      "title": "Search",
       "heading": "Services you can use with GOV.UK One Login",
       "paragraphs": [
         "At the moment, you can only use GOV.UK One Login to access some government services.",
@@ -161,7 +161,8 @@
         "paragraph3": "You can <a class='govuk-link' href='https://www.gov.uk/'> go to the GOV.UK homepage to find the service you need</a>.",
         "welshDisclaimer": "If there are still no matching results, the service might not be available in Welsh. <a class='govuk-link' href='[ENGLISH_LINK]'>Go to the English page to find a service in English</a>."
       },
-      "welshDisclaimer": "Only services that are available in Welsh will appear in the results. <a class='govuk-link' href='[ENGLISH_LINK]'>Go to the English page to find a service in English</a>."
+      "welshDisclaimer": "Only services that are available in Welsh will appear in the results. <a class='govuk-link' href='[ENGLISH_LINK]'>Go to the English page to find a service in English</a>.",
+      "clearSearch": "Clear search"
     },
     "security": {
       "title": "Security",


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add "Clear search" link to "Services you can use with GOV.UK One Login" page.

Update page title to reflect current search term.

Add missing Welsh translations for searchable list

Change input field type from `search` to `text` as a quick fix for the inline "x" which is appended to the field in some browsers – this can also be done with CSS but I figured changing the type of field would be easier and would avoid increasing CSS payload, with minimal consequence:
- when AT is used, the form still appears in the landmarks list as a `search` landmark and functions the same way
- there is a subtle difference in the way the field is announced when using screen readers ("text" vs "search"). However the purpose of the field is clear from the label/context
- there are slight differences in mobile device keyboard layout presentation – some examples below (in hindsight maybe [enterkeyhint](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/enterkeyhint) could be used here, for a more consistent experience) 







| type=search  | type=text |
| ------------- | ------------- |
| <img width="542" alt="typesearch" src="https://github.com/user-attachments/assets/b0519359-22de-4b94-bc98-1a87526b38b6" />  | <img width="689" alt="typetext" src="https://github.com/user-attachments/assets/95dd62ea-36e4-4bc7-8272-237bc6d39198" />  |
| <img width="486" alt="typesearch3" src="https://github.com/user-attachments/assets/a313e28c-e378-4376-bb9b-1cbb75d74f80" />  | <img width="606" alt="typetext3" src="https://github.com/user-attachments/assets/615e5718-4baa-4895-bf93-1be5e7af6b25" />  |


<!-- Describe the changes in detail - the "what"-->

### Why did it change
Bring searchable list page in line with the specification in Figma (linked on the original ticket)

The original task centred around "Clear search", however the scope of the ticket increased slightly as I kept spotting bits to fix. 
<!-- Describe the reason these changes were made - the "why" -->


### Sign-offs

- [x] Design updates have been signed off by a member of the UCD team



## How to review
Content/design has been signed off.
Check everything looks as described on `/services-using-one-login`. Feel free to share any concerns or issues with the approach.
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
