### PR TITLE
OLH-2720 Resolve access denied error that is being logged

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectName=di-account-management-frontend
 sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src/
-sonar.exclusions=src/**/*.test.ts,src/assets/javascript/*.js,src/app.ts, src/server.ts, src/config.ts, post-deploy-tests/**/*, src/components/oidc-callback/call-back-controller.ts
+sonar.exclusions=src/**/*.test.ts,src/assets/javascript/*.js,src/app.ts, src/server.ts, src/config.ts, post-deploy-tests/**/*
 sonar.tests=test/,src/
 sonar.test.inclusions=**/*.test.ts
 

--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -1,18 +1,18 @@
 import { Request, Response } from "express";
-import { CallbackParamsType, TokenSet, UserinfoResponse } from "openid-client";
-import { LOG_MESSAGES, PATH_DATA, VECTORS_OF_TRUST } from "../../app.constants";
+import { CallbackParamsType, UserinfoResponse } from "openid-client";
+import { PATH_DATA, VECTORS_OF_TRUST } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { ClientAssertionServiceInterface } from "../../utils/types";
 import { clientAssertionGenerator } from "../../utils/oidc";
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { detectOidcError } from "../../utils/detect-oidc-error";
 import {
+  attachSessionIdsFromGsCookie,
   determineRedirectUri,
+  generateTokenSet,
   handleOidcCallbackError,
   populateSessionWithUserInfo,
 } from "./call-back-utils";
-import xss from "xss";
-import { logger } from "../../utils/logger";
 
 export function oidcAuthCallbackGet(
   service: ClientAssertionServiceInterface = clientAssertionGenerator()
@@ -20,6 +20,7 @@ export function oidcAuthCallbackGet(
   return async function (req: Request, res: Response) {
     try {
       req.metrics?.addMetric("oidcAuthCallbackGet", MetricUnit.Count, 1);
+
       const queryParams: CallbackParamsType = req.oidc.callbackParams(req);
       if (queryParams?.error) {
         await handleOidcCallbackError(req, res, queryParams);
@@ -33,21 +34,13 @@ export function oidcAuthCallbackGet(
       if (!req.session.state || !req.session.nonce) {
         return res.redirect(PATH_DATA.SESSION_EXPIRED.url);
       }
-      const tokenSet: TokenSet = await req.oidc.callback(
-        req.oidc.metadata.redirect_uris[0],
+
+      const tokenSet = await generateTokenSet(
+        req,
         queryParams,
-        { nonce: req.session.nonce, state: req.session.state },
-        {
-          exchangeBody: {
-            client_assertion_type:
-              "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            client_assertion: clientAssertion,
-          },
-        }
+        clientAssertion
       );
-
       const vot = tokenSet.claims().vot;
-
       if (vot !== VECTORS_OF_TRUST.MEDIUM) {
         return res.redirect(PATH_DATA.START.url);
       }
@@ -59,30 +52,7 @@ export function oidcAuthCallbackGet(
 
       populateSessionWithUserInfo(req, userInfoResponse, tokenSet);
 
-      if (req.cookies?.gs) {
-        logger.info(
-          { trace: res.locals.trace },
-          `gs cookie: ${req.cookies.gs}`
-        );
-        const ids = xss(req.cookies.gs).split(".");
-
-        if (ids.length !== 2) {
-          logger.error(
-            { trace: res.locals.trace },
-            LOG_MESSAGES.MALFORMED_GS_COOKIE(req.cookies.gs)
-          );
-        } else {
-          req.session.authSessionIds = {
-            sessionId: ids[0],
-            clientSessionId: ids[1],
-          };
-        }
-      } else {
-        logger.info(
-          { trace: res.locals.trace },
-          LOG_MESSAGES.GS_COOKIE_NOT_IN_REQUEST
-        );
-      }
+      attachSessionIdsFromGsCookie(req, res);
 
       // saved to session where `user_id` attribute is stored as a db item's root-level attribute that is used in indexing
       req.session.user_id = userInfoResponse.sub;

--- a/src/components/oidc-callback/call-back-utils.ts
+++ b/src/components/oidc-callback/call-back-utils.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from "express";
 import { CallbackParamsType, TokenSet, UserinfoResponse } from "openid-client";
-import { ClientAssertionServiceInterface } from "../../utils/types";
 import { LOG_MESSAGES, PATH_DATA } from "../../app.constants";
 import { logger } from "../../utils/logger";
 import { deleteExpressSession } from "../../utils/session-store";
@@ -43,31 +42,24 @@ export function setPreferencesCookie(
   });
 }
 
-export async function exchangeToken(
+export async function generateTokenSet(
   req: Request,
-  service: ClientAssertionServiceInterface,
-  queryParams: CallbackParamsType
-): Promise<TokenSet> {
-  const clientAssertion = await service.generateAssertionJwt(
-    req.oidc.metadata.client_id,
-    req.oidc.issuer.metadata.token_endpoint
-  );
-
-  return req.oidc.callback(
+  queryParams: CallbackParamsType,
+  clientAssertion: string
+) {
+  const tokenSet: TokenSet = await req.oidc.callback(
     req.oidc.metadata.redirect_uris[0],
     queryParams,
-    {
-      nonce: req.session.nonce,
-      state: req.session.state,
-    },
+    { nonce: req.session.nonce, state: req.session.state },
     {
       exchangeBody: {
         client_assertion_type:
-          "urn:ietf:params:oauth:client-assertioncall-type:jwt-bearer",
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         client_assertion: clientAssertion,
       },
     }
   );
+  return tokenSet;
 }
 
 export function determineRedirectUri(req: Request, res: Response): string {

--- a/src/components/oidc-callback/call-back-utils.ts
+++ b/src/components/oidc-callback/call-back-utils.ts
@@ -115,17 +115,16 @@ export async function handleOidcCallbackError(
 
 export function populateSessionWithUserInfo(
   req: Request,
-  res: Response,
-  userInfo: UserinfoResponse,
+  userInfoResponse: UserinfoResponse,
   tokenSet: TokenSet
 ) {
   req.session.user = {
-    email: userInfo.email,
-    phoneNumber: userInfo.phone_number,
-    isPhoneNumberVerified: userInfo.phone_number_verified as boolean,
-    subjectId: userInfo.sub,
-    legacySubjectId: userInfo.legacy_subject_id as string,
-    publicSubjectId: userInfo.public_subject_id as string,
+    email: userInfoResponse.email,
+    phoneNumber: userInfoResponse.phone_number,
+    isPhoneNumberVerified: userInfoResponse.phone_number_verified as boolean,
+    subjectId: userInfoResponse.sub,
+    legacySubjectId: userInfoResponse.legacy_subject_id as string,
+    publicSubjectId: userInfoResponse.public_subject_id as string,
     tokens: {
       idToken: tokenSet.id_token,
       accessToken: tokenSet.access_token,
@@ -134,12 +133,6 @@ export function populateSessionWithUserInfo(
     isAuthenticated: true,
     state: {},
   };
-
-  /** saved to session where `user_id` attribute is stored as
-   a db item's root-level attribute that is used in indexing **/
-
-  req.session.user_id = userInfo.sub;
-  res.locals.isUserLoggedIn = true;
 }
 
 export function attachSessionIdsFromGsCookie(req: Request, res: Response) {

--- a/src/components/oidc-callback/tests/callback-utils.test.ts
+++ b/src/components/oidc-callback/tests/callback-utils.test.ts
@@ -150,10 +150,6 @@ describe("callback-utils", () => {
       const req: any = {
         session: {},
       };
-      const res: any = {
-        locals: {},
-      };
-
       const userInfo = {
         email: "user@example.com",
         phone_number: "1234567890",
@@ -169,13 +165,11 @@ describe("callback-utils", () => {
         refresh_token: "refresh.token",
       };
 
-      populateSessionWithUserInfo(req, res, userInfo as any, tokenSet as any);
+      populateSessionWithUserInfo(req, userInfo as any, tokenSet as any);
 
       expect(req.session.user.email).to.equal("user@example.com");
       expect(req.session.user.tokens.accessToken).to.equal("access.token");
       expect(req.session.user.legacySubjectId).to.equal("legacy123");
-      expect(res.locals.isUserLoggedIn).to.be.true;
-      expect(req.session.user_id).to.equal("subject123");
     });
   });
 


### PR DESCRIPTION
## Proposed changes

Resolve access denied error that is being logged

### What changed

remove double wrapping for async handler on all controllers
Ensure all sampled OIDC errors are handled and users are sent to sign-in


### Why did it change
So that we OIDC errors are handled correctly and to remove unnecessary error messages from the log

### Related links
https://govukverify.atlassian.net/browse/OLH-2720

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing

Deploy to dev and ensure core functionalities are not broken

### Sign-offs


## How to review
