### PR TITLE
OLH-2905 Resolve missing stack trace in global try catch

### DIFF
--- a/src/utils/global-try-catch.ts
+++ b/src/utils/global-try-catch.ts
@@ -8,7 +8,7 @@ export function globalTryCatchAsync(
   return function (req: Request, res: Response, next: NextFunction) {
     return Promise.resolve(fn(req, res, next)).catch((error) => {
       req.metrics?.addMetric("globalTryCatchAsyncError", MetricUnit.Count, 1);
-      logger.error(`Global async error handler : ${error}`);
+      logger.error("Global async error handler:", error);
       next?.(error);
     });
   };
@@ -22,7 +22,7 @@ export const globalTryCatch = (
       fn(req, res, next);
     } catch (error) {
       req.metrics?.addMetric("globalTryCatchError", MetricUnit.Count, 1);
-      logger.error(`Global error handler : ${error}`);
+      logger.error("Global error handler:", error);
       next?.(error);
     }
   };


### PR DESCRIPTION
## Proposed changes

OLH-2905 Resolve missing stack trace in global try catch

### What changed

Fix logging to include stak trace

### Why did it change
So that stack trace is shown the logs.

### Related links


## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing

### Sign-offs

## How to review
