### PR TITLE
OLH-2921: perform search against searchText not header

### DIFF
--- a/src/components/search-services/search-services-controller.ts
+++ b/src/components/search-services/search-services-controller.ts
@@ -20,7 +20,7 @@ export function searchServicesGet(req: Request, res: Response): void {
       if (query.length === 0) return true;
 
       const serviceName = prepareForSearch(
-        req.t(`clientRegistry.${getAppEnv()}.${service}.header`)
+        req.t(`clientRegistry.${getAppEnv()}.${service}.startText`)
       );
 
       for (const q of query) {
@@ -32,8 +32,8 @@ export function searchServicesGet(req: Request, res: Response): void {
       return false;
     })
     .sort((a, b) => {
-      const a_trn = req.t(`clientRegistry.${getAppEnv()}.${a}.header`);
-      const b_trn = req.t(`clientRegistry.${getAppEnv()}.${b}.header`);
+      const a_trn = req.t(`clientRegistry.${getAppEnv()}.${a}.startText`);
+      const b_trn = req.t(`clientRegistry.${getAppEnv()}.${b}.startText`);
       return a_trn.localeCompare(b_trn, req.language ?? LOCALE.EN);
     });
 

--- a/src/components/search-services/tests/search-services-controller.test.ts
+++ b/src/components/search-services/tests/search-services-controller.test.ts
@@ -7,11 +7,11 @@ import { sinon } from "../../../../test/utils/test-utils";
 import * as config from "../../../config";
 
 const translations: Record<string, string> = {
-  "clientRegistry.test.govuk.searchText": "gov.uk email",
-  "clientRegistry.test.lite.searchText": "LITE (licenseing)",
-  "clientRegistry.test.ofqual.searchText": "Ofqual subject matter",
-  "clientRegistry.test.slavery.searchText": "Modern slavery statement registry",
-  "clientRegistry.test.apprentice.searchText": "Manage apprenticeships",
+  "clientRegistry.test.govuk.startText": "gov.uk email",
+  "clientRegistry.test.lite.startText": "LITE (licenseing)",
+  "clientRegistry.test.ofqual.startText": "Ofqual subject matter",
+  "clientRegistry.test.slavery.startText": "Modern slavery statement registry",
+  "clientRegistry.test.apprentice.startText": "Manage apprenticeships",
 };
 
 const servicesMock = ["govuk", "lite", "ofqual", "slavery", "apprentice"];
@@ -110,7 +110,7 @@ describe("search services controller", () => {
     });
   });
 
-  it("should match across words in the service searchText", () => {
+  it("should match across words in the service startText", () => {
     searchServicesGet(getRequestMock("ageappre") as Request, res as Response);
     expect(res.render).to.have.calledWith("search-services/index.njk", {
       env: "test",

--- a/src/components/search-services/tests/search-services-controller.test.ts
+++ b/src/components/search-services/tests/search-services-controller.test.ts
@@ -7,11 +7,11 @@ import { sinon } from "../../../../test/utils/test-utils";
 import * as config from "../../../config";
 
 const translations: Record<string, string> = {
-  "clientRegistry.test.govuk.header": "gov.uk email",
-  "clientRegistry.test.lite.header": "LITE (licenseing)",
-  "clientRegistry.test.ofqual.header": "Ofqual subject matter",
-  "clientRegistry.test.slavery.header": "Modern slavery statement registry",
-  "clientRegistry.test.apprentice.header": "Manage apprenticeships",
+  "clientRegistry.test.govuk.searchText": "gov.uk email",
+  "clientRegistry.test.lite.searchText": "LITE (licenseing)",
+  "clientRegistry.test.ofqual.searchText": "Ofqual subject matter",
+  "clientRegistry.test.slavery.searchText": "Modern slavery statement registry",
+  "clientRegistry.test.apprentice.searchText": "Manage apprenticeships",
 };
 
 const servicesMock = ["govuk", "lite", "ofqual", "slavery", "apprentice"];
@@ -110,7 +110,7 @@ describe("search services controller", () => {
     });
   });
 
-  it("should match across words in the service header", () => {
+  it("should match across words in the service searchText", () => {
     searchServicesGet(getRequestMock("ageappre") as Request, res as Response);
     expect(res.render).to.have.calledWith("search-services/index.njk", {
       env: "test",


### PR DESCRIPTION
### What changed

When searching RPs match against the `startText` field not the `header` field.

### Why did it change

To ensure the search is performed against the same string as is shown in the searchable list.