### PR TITLE
OLH-2966: check new phone number is defined

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -194,6 +194,11 @@ export async function checkYourPhonePost(req: Request, res: Response) {
 
   const { newPhoneNumber } = req.session.user;
 
+  if (!newPhoneNumber) {
+    res.redirect(PATH_DATA.YOUR_SERVICES.url);
+    return;
+  }
+
   logger.info(
     { trace: res?.locals?.trace },
     `Check your phone POST controller newPhoneNumber: ${

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -201,6 +201,16 @@ describe("check your phone controller", () => {
       );
     });
 
+    it("should redirect to 'Your services' when newPhoneNumber is undefined", async () => {
+      req.body.code = "123456";
+      req.body.intent = INTENT_ADD_BACKUP;
+      req.session.user.newPhoneNumber = undefined;
+
+      await checkYourPhonePost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_DATA.YOUR_SERVICES.url);
+    });
+
     it("should log an error when intent is not valid", async () => {
       req.session.user.tokens = { accessToken: "token" } as any;
       req.session.user.state.changePhoneNumber.value = "CHANGE_VALUE";


### PR DESCRIPTION
### What changed

Check that `newPhoneNumber` is actually defined in the session before proceeding in the `check your phone` `POST` controller.

### Why did it change

To eliminate errors where we try to add an SMS backup MFA method but submit `undefined` as the phone number.