### PR TITLE
OLH-2894: switch on rebrand flag for integration (due 11/07)

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -320,7 +320,7 @@ Mappings:
       DTRUMURL: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/416cd438acc3a6f_complete.js"
       MISSIONLABWEBSOCKETADDR: "wss://sqs8l2bqn1.execute-api.eu-west-2.amazonaws.com"
       DEVICEINTELLIGENCETOGGLE: "1"
-      BRANDREFRESHENABLED: "0"
+      BRANDREFRESHENABLED: "1"
       SUPPORTCHANGEONINTERVENTION: "1"
       FINGERPRINTCOOKIEDOMAIN: "account.gov.uk"
       SUPPORTGLOBALLOGOUT: "0"

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -204,11 +204,14 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
   position: absolute;
   padding: 5px;
   right: 0;
-  bottom: 7px;
+  bottom: 50%;
+  transform: translateY(50%);
+
   @include govuk-media-query($until: mobile) {
     position: relative;
     float: left;
     padding-left: 0;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
[OLH-2894: enable brand refresh flag for testing in integration](https://github.com/govuk-one-login/di-account-management-frontend/commit/a5e24d6c6feb25a4639f3b3eff9893947d55e24c)
Testing is due to take place early next week. This switches on the brand refresh flag for integration only. 
 
[BAU: Fix sign out link alignment in new header](https://github.com/govuk-one-login/di-account-management-frontend/commit/44ee9e2e0501b01746cb5d26185c36b9b51ff6ce) 

The sign out link in the new (blue header) was slightly off centre. This fixes it.
<img width="1036" height="477" alt="alignment" src="https://github.com/user-attachments/assets/99ec962d-f68a-44f0-82b0-e7ba4f2146c9" />

<!-- Describe the changes in detail - the "what"-->

## How to review
Check the flag is on for integration only.
Sense check the CSS tweak. 
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
