### PR TITLE
BAU: bump govuk-one-login/devplatform-upload-action-ecr [skip canary]

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -36,7 +36,7 @@ jobs:
     needs: validate_deployment
     steps:
       - name: "Push signed image to ECR, updated SAM template wih image then upload it to the S3 Artifact Bucket"
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # pin@1.4.0
         with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
### What changed

Bumps the version of the GitHub Action `govuk-one-login/devplatform-upload-action-ecr` to fix deployments.

### Why did it change

The previous version of `govuk-one-login/devplatform-upload-action-ecr` developed an issue which broke deployment.