### PR TITLE
OLH-2900 Resolve TypeErrors being raised in OIDC callback controller

### DIFF
--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -31,7 +31,7 @@ export function oidcAuthCallbackGet(
         req.oidc.issuer.metadata.token_endpoint
       );
 
-      if (!req.session.state || !req.session.nonce) {
+      if (!req.session?.state || !req.session?.nonce) {
         return res.redirect(PATH_DATA.SESSION_EXPIRED.url);
       }
 

--- a/src/components/oidc-callback/call-back-utils.ts
+++ b/src/components/oidc-callback/call-back-utils.ts
@@ -63,7 +63,7 @@ export async function generateTokenSet(
 }
 
 export function determineRedirectUri(req: Request, res: Response): string {
-  let redirectUri = req.session.currentURL || PATH_DATA.YOUR_SERVICES.url;
+  let redirectUri = req.session?.currentURL || PATH_DATA.YOUR_SERVICES.url;
   const crossDomainGaIdParam = req.query._ga as string;
 
   if (req.query.cookie_consent) {

--- a/src/components/oidc-callback/tests/callback-controller.test.ts
+++ b/src/components/oidc-callback/tests/callback-controller.test.ts
@@ -238,6 +238,18 @@ describe("callback controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_DATA.SESSION_EXPIRED.url);
     });
 
+    it("should redirect to session expired if session is missing", async () => {
+      req.session = undefined;
+
+      const fakeService: ClientAssertionServiceInterface = {
+        generateAssertionJwt: sandbox.fake(),
+      };
+
+      await oidcAuthCallbackGet(fakeService)(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_DATA.SESSION_EXPIRED.url);
+    });
+
     it("redirect to session expired when access denied error is thrown", async () => {
       req.oidc.callbackParams = sandbox.fake.throws(new Error("access_denied"));
       const fakeService: ClientAssertionServiceInterface = {

--- a/src/components/oidc-callback/tests/callback-utils.test.ts
+++ b/src/components/oidc-callback/tests/callback-utils.test.ts
@@ -106,6 +106,15 @@ describe("callback-utils", () => {
       expect(result).to.equal(PATH_DATA.YOUR_SERVICES.url);
     });
 
+    it("should return default path if session is null", () => {
+      const req: any = {
+        query: {},
+      };
+      const res: any = {};
+      const result = determineRedirectUri(req, res);
+      expect(result).to.equal(PATH_DATA.YOUR_SERVICES.url);
+    });
+
     it("should append _ga param to redirect URL if consent is accepted", () => {
       const req: any = {
         session: {},


### PR DESCRIPTION
## Proposed changes

OLH-2900 Resolve TypeErrors being raised in OIDC callback controller

### What changed

Check for null or undefined session

### Why did it change

To resolve two errors found in prod

- Global async error handler : TypeError: Cannot read properties of undefined (reading 'state')	23	10.648%	
- Global async error handler : TypeError: Cannot read properties of undefined (reading 'currentURL')

### Related links

https://govukverify.atlassian.net/browse/OLH-2900

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing


### Sign-offs


## How to review