### PR TITLE
OLH-2883: improved handling of switch MFA methods errors

### DIFF
--- a/src/components/switch-backup-method/switch-backup-method-routes.ts
+++ b/src/components/switch-backup-method/switch-backup-method-routes.ts
@@ -7,7 +7,6 @@ import {
 } from "./switch-backup-method-controller";
 import { mfaMethodMiddleware } from "../../middleware/mfa-method-middleware";
 import { validateStateMiddleware } from "../../middleware/validate-state-middleware";
-import { globalTryCatchAsync } from "../../utils/global-try-catch";
 
 const router = express.Router();
 
@@ -16,7 +15,7 @@ router.get(
   requiresAuthMiddleware,
   mfaMethodMiddleware,
   validateStateMiddleware,
-  globalTryCatchAsync(switchBackupMfaMethodGet)
+  switchBackupMfaMethodGet
 );
 
 router.post(
@@ -24,7 +23,7 @@ router.post(
   requiresAuthMiddleware,
   mfaMethodMiddleware,
   validateStateMiddleware,
-  globalTryCatchAsync(switchBackupMfaMethodPost)
+  switchBackupMfaMethodPost
 );
 
 export { router as switchBackupMethodRouter };

--- a/src/components/switch-backup-method/tests/switch-backup-method-controller.test.ts
+++ b/src/components/switch-backup-method/tests/switch-backup-method-controller.test.ts
@@ -146,7 +146,7 @@ describe("change default method", () => {
       expect(statusFn).to.be.calledWith(404);
     });
 
-    it("should return a 500 if the request to the API fails", async () => {
+    it("should throw an error if the request to the API fails", async () => {
       mfaClientStub.makeDefault.resolves({
         data: [mfaMethod],
         success: false,
@@ -157,10 +157,12 @@ describe("change default method", () => {
       const req = generateRequest("1", false);
       const res = generateResponse();
 
-      //@ts-expect-error req and res aren't valid objects since they are mocked
-      await switchBackupMfaMethodPost(req as Request, res as Response);
-
-      expect(statusFn).to.be.calledWith(500);
+      expect(
+        //@ts-expect-error req and res aren't valid objects since they are mocked
+        switchBackupMfaMethodPost(req, res)
+      ).to.be.rejectedWith(
+        "Switch backup method controller: error updating default MFA method. Status code: 500, API error code: 1, API error message: Internal server error"
+      );
     });
   });
 });

--- a/src/middleware/log-error-middleware.ts
+++ b/src/middleware/log-error-middleware.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { shouldLogError } from "../utils/shouldLogError";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 
 export function logErrorMiddleware(
   error: any,
@@ -7,7 +8,15 @@ export function logErrorMiddleware(
   res: Response,
   next: NextFunction
 ): void {
+  req.metrics?.addMetric("logErrorMiddleware", MetricUnit.Count, 1);
+
   if (shouldLogError(error)) {
+    req.metrics?.addMetric(
+      "logErrorMiddlewareErrorLogged",
+      MetricUnit.Count,
+      1
+    );
+
     req.log.error(error, error?.message);
   }
   next(error);


### PR DESCRIPTION
### What changed and why

If an error occurred in the switch MFA methods POST handler the page would just hang. These changes ensure that the error bubbles up to the `log-error-middleware` for logging. The user will also now see the error page. Unnecessary use of  `globalTryCatchAsync` has also been removed from the switch MFA methods routes and metrics have been added to `log-error-middleware`.