### PR TITLE
OLH-2802: remove global logout route

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -162,7 +162,6 @@ export const PATH_DATA: Record<
   HEALTHCHECK: { url: "/healthcheck" },
   FINGERPRINT: { url: "/fingerprint" },
   BACKCHANNEL_LOGOUT: { url: "/backchannel-logout" },
-  GLOBAL_LOGOUT: { url: "/global-logout" },
   RESEND_EMAIL_CODE: {
     url: "/resend-email-code",
     event: EventType.ValueUpdated,

--- a/src/components/backchannel-logout/backchannel-logout-routes.ts
+++ b/src/components/backchannel-logout/backchannel-logout-routes.ts
@@ -11,9 +11,4 @@ router.post(
   globalTryCatchAsync(asyncHandler(backchannelLogoutPost))
 );
 
-router.post(
-  PATH_DATA.GLOBAL_LOGOUT.url,
-  globalTryCatchAsync(asyncHandler(backchannelLogoutPost))
-);
-
 export { router as backchannelLogoutRouter };


### PR DESCRIPTION
### What changed

Removes the redundant global logout route now that orchestration have pointed to the new backchannel logout route.

### Why did it change

To prevent naming confusion between backchannel logout and the incoming global logout feature.