### PR TITLE
OLH-2879: remove unnecessary phone code validation

### DIFF
--- a/src/components/resend-phone-code/resend-phone-code-controller.ts
+++ b/src/components/resend-phone-code/resend-phone-code-controller.ts
@@ -8,11 +8,8 @@ import { getLastNDigits } from "../../utils/phone-number";
 import { EventType, getNextState } from "../../utils/state-machine";
 import {
   formatValidationError,
-  isObjectEmpty,
   renderBadRequest,
 } from "../../utils/validation";
-import { validationResult } from "express-validator";
-import { validationErrorFormatter } from "../../middleware/form-validation-middleware";
 import { getRequestConfigFromExpress } from "../../utils/http";
 import {
   MFA_COMMON_OPL_SETTINGS,
@@ -106,20 +103,6 @@ export function resendPhoneCodePost(
     const intent = req.body.intent;
 
     setLocalOplSettings(intent, req, res);
-
-    const errors = validationResult(req)
-      .formatWith(validationErrorFormatter)
-      .mapped();
-
-    if (!isObjectEmpty(errors)) {
-      return renderBadRequest(
-        res,
-        req,
-        TEMPLATE_NAME,
-        errors,
-        getRenderOptions(req, intent)
-      );
-    }
 
     const { email } = req.session.user;
     const newPhoneNumber = req.body.phoneNumber;

--- a/src/components/resend-phone-code/resend-phone-code-routes.ts
+++ b/src/components/resend-phone-code/resend-phone-code-routes.ts
@@ -8,7 +8,6 @@ import {
 import { asyncHandler } from "../../utils/async";
 import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
-import { validatePhoneNumberRequest } from "../change-phone-number/change-phone-number-validation";
 import { globalTryCatchAsync } from "../../utils/global-try-catch";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
 
@@ -25,7 +24,6 @@ router.post(
   PATH_DATA.RESEND_PHONE_CODE.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  validatePhoneNumberRequest(),
   refreshTokenMiddleware(),
   globalTryCatchAsync(asyncHandler(resendPhoneCodePost()))
 );


### PR DESCRIPTION
### What changed

Removed unnecessary validation in the resend phone code controller which was causing silent errors when trying to resend a phone code to an international phone number. It is not necessary to validate the phone number in this controller as it has already been validated when entered by the user.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed