### PR TITLE
OLH-2878: don't error on refresh token fail

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -296,7 +296,6 @@ export const ERROR_MESSAGES = {
   FAILED_TO_SEND_TO_TXMA: "Failed to send to TxMA",
   FAILED_SEND_TO_TXMA_DLQ: "Failed to send to TxMA DLQ.",
   FAILED_MFA_RETRIEVE_CALL: "Failed to call mfa methods API",
-  FAILED_TO_REFRESH_TOKEN: "Failed to refresh token",
 };
 
 export const ERROR_CODES = {

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -1,12 +1,6 @@
 import { NextFunction, Request, Response } from "express";
-import {
-  ERROR_MESSAGES,
-  HTTP_STATUS_CODES,
-  LogoutState,
-  PATH_DATA,
-} from "../app.constants";
+import { HTTP_STATUS_CODES, PATH_DATA } from "../app.constants";
 import { EMPTY_OPL_SETTING_VALUE, setOplSettings } from "../utils/opl";
-import { handleLogout } from "../utils/logout";
 
 export async function serverErrorHandler(
   err: any,
@@ -16,11 +10,6 @@ export async function serverErrorHandler(
 ): Promise<void> {
   if (res.headersSent) {
     return next(err);
-  }
-
-  if (err.message === ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN) {
-    await handleLogout(req, res, LogoutState.Default);
-    return;
   }
 
   setOplSettings(

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -47,7 +47,7 @@ export async function getRequestConfigFromExpress(
   req: Request,
   res: Response
 ): Promise<Parameters<typeof getRequestConfig>[0]> {
-  await refreshToken(req);
+  await refreshToken(req, res);
 
   return {
     token: req.session.user.tokens.accessToken,

--- a/test/unit/utils/oidc.test.ts
+++ b/test/unit/utils/oidc.test.ts
@@ -17,7 +17,6 @@ import {
 import base64url from "base64url";
 import { invalidateCache } from "../../../src/utils/cache";
 import { UnsecuredJWT } from "jose";
-import { ERROR_MESSAGES } from "../../../src/app.constants";
 
 function createAccessToken(expiry = 1600711538) {
   return new UnsecuredJWT({ exp: expiry })
@@ -354,12 +353,13 @@ describe("OIDC Functions", () => {
           addMetric: sandbox.fake(),
         },
       };
+      const res = {} as any;
 
       const fakeClientAssertionService: ClientAssertionServiceInterface = {
         generateAssertionJwt: sinon.fake(),
       };
 
-      await initRefreshToken(fakeClientAssertionService)(req);
+      await initRefreshToken(fakeClientAssertionService)(req, res);
 
       expect(req.session.user.tokens.accessToken).to.eq(accessToken);
       expect(req.session.user.tokens.refreshToken).to.eq(refreshTokenToken);
@@ -393,12 +393,13 @@ describe("OIDC Functions", () => {
           addMetric: sandbox.fake(),
         },
       };
+      const res = {} as any;
 
       const fakeClientAssertionService: ClientAssertionServiceInterface = {
         generateAssertionJwt: sinon.fake(),
       };
 
-      await initRefreshToken(fakeClientAssertionService)(req);
+      await initRefreshToken(fakeClientAssertionService)(req, res);
 
       expect(fakeClientAssertionService.generateAssertionJwt).to.have.been
         .calledOnce;
@@ -429,17 +430,18 @@ describe("OIDC Functions", () => {
           addMetric: sandbox.fake(),
         },
       };
+      const res = {} as any;
 
       const fakeClientAssertionService: ClientAssertionServiceInterface = {
         generateAssertionJwt: sinon.fake(),
       };
+      const fakeHandleLogout = sinon.fake();
 
-      let error;
-      try {
-        await initRefreshToken(fakeClientAssertionService)(req);
-      } catch (err) {
-        error = err;
-      }
+      await initRefreshToken(fakeClientAssertionService, fakeHandleLogout)(
+        req,
+        res
+      );
+
       expect(fakeClientAssertionService.generateAssertionJwt).to.have.been
         .calledOnce;
       expect(req.oidc.refresh).to.have.been.calledTwice;
@@ -448,7 +450,7 @@ describe("OIDC Functions", () => {
       expect(req.metrics.addMetric).to.have.been.calledWith(
         "refreshTokenError"
       );
-      expect(error.message).to.eq(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN);
+      expect(fakeHandleLogout).to.have.been.calledOnceWith(req, res, "default");
     });
   });
 });


### PR DESCRIPTION
### What changed

Don't throw an error when refreshing the token fails, just log the user out.

### Why did it change

There's no need to throw an error as we're not considering it an error and the user won't see an error page.