### PR TITLE
OLH-2799: fix forward refresh token middleware [skip canary]

### DIFF
--- a/src/components/change-default-method/change-default-method-routes.ts
+++ b/src/components/change-default-method/change-default-method-routes.ts
@@ -21,6 +21,7 @@ router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodGet)
 );
@@ -29,6 +30,7 @@ router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD_APP.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodAppGet)
 );
@@ -37,8 +39,8 @@ router.post(
   PATH_DATA.CHANGE_DEFAULT_METHOD_APP.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
-  mfaMethodMiddleware,
   refreshTokenMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodAppPost)
 );
 
@@ -46,6 +48,7 @@ router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD_SMS.url,
   requiresAuthMiddleware,
   validateStateMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodSmsGet)
 );
@@ -55,8 +58,8 @@ router.post(
   requiresAuthMiddleware,
   validateStateMiddleware,
   validatePhoneNumberRequest(),
-  mfaMethodMiddleware,
   refreshTokenMiddleware(),
+  mfaMethodMiddleware,
   globalTryCatchAsync(changeDefaultMethodSmsPost(changePhoneNumberService()))
 );
 

--- a/src/components/check-your-phone/check-your-phone-routes.ts
+++ b/src/components/check-your-phone/check-your-phone-routes.ts
@@ -20,6 +20,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.CHECK_YOUR_PHONE.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatch(checkYourPhoneGet)

--- a/src/components/choose-backup/choose-backup-routes.ts
+++ b/src/components/choose-backup/choose-backup-routes.ts
@@ -6,12 +6,14 @@ import { validateStateMiddleware } from "../../middleware/validate-state-middlew
 import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { validateChooseBackupRequest } from "./choose-backup-validation";
 import { globalTryCatch } from "../../utils/global-try-catch";
+import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 
 const router = express.Router();
 
 router.get(
   PATH_DATA.ADD_MFA_METHOD.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatch(chooseBackupGet)

--- a/src/components/delete-mfa-method/delete-mfa-method-routes.ts
+++ b/src/components/delete-mfa-method/delete-mfa-method-routes.ts
@@ -15,6 +15,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.DELETE_MFA_METHOD.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(deleteMfaMethodGet)
@@ -23,9 +24,9 @@ router.get(
 router.post(
   PATH_DATA.DELETE_MFA_METHOD.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
-  refreshTokenMiddleware(),
   globalTryCatchAsync(deleteMfaMethodPost)
 );
 

--- a/src/components/security/security-routes.ts
+++ b/src/components/security/security-routes.ts
@@ -4,12 +4,14 @@ import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
 import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { globalTryCatch } from "../../utils/global-try-catch";
+import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 
 const router = express.Router();
 
 router.get(
   PATH_DATA.SECURITY.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   globalTryCatch(securityGet)
 );

--- a/src/components/security/tests/security-integration.test.ts
+++ b/src/components/security/tests/security-integration.test.ts
@@ -9,6 +9,7 @@ import { PATH_DATA } from "../../../app.constants";
 import { getLastNDigits } from "../../../utils/phone-number";
 import { MfaMethod } from "../../../utils/mfaClient/types";
 import { MfaClient } from "../../../utils/mfaClient";
+import { UnsecuredJWT } from "jose";
 
 const { url } = PATH_DATA.SECURITY;
 const TEST_USER_EMAIL = "test@test.com";
@@ -20,7 +21,13 @@ const DEFAULT_USER_SESSION = {
   isAuthenticated: true,
   state: {},
   tokens: {
-    accessToken: "token",
+    accessToken: new UnsecuredJWT({})
+      .setIssuedAt()
+      .setSubject("12345")
+      .setIssuer("urn:example:issuer")
+      .setAudience("urn:example:audience")
+      .setExpirationTime("2h")
+      .encode(),
     idToken: "Idtoken",
     refreshToken: "token",
   },

--- a/src/components/switch-backup-method/switch-backup-method-routes.ts
+++ b/src/components/switch-backup-method/switch-backup-method-routes.ts
@@ -15,6 +15,7 @@ const router = express.Router();
 router.get(
   PATH_DATA.SWITCH_BACKUP_METHOD.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(switchBackupMfaMethodGet)
@@ -23,9 +24,9 @@ router.get(
 router.post(
   PATH_DATA.SWITCH_BACKUP_METHOD.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
-  refreshTokenMiddleware(),
   globalTryCatchAsync(switchBackupMfaMethodPost)
 );
 

--- a/src/components/update-confirmation/update-confirmation-routes.ts
+++ b/src/components/update-confirmation/update-confirmation-routes.ts
@@ -19,6 +19,7 @@ import {
   globalTryCatchAsync,
   globalTryCatch,
 } from "../../utils/global-try-catch";
+import { refreshTokenMiddleware } from "../../middleware/refresh-token-middleware";
 
 const router = express.Router();
 
@@ -68,6 +69,7 @@ router.get(
 router.get(
   PATH_DATA.SWITCH_BACKUP_METHOD_CONFIRMATION.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(changeDefaultMfaMethodConfirmationGet)
@@ -76,6 +78,7 @@ router.get(
 router.get(
   PATH_DATA.CHANGE_DEFAULT_METHOD_CONFIRMATION.url,
   requiresAuthMiddleware,
+  refreshTokenMiddleware(),
   mfaMethodMiddleware,
   validateStateMiddleware,
   globalTryCatchAsync(changeDefaultMethodConfirmationGet)


### PR DESCRIPTION
### What changed

Call refresh token middleware before middleware to fetch MFA methods.

### Why did it change

To ensure the user has a valid token when fetching MFA methods.