### PR TITLE
OLH-2905 Resolve missing stack trace in global try catch -2

### DIFF
--- a/src/components/oidc-callback/call-back-controller.ts
+++ b/src/components/oidc-callback/call-back-controller.ts
@@ -12,6 +12,7 @@ import {
   generateTokenSet,
   handleOidcCallbackError,
   populateSessionWithUserInfo,
+  setPreferencesCookie,
 } from "./call-back-utils";
 
 export function oidcAuthCallbackGet(
@@ -58,7 +59,19 @@ export function oidcAuthCallbackGet(
       req.session.user_id = userInfoResponse.sub;
       res.locals.isUserLoggedIn = true;
 
-      return res.redirect(determineRedirectUri(req, res));
+      const crossDomainGaIdParam = req.query._ga as string;
+
+      if (req.query.cookie_consent) {
+        setPreferencesCookie(
+          req.query.cookie_consent as string,
+          res,
+          crossDomainGaIdParam
+        );
+      }
+
+      const redirectUri = determineRedirectUri(req);
+
+      return res.redirect(redirectUri);
     } catch (error) {
       const detected = detectOidcError(error);
       if (detected) {

--- a/src/components/oidc-callback/call-back-utils.ts
+++ b/src/components/oidc-callback/call-back-utils.ts
@@ -62,24 +62,15 @@ export async function generateTokenSet(
   return tokenSet;
 }
 
-export function determineRedirectUri(req: Request, res: Response): string {
+export function determineRedirectUri(req: Request): string {
   let redirectUri = req.session?.currentURL || PATH_DATA.YOUR_SERVICES.url;
   const crossDomainGaIdParam = req.query._ga as string;
-
-  if (req.query.cookie_consent) {
-    setPreferencesCookie(
-      req.query.cookie_consent as string,
-      res,
-      crossDomainGaIdParam
-    );
-
-    if (
-      crossDomainGaIdParam &&
-      req.query.cookie_consent === COOKIE_CONSENT.ACCEPT
-    ) {
-      const searchParams = new URLSearchParams({ _ga: crossDomainGaIdParam });
-      redirectUri += `?${searchParams.toString()}`;
-    }
+  if (
+    crossDomainGaIdParam &&
+    req.query.cookie_consent === COOKIE_CONSENT.ACCEPT
+  ) {
+    const searchParams = new URLSearchParams({ _ga: crossDomainGaIdParam });
+    redirectUri += `?${searchParams.toString()}`;
   }
 
   return redirectUri;

--- a/src/components/oidc-callback/tests/callback-utils.test.ts
+++ b/src/components/oidc-callback/tests/callback-utils.test.ts
@@ -91,8 +91,7 @@ describe("callback-utils", () => {
         session: { currentURL: "/dashboard" },
         query: {},
       };
-      const res: any = {};
-      const result = determineRedirectUri(req, res);
+      const result = determineRedirectUri(req);
       expect(result).to.equal("/dashboard");
     });
 
@@ -101,8 +100,7 @@ describe("callback-utils", () => {
         session: {},
         query: {},
       };
-      const res: any = {};
-      const result = determineRedirectUri(req, res);
+      const result = determineRedirectUri(req);
       expect(result).to.equal(PATH_DATA.YOUR_SERVICES.url);
     });
 
@@ -110,8 +108,7 @@ describe("callback-utils", () => {
       const req: any = {
         query: {},
       };
-      const res: any = {};
-      const result = determineRedirectUri(req, res);
+      const result = determineRedirectUri(req);
       expect(result).to.equal(PATH_DATA.YOUR_SERVICES.url);
     });
 
@@ -123,14 +120,7 @@ describe("callback-utils", () => {
           _ga: "GA1.2.123456",
         },
       };
-      const res: any = {
-        cookie: sinon.fake(),
-        locals: {
-          trace: "fake_trace",
-          analyticsCookieDomain: "fake_analytics_domain",
-        },
-      };
-      const result = determineRedirectUri(req, res);
+      const result = determineRedirectUri(req);
       expect(result).to.equal(
         `${PATH_DATA.YOUR_SERVICES.url}?_ga=GA1.2.123456`
       );
@@ -144,14 +134,7 @@ describe("callback-utils", () => {
           _ga: "GA1.2.123456",
         },
       };
-      const res: any = {
-        cookie: sinon.fake(),
-        locals: {
-          trace: "fake_trace",
-          analyticsCookieDomain: "fake_analytics_domain",
-        },
-      };
-      const result = determineRedirectUri(req, res);
+      const result = determineRedirectUri(req);
       expect(result).to.equal(PATH_DATA.YOUR_SERVICES.url);
     });
   });

--- a/src/utils/global-try-catch.ts
+++ b/src/utils/global-try-catch.ts
@@ -4,11 +4,11 @@ import { MetricUnit } from "@aws-lambda-powertools/metrics";
 
 export function globalTryCatchAsync(
   fn: RequestHandler
-): (req: Request, res: Response, next: NextFunction) => Promise<void> {
-  return function (req: Request, res: Response, next: NextFunction) {
+): (req: Request, res: Response, next?: NextFunction) => Promise<void> {
+  return function (req: Request, res: Response, next?: NextFunction) {
     return Promise.resolve(fn(req, res, next)).catch((error) => {
       req.metrics?.addMetric("globalTryCatchAsyncError", MetricUnit.Count, 1);
-      logger.error("Global async error handler:", error);
+      logger.error(error, "Global async error handler:")
       next?.(error);
     });
   };
@@ -22,7 +22,7 @@ export const globalTryCatch = (
       fn(req, res, next);
     } catch (error) {
       req.metrics?.addMetric("globalTryCatchError", MetricUnit.Count, 1);
-      logger.error("Global error handler:", error);
+      logger.error(error, "Global error handler:")
       next?.(error);
     }
   };

--- a/test/utils/global-try-catch.test.ts
+++ b/test/utils/global-try-catch.test.ts
@@ -62,8 +62,6 @@ describe("globalTryCatchAsync", () => {
       "Error: Test error"
     );
 
-    expect(next.calledOnce).to.be.false;
-
     loggerSpy.restore();
   });
 });

--- a/test/utils/global-try-catch.test.ts
+++ b/test/utils/global-try-catch.test.ts
@@ -19,7 +19,7 @@ describe("globalTryCatchAsync", () => {
   });
 
   it("should call the wrapped async function and handle no error", async () => {
-    const fn = sinon.stub().resolves(); // Simulate an async function that resolves without error
+    const fn = sinon.stub().resolves();
 
     const wrapped = globalTryCatchAsync(fn);
 
@@ -29,7 +29,7 @@ describe("globalTryCatchAsync", () => {
     expect(next.called).to.be.false;
   });
 
-  it("should log the error and call next if the wrapped async function throws an error", async () => {
+  it("should log the error and stack when wrapped async function throws an error", async () => {
     const fn = sinon.stub().rejects(new Error("Test error"));
 
     const loggerSpy = sinon.spy(logger, "error");
@@ -44,19 +44,16 @@ describe("globalTryCatchAsync", () => {
       "Error: Test error"
     );
 
-    expect(next.calledOnce).to.be.true;
-    expect(next.firstCall.args[0].message).to.equal("Test error");
-
     loggerSpy.restore();
   });
 
-  it("should log the error only when next is not provided and the wrapped async function throws an error", async () => {
+  it("should log the error when next is not provided and the wrapped function throws an error", async () => {
     const fn = sinon.stub().rejects(new Error("Test error"));
 
     const loggerSpy = sinon.spy(logger, "error");
     const wrapped = globalTryCatchAsync(fn);
 
-    await wrapped(req as Request, res as Response, next as NextFunction);
+    await wrapped(req as Request, res as Response);
 
     expect(fn.calledOnce).to.be.true;
 
@@ -107,14 +104,12 @@ describe("globalTryCatch", () => {
     expect(loggerSpy.firstCall.args[0].toString()).to.equal(
       "Error: Test error"
     );
-
     expect(next.calledOnce).to.be.true;
-    expect(next.firstCall.args[0].message).to.equal("Test error");
 
     loggerSpy.restore();
   });
 
-  it("should log the error only when next is not provided and the wrapped function throws an error", () => {
+  it("should log the error when next is not provided and the wrapped function throws an error", () => {
     const fn = sinon.stub().throws(new Error("Test error"));
 
     const loggerSpy = sinon.spy(logger, "error");


### PR DESCRIPTION
## Proposed changes

OLH-2905 Resolve missing stack trace in global try catch

### What changed

Fix logging to include stak trace

### Why did it change
So that stack trace is shown the logs.

### Related links


## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing

### Sign-offs

## How to review
