### PR TITLE
OLH-2880: updated subsciption filter to exclude EMF logs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1880,7 +1880,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
-      FilterPattern: '{$.message != "*CloudWatchMetrics*"}'
+      FilterPattern: "{$._aws.CloudWatchMetrics NOT EXISTS}"
       LogGroupName: !Ref TaskLogGroup
 
   #


### PR DESCRIPTION
## Proposed changes
Fix ECS Task Log Group's Subscription Filter's Filter pattern.

### What changed
ECS Task Log Group's Subscription Filter's Filter pattern.

### Why did it change

ECS Task logs are not being propagated to CSLS’s Splunk endpoint since we updated the SubcriptionFilter’s FilterPattern as the SubscriptionFilter filter pattern was incorrect.

### Related links

<!-- List any related PRs -->
[OLH-2329: Implement powertools metric logging](https://github.com/govuk-one-login/di-account-management-frontend/pull/2294)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

### Testing
Tested Filter expression in CloudWatch Log Group called [/ecs/account-mgmt-frontend/server](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/$252Fecs$252Faccount-mgmt-frontend$252Fserver)

**Log group without any filter**
![Screenshot 2025-07-03 at 18 19 06](https://github.com/user-attachments/assets/f55bca4e-bfdb-42fa-ae48-2d25f777336c)

**Log group with new filter applied - all EMF events disappear**
![Screenshot 2025-07-03 at 18 19 20](https://github.com/user-attachments/assets/e206d015-e762-459d-aa61-6e1ade00beb7)

### Sign-offs


## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
