### PR TITLE
OLH-2328: Error alarm + rollback canary

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2247,6 +2247,35 @@ Resources:
             Period: 60
             Stat: Maximum
 
+  LoggerErrorsFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = 50 || $.level = "error" }'
+      LogGroupName: !Ref TaskLogGroup
+      MetricTransformations:
+        - MetricName: LoggerErrorCount
+          MetricNamespace: !Sub "${AWS::StackName}/Logger"
+          MetricValue: "1"
+          Unit: Count
+
+  LoggerErrorRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-LoggerErrorRateAlarm"
+      AlarmDescription: "Alarm when Logger error rate exceeds 5 errors in 5 minutes"
+      Namespace: !Sub "${AWS::StackName}/Logger"
+      MetricName: LoggerErrorCount
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+
   #
   # Canary Deployment
   #
@@ -2275,8 +2304,9 @@ Resources:
         ContainerName: !Sub "${AWS::StackName}-TaskDefinition"
         ContainerPort: !Ref ContainerPort
         CloudWatchAlarms: !Sub
-          - "${ELB5XX10PercentAlarm}"
+          - "${ELB5XX10PercentAlarm},${LoggerErrorRateAlarm}"
           - ELB5XX10PercentAlarm: !Ref ELB5XX10PercentAlarm
+            LoggerErrorRateAlarm: !Ref LoggerErrorRateAlarm
 
 Outputs:
   ApiGatewayEndpoint:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2328] Implement an Alarm that checks for errors

### What changed
<!-- Describe the changes in detail - the "what"-->
- Alarm that checks logger.errors
- Mechanism to roll back if errors when treshold is met

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
A number of bugs were identified in production which were going unnoticed. This did not have a significant impact, but with the intention to reduce the number of errors, we have increased our observability to be more aware of the issues. 

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
Check if the rate for the alarm makes sense, should it trigger for any error or only if there's at least 1 error every minute for 5 mins.
