### PR TITLE
OLH-2896: delete correct user state after adding SMS backup

### DIFF
--- a/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
+++ b/src/components/add-mfa-method-sms/add-mfa-method-sms-controller.ts
@@ -174,7 +174,7 @@ export async function addMfaSmsMethodConfirmationGet(
     res
   );
 
-  delete req.session.user.state.addBackup;
+  delete req.session.user.state.changePhoneNumber;
 
   return res.render("update-confirmation/index.njk", {
     pageTitle: req.t("pages.addBackupSms.confirm.title"),

--- a/src/components/add-mfa-method-sms/tests/add-mfa-method-sms-controller.test.ts
+++ b/src/components/add-mfa-method-sms/tests/add-mfa-method-sms-controller.test.ts
@@ -129,7 +129,7 @@ describe("addMfaSmsMethodConfirmationGet", () => {
 
     req = new RequestBuilder()
       .withBody({})
-      .withSessionUserState({ addBackup: { value: "CHANGE_VALUE" } })
+      .withSessionUserState({ changePhoneNumber: { value: "CHANGE_VALUE" } })
       .withTranslate(sandbox.fake((id) => id))
       .withHeaders({ "txma-audit-encoded": TXMA_AUDIT_ENCODED })
       .build();
@@ -152,6 +152,6 @@ describe("addMfaSmsMethodConfirmationGet", () => {
 
   it("should clear the user's state", async () => {
     await addMfaSmsMethodConfirmationGet(req as Request, res as Response);
-    expect(req.session.user.state.addBackup).to.be.undefined;
+    expect(req.session.user.state.changePhoneNumber).to.be.undefined;
   });
 });


### PR DESCRIPTION
### What changed

Delete the `changePhoneNumber` not `addBackup` user state after adding an SMS backup in order to stop `Error:Could not change phone number. Status code: 400, API error code: 1001, API error message: Request is missing parameters` errors.

A separate ticket will be created to investigate refactoring the way we use state machines to make them easier to understand and change.