### PR TITLE
OLH-2925: don't log refresh token fail errors

### DIFF
--- a/src/middleware/log-error-middleware.ts
+++ b/src/middleware/log-error-middleware.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import { shouldLogError } from "../utils/shouldLogError";
 
 export function logErrorMiddleware(
   error: any,
@@ -6,9 +7,8 @@ export function logErrorMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  req.log.error({
-    err: { data: error.data, status: error.status, stack: error.stack },
-    msg: `Error:${error.message}`,
-  });
+  if (shouldLogError(error)) {
+    req.log.error(error, error?.message);
+  }
   next(error);
 }

--- a/src/utils/shouldLogError.ts
+++ b/src/utils/shouldLogError.ts
@@ -1,0 +1,8 @@
+import { ERROR_MESSAGES } from "../app.constants";
+
+export function shouldLogError(error: any) {
+  return (
+    !(error instanceof Error) ||
+    ![ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN].includes(error.message)
+  );
+}

--- a/src/utils/test/shouldLogError.test.ts
+++ b/src/utils/test/shouldLogError.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { shouldLogError } from "../shouldLogError";
+import { ERROR_MESSAGES } from "../../app.constants";
+
+describe("shouldLogError", () => {
+  it("should return false for FAILED_TO_REFRESH_TOKEN errors", () => {
+    expect(shouldLogError(new Error(ERROR_MESSAGES.FAILED_TO_REFRESH_TOKEN))).to
+      .be.false;
+  });
+
+  it("should return true for other errors", () => {
+    expect(shouldLogError(new Error("Uh oh"))).to.be.true;
+  });
+
+  it("should return true for non-errors", () => {
+    expect(shouldLogError("not an error")).to.be.true;
+  });
+});

--- a/test/unit/middleware/mfa-method-middleware.test.ts
+++ b/test/unit/middleware/mfa-method-middleware.test.ts
@@ -12,7 +12,6 @@ describe("mfaMethodMiddleware", () => {
   let res: Partial<Response>;
   let next: NextFunction;
   let mfaClientStub: sinon.SinonStubbedInstance<mfaClient.MfaClient>;
-  const error: sinon.SinonSpy = sinon.spy();
   const configFuncs = require("../../../src/config");
   const legacyMfaMiddleware = require("../../../src/middleware/mfa-methods-legacy");
   const sandbox = sinon.createSandbox();
@@ -39,7 +38,7 @@ describe("mfaMethodMiddleware", () => {
     req = {
       session: {} as any,
       log: {
-        error,
+        error: sinon.fake(),
       } as any,
     };
     res = {
@@ -75,10 +74,7 @@ describe("mfaMethodMiddleware", () => {
     });
 
     await mfaMethodMiddleware(req as Request, res as Response, next);
-    expect(error).to.have.been.calledWith(
-      { trace: res.locals.trace },
-      "Failed MFA retrieve. Status code: 403, API error code: 1, API error message: Forbidden"
-    );
+    expect(req.log.error).to.have.been.calledOnce;
     expect((next as Sinon.SinonSpy).getCalls()[0].args[0]).to.be.instanceOf(
       Error
     );
@@ -88,10 +84,7 @@ describe("mfaMethodMiddleware", () => {
     mfaClientStub.retrieve.rejects();
 
     await mfaMethodMiddleware(req as Request, res as Response, next);
-    expect(error).to.have.been.calledWith(
-      { trace: res.locals.trace },
-      "Failed MFA retrieve. Status code: 403, API error code: 1, API error message: Forbidden"
-    );
+    expect(req.log.error).to.have.been.calledOnce;
     expect((next as Sinon.SinonSpy).getCalls()[0].args[0]).to.be.instanceOf(
       Error
     );


### PR DESCRIPTION
### What changed

Don't log refresh token failure errors in the MFA methods retrieval middleware or in the global error handler middleware.

### Why did it change

To quieten the logs. In these scenarios the user is redirected to sign in again so it does not appear as an error to the user.