### PR TITLE
OLH-2792: activity history Welsh language tweaks

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -250,7 +250,7 @@
       "securityNoticeTitle": "Os oes gweithgaredd nad ydych yn ei adnabod",
       "securityNoticeContent1": "Dylech <a href='[changePasswordLink]' class='govuk-link'>newid eich cyfrinair</a>. Dyma'r ffordd orau o gadw'ch GOV.UK One Login yn ddiogel.",
       "securityNoticeContent2": "Gallwch hefyd <a target='_blank' href='[reportActivityLink]' class='govuk-link'>roi gwybod i dîm GOV.UK One Login (agor mewn tab newydd)</a>. Mae'r tîm yn adolygu ac yn gweithredu ar yr adroddiadau hyn ond ni fyddwch yn cael ateb personol.",
-      "securityNoticeContentAlt": "If there's activity you do not recognise, you should <a href='[changePasswordLink]' class='govuk-link'>change your password</a>. This is the best way to keep your GOV.UK One Login safe.",
+      "securityNoticeContentAlt": "Os oes gweithgaredd nad ydych yn ei adnabod, dylech <a href='[changePasswordLink]' class='govuk-link'>newid eich cyfrinair</a>. Dyma'r ffordd orau o gadw'ch GOV.UK One Login yn ddiogel.",
       "noWelshNotice": "Os nad yw gwasanaeth rydych wedi cael mynediad iddo ar gael yn Gymraeg, bydd yn ymddangos yma yn Saesneg."
     },
     "reportSuspiciousActivity": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -247,9 +247,9 @@
           }
         }
       },
-      "securityNoticeTitle": "Os ydych yn gweld rhywbeth nad ydych yn ei adnabod",
-      "securityNoticeContent1": "Dylech <a href='[changePasswordLink]' class='govuk-link'>newid eich cyfrinair</a>. Dyma'r ffordd orau i gadw eich GOV.UK One Login yn ddiogel.",
-      "securityNoticeContent2": "Gallwch hefyd <a target='_blank' href='[reportActivityLink]' class='govuk-link'>roi gwybod am y weithgaredd i GOV.UK One Login gan ddefnyddio ffôn neu gwe sgwrs (agor mewn tab newydd)</a>.",
+      "securityNoticeTitle": "Os oes gweithgaredd nad ydych yn ei adnabod",
+      "securityNoticeContent1": "Dylech <a href='[changePasswordLink]' class='govuk-link'>newid eich cyfrinair</a>. Dyma'r ffordd orau o gadw'ch GOV.UK One Login yn ddiogel.",
+      "securityNoticeContent2": "Gallwch hefyd <a target='_blank' href='[reportActivityLink]' class='govuk-link'>roi gwybod i dîm GOV.UK One Login (agor mewn tab newydd)</a>. Mae'r tîm yn adolygu ac yn gweithredu ar yr adroddiadau hyn ond ni fyddwch yn cael ateb personol.",
       "securityNoticeContentAlt": "If there's activity you do not recognise, you should <a href='[changePasswordLink]' class='govuk-link'>change your password</a>. This is the best way to keep your GOV.UK One Login safe.",
       "noWelshNotice": "Os nad yw gwasanaeth rydych wedi cael mynediad iddo ar gael yn Gymraeg, bydd yn ymddangos yma yn Saesneg."
     },


### PR DESCRIPTION
## Proposed changes

### What changed
Fixed Welsh translations on activity history page. Mel flagged up that some of the content wasn't looking quite right.
Plus: added missing translation for `securityNoticeContentAlt`.

### Sign-offs
<!-- New Node.JS/NPM dependencies need to be approved by a Lead Developer or Lead SRE: https://govukverify.atlassian.net/wiki/spaces/DIWAY/pages/4335697997/Library+approval+process -->
<!-- Delete if changes do NOT include any new libraries -->
<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
<!-- Delete if changes do NOT include any design updates -->
- [x] Design updates have been signed off by a member of the UCD team


## How to review
Please check that the new additions match the content in the description of the ticket (and in Mel's comment lower down)

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
