### PR TITLE
OLH-2628: Update ML websocket addr for integration env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -318,7 +318,7 @@ Mappings:
       ACCESSIBILITYSTATEMENTURL: "https://signin.account.gov.uk/accessibility-statement"
       LANGUAGETOGGLE: "1"
       DTRUMURL: "https://js-cdn.dynatrace.com/jstag/17177a07246/bf01311dte/416cd438acc3a6f_complete.js"
-      MISSIONLABWEBSOCKETADDR: "wss://sqs8l2bqn1.execute-api.eu-west-2.amazonaws.com"
+      MISSIONLABWEBSOCKETADDR: "wss://jxcr697tal.execute-api.eu-west-2.amazonaws.com"
       DEVICEINTELLIGENCETOGGLE: "1"
       BRANDREFRESHENABLED: "1"
       SUPPORTCHANGEONINTERVENTION: "1"


### PR DESCRIPTION
## Proposed changes


<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
A while ago the webchat source URL for integration was updated to the new production URL. This was done in order to test the new infrastructure in integration first, before proceeding to prod.

The prod script running in integration is attempting calls to the prod version of websocket, however the integration CSP is currently configured to only allow calls to the integration version of the websocket. 

This updates the relevant env variable in order to enable connection to the prod websocket on our integration env. This (along with the aforementioned Webchat src URL change) should be reverted as soon as testing is complete.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To allow testing of prod webchat on integration (for real this time)
<!-- Describe the reason these changes were made - the "why" -->


## How to review
Verify that only the integration config has been changed. 
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
