### PR TITLE
OLH-2898: remove error logging

### DIFF
--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -123,13 +123,12 @@ const initRefreshToken = function (
         );
         req.session.user.tokens.accessToken = tokenSet.access_token;
         req.session.user.tokens.refreshToken = tokenSet.refresh_token;
-      } catch (error) {
+      } catch {
         req.metrics?.addMetric(
           "refreshTokenMiddlewareError",
           MetricUnit.Count,
           1
         );
-        req.log.error(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN, error);
         throw new Error(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN);
       }
     }

--- a/src/utils/oidc.ts
+++ b/src/utils/oidc.ts
@@ -124,11 +124,7 @@ const initRefreshToken = function (
         req.session.user.tokens.accessToken = tokenSet.access_token;
         req.session.user.tokens.refreshToken = tokenSet.refresh_token;
       } catch {
-        req.metrics?.addMetric(
-          "refreshTokenMiddlewareError",
-          MetricUnit.Count,
-          1
-        );
+        req.metrics?.addMetric("refreshTokenError", MetricUnit.Count, 1);
         throw new Error(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN);
       }
     }

--- a/test/unit/utils/oidc.test.ts
+++ b/test/unit/utils/oidc.test.ts
@@ -428,9 +428,6 @@ describe("OIDC Functions", () => {
         metrics: {
           addMetric: sandbox.fake(),
         },
-        log: {
-          error: sandbox.fake(),
-        },
       };
 
       const fakeClientAssertionService: ClientAssertionServiceInterface = {
@@ -450,9 +447,6 @@ describe("OIDC Functions", () => {
       expect(req.session.user.tokens.refreshToken).to.eq(refreshTokenToken);
       expect(req.metrics.addMetric).to.have.been.calledWith(
         "refreshTokenMiddlewareError"
-      );
-      expect(req.log.error).to.have.been.calledWith(
-        ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN
       );
       expect(error.message).to.eq(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN);
     });

--- a/test/unit/utils/oidc.test.ts
+++ b/test/unit/utils/oidc.test.ts
@@ -446,7 +446,7 @@ describe("OIDC Functions", () => {
       expect(req.session.user.tokens.accessToken).to.eq(accessToken);
       expect(req.session.user.tokens.refreshToken).to.eq(refreshTokenToken);
       expect(req.metrics.addMetric).to.have.been.calledWith(
-        "refreshTokenMiddlewareError"
+        "refreshTokenError"
       );
       expect(error.message).to.eq(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN);
     });


### PR DESCRIPTION
### What changed

Remove error logging when token refresh fails. It is a legitimate error which can occur when the user's token has expired. We catch the error and the user is redirected to sign in so there is no need to log the error. We also have a metric `refreshTokenError` which we can use to see volumes of the error occuring.