### PR TITLE
BAU: Only use `APP_ENV` to determine environment

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -305,11 +305,15 @@ export const ERROR_CODES = {
   NEW_PHONE_NUMBER_SAME_AS_EXISTING: 1044,
 };
 
-export const ENVIRONMENT_NAME = {
-  PROD: "production",
-  DEV: "development",
-  TEST: "test",
-};
+export const enum ENVIRONMENT_NAME {
+  LOCAL = "local",
+  TEST = "test",
+  DEV = "development",
+  BUILD = "build",
+  STAGING = "staging",
+  INTEGRATION = "integration",
+  PROD = "production",
+}
 
 export const enum EventName {
   HOME_TRIAGE_PAGE_VISIT = "HOME_TRIAGE_PAGE_VISIT",

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,7 @@ import i18next from "i18next";
 import Backend from "i18next-fs-backend";
 import {
   getAppEnv,
-  getNodeEnv,
+  isLocalEnv,
   getSessionExpiry,
   getSessionSecret,
   supportActivityLog,
@@ -36,7 +36,7 @@ import { securityRouter } from "./components/security/security-routes";
 import { activityHistoryRouter } from "./components/activity-history/activity-history-routes";
 import { yourServicesRouter } from "./components/your-services/your-services-routes";
 import { getSessionCookieOptions } from "./config/cookie";
-import { ENVIRONMENT_NAME, LOCALE, PATH_DATA } from "./app.constants";
+import { LOCALE, PATH_DATA } from "./app.constants";
 import { startRouter } from "./components/start/start-routes";
 import { oidcAuthCallbackRouter } from "./components/oidc-callback/call-back-routes";
 import { authMiddleware } from "./middleware/auth-middleware";
@@ -96,12 +96,12 @@ const APP_VIEWS = [
 
 async function createApp(): Promise<express.Application> {
   const app: express.Application = express();
-  const isProduction = getNodeEnv() === ENVIRONMENT_NAME.PROD;
+  const isDeployedEnvironment = !isLocalEnv();
   app.use(metricsMiddleware());
   app.enable("trust proxy");
 
-  if (isProduction) {
-    const protect = applyOverloadProtection(isProduction);
+  if (isDeployedEnvironment) {
+    const protect = applyOverloadProtection(isDeployedEnvironment);
     app.use(protect);
   }
 
@@ -147,7 +147,7 @@ async function createApp(): Promise<express.Application> {
       resave: false,
       unset: "destroy",
       cookie: getSessionCookieOptions(
-        isProduction,
+        isDeployedEnvironment,
         getSessionExpiry(),
         getSessionSecret()
       ),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { filterClients } from "di-account-management-rp-registry";
 import memoize from "fast-memoize";
-import { LOCALE } from "./app.constants";
+import { ENVIRONMENT_NAME, LOCALE } from "./app.constants";
 
 export function getLogLevel(): string {
   return process.env.LOGS_LEVEL || "debug";
@@ -34,16 +34,12 @@ export function getOIDCClientScopes(): string {
   return process.env.OIDC_CLIENT_SCOPES;
 }
 
-export function getNodeEnv(): string {
-  return process.env.NODE_ENV || "development";
-}
-
 export function getAppEnv(): string {
-  return process.env.APP_ENV || "local";
+  return process.env.APP_ENV || ENVIRONMENT_NAME.LOCAL;
 }
 
 export function isLocalEnv(): boolean {
-  return getAppEnv() === "local";
+  return getAppEnv() === ENVIRONMENT_NAME.LOCAL;
 }
 
 export function getGtmId(): string {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Setting `NODE_ENV` to anything other than `production` is considered an anti-pattern and is discouraged[^1].

This is to prevent issues where we write code that behaves differently in our tests vs. when deployed.

That means we should also not use this variable to determine what environment we're currently in. This replaces any use of `getNodeEnv()` with the more appropriate `getAppEnv()` and removes `getNodeEnv()`.

I've also updated the `ENVIRONMENT_NAME` constant to:
  1. a const enum, in line with our other recent changes (see the `EventName` enum)
  2. actually reflect the environment names, not the NODE_ENV options


[^1]: https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production

### Why did it change

This will make it easier for us to understand the intent of switches for different behaviour in environments.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### How to review

Please check I've not missed somewhere with a hardcoded environment name
