### PR TITLE
OLH-2959: Add TEST phase banner in pre-prod

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -387,13 +387,16 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
   // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
   outline: 2px solid transparent;
   outline-offset: -2px;
-
-  // the most important properties for keeping the phase banner looking the same have been !important-ed
-  color: govuk-colour("white") !important;
-  background-color: govuk-colour("blue") !important;
   letter-spacing: 1px !important;
   text-decoration: none !important;
   text-transform: uppercase !important;
+
+  // the most important properties for keeping the phase banner looking the same have been !important-ed
+  // we use the yellow variation in non-prod environments
+  &:not(.govuk-tag--yellow) {
+    color: govuk-colour("white") !important;
+    background-color: govuk-colour("blue") !important;
+  }
 }
 
 .search-results {

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -38,12 +38,24 @@
 
 {% block main %}
     <div class="govuk-width-container {{ containerClasses }}">
-        {{ govukPhaseBanner({
-            tag: {
-                text: 'general.phaseBanner.tag' | translate
-            },
-            html: 'general.phaseBanner.text' | translate | replace ("[supportUrl]", authFrontEndUrl + "/contact-us-questions?theme=suggestions_feedback")
-        }) if not hidePhaseBanner}}
+        {% if not hidePhaseBanner %}
+          {% if isProd %}
+            {{ govukPhaseBanner({
+                tag: {
+                  text: 'general.phaseBanner.tag' | translate
+                },
+                html: 'general.phaseBanner.text' | translate | replace ("[supportUrl]", authFrontEndUrl + "/contact-us-questions?theme=suggestions_feedback")
+            })}}
+          {% else %}
+            {{ govukPhaseBanner({
+                tag: {
+                  text: "TEST",
+                  classes: "govuk-tag--yellow"
+                },
+                text: 'general.phaseBanner.testText' | translate
+            })}}
+          {% endif %}
+        {% endif %}
         {% if showLanguageToggle %}
           {{ languageSelect({
             ariaLabel: 'general.languageToggle.ariaLabel' | translate,

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,10 @@ export function isLocalEnv(): boolean {
   return getAppEnv() === ENVIRONMENT_NAME.LOCAL;
 }
 
+export function isProd(): boolean {
+  return getAppEnv() === ENVIRONMENT_NAME.PROD;
+}
+
 export function getGtmId(): string {
   return process.env.GTM_ID;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -9,7 +9,8 @@
     "errorSummaryTitle": "Mae problem",
     "phaseBanner": {
       "tag": "Beta",
-      "text": "Mae hwn yn wasanaeth newydd – bydd eich <a  href=\"[supportUrl]\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella."
+      "text": "Mae hwn yn wasanaeth newydd – bydd eich <a  href=\"[supportUrl]\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella.",
+      "testText": "Mae hwn yn amgylchedd profi."
     },
     "yes": "Yes",
     "no": "Na",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -9,7 +9,8 @@
     "errorSummaryTitle": "There is a problem",
     "phaseBanner": {
       "tag": "Beta",
-      "text": "This is a new service – your <a  href=\"[supportUrl]\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."
+      "text": "This is a new service – your <a  href=\"[supportUrl]\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it.",
+      "testText": "This is a test environment."
     },
     "yes": "Yes",
     "no": "No",

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -11,6 +11,7 @@ import {
   getDtRumUrl,
   missionLabsWebSocketAddress,
   supportDeviceIntelligence,
+  isProd,
 } from "../config";
 import { generateNonce } from "../utils/strings";
 import { PATH_DATA } from "../app.constants";
@@ -38,6 +39,7 @@ export async function setLocalVarsMiddleware(
   res.locals.isSelectContentTrackingEnabled = selectContentTrackingEnabled();
   res.locals.currentUrl = getCurrentUrl(req);
   res.locals.supportDeviceIntelligence = supportDeviceIntelligence();
+  res.locals.isProd = isProd();
 
   const sessionIds = getSessionIdsFrom(req);
   res.locals.sessionId = sessionIds.sessionId;

--- a/src/utils/mfa/index.ts
+++ b/src/utils/mfa/index.ts
@@ -1,5 +1,4 @@
-import { ENVIRONMENT_NAME } from "../../app.constants";
-import { getAppEnv } from "../../config";
+import { getAppEnv, isProd } from "../../config";
 import { authenticator } from "otplib";
 
 export function generateMfaSecret(): string {
@@ -11,10 +10,7 @@ export function generateQRCodeValue(
   email: string,
   issuerName: string
 ): string {
-  const issuer =
-    getAppEnv() === ENVIRONMENT_NAME.PROD
-      ? issuerName
-      : `${issuerName} - ${getAppEnv()}`;
+  const issuer = isProd() ? issuerName : `${issuerName} - ${getAppEnv()}`;
   return authenticator.keyuri(email, issuer, secret);
 }
 

--- a/test/unit/middleware/set-local-vars-middleware.test.ts
+++ b/test/unit/middleware/set-local-vars-middleware.test.ts
@@ -2,7 +2,10 @@ import { NextFunction, Request, Response } from "express";
 import { expect, sinon } from "../../utils/test-utils";
 import { describe } from "mocha";
 import { setLocalVarsMiddleware } from "../../../src/middleware/set-local-vars-middleware";
-import { PERSISTENT_SESSION_ID_UNKNOWN } from "../../../src/app.constants";
+import {
+  ENVIRONMENT_NAME,
+  PERSISTENT_SESSION_ID_UNKNOWN,
+} from "../../../src/app.constants";
 import * as nonceModule from "../../../src/utils/strings";
 
 describe("set-local-vars-middleware", () => {
@@ -35,6 +38,7 @@ describe("set-local-vars-middleware", () => {
 
   afterEach(() => {
     sandbox.restore();
+    delete process.env.APP_ENV;
   });
 
   describe("setLocalVarsMiddleware", () => {
@@ -83,12 +87,71 @@ describe("set-local-vars-middleware", () => {
 
     it("should not add supportDeviceIntelligence to locals when flag is false", async () => {
       process.env.DEVICE_INTELLIGENCE_TOGGLE = "0";
-
       await setLocalVarsMiddleware(req as Request, res as Response, next);
 
       expect(res.locals).to.have.property("supportDeviceIntelligence");
       expect(res.locals.supportDeviceIntelligence).to.equal(false);
       expect(next).to.be.calledOnce;
+    });
+
+    describe("isProd", () => {
+      afterEach(() => {
+        delete process.env.APP_ENV;
+      });
+
+      it("should be true when the value of APP_ENV is 'production'", async () => {
+        process.env.APP_ENV = ENVIRONMENT_NAME.PROD;
+        await setLocalVarsMiddleware(req as Request, res as Response, next);
+
+        expect(res.locals).to.have.property("isProd");
+        expect(res.locals.isProd).to.equal(true);
+        expect(next).to.be.calledOnce;
+      });
+
+      it("should be false when the value of APP_ENV is 'local'", async () => {
+        process.env.APP_ENV = ENVIRONMENT_NAME.LOCAL;
+        await setLocalVarsMiddleware(req as Request, res as Response, next);
+
+        expect(res.locals).to.have.property("isProd");
+        expect(res.locals.isProd).to.equal(false);
+        expect(next).to.be.calledOnce;
+      });
+
+      it("should be false when the value of APP_ENV is 'development'", async () => {
+        process.env.APP_ENV = ENVIRONMENT_NAME.DEV;
+        await setLocalVarsMiddleware(req as Request, res as Response, next);
+
+        expect(res.locals).to.have.property("isProd");
+        expect(res.locals.isProd).to.equal(false);
+        expect(next).to.be.calledOnce;
+      });
+
+      it("should be false when the value of APP_ENV is 'build'", async () => {
+        process.env.APP_ENV = ENVIRONMENT_NAME.BUILD;
+        await setLocalVarsMiddleware(req as Request, res as Response, next);
+
+        expect(res.locals).to.have.property("isProd");
+        expect(res.locals.isProd).to.equal(false);
+        expect(next).to.be.calledOnce;
+      });
+
+      it("should be false when the value of APP_ENV is 'staging'", async () => {
+        process.env.APP_ENV = ENVIRONMENT_NAME.STAGING;
+        await setLocalVarsMiddleware(req as Request, res as Response, next);
+
+        expect(res.locals).to.have.property("isProd");
+        expect(res.locals.isProd).to.equal(false);
+        expect(next).to.be.calledOnce;
+      });
+
+      it("should be false when the value of APP_ENV is 'integration'", async () => {
+        process.env.APP_ENV = ENVIRONMENT_NAME.INTEGRATION;
+        await setLocalVarsMiddleware(req as Request, res as Response, next);
+
+        expect(res.locals).to.have.property("isProd");
+        expect(res.locals.isProd).to.equal(false);
+        expect(next).to.be.calledOnce;
+      });
     });
   });
 });


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add TEST version of phase banner to mirror auth team's implementation for their pre-prod journeys.

The auth journeys have an additional yellow bar under the header however this didn't look great with the secondary navigation in home, and I thought that the phase banner update made the current environment clear enough. 


~Added a layout test which checks for the existence of basic page furniture elements including the phase banner.~ I've removed the bonus test after spending hours trying to debug why it was failing 🫠  It might be more practical to use @liegeandlief's Playwright implementation to verify the existence of page furniture elements (including the phase banner) instead. 
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Consistency with the auth journeys. Make it immediately clear the current environment is non-prod.
<!-- Describe the reason these changes were made - the "why" -->


## How to review
When this branch is tested locally (or in any env other than prod), the phase banner tag should be yellow, and the text should reflect that the current env is a test one.

Like the screenshot below, but minus the yellow bar. 

<img width="1347" height="656" alt="Screenshot 2025-07-24 at 16 02 55" src="https://github.com/user-attachments/assets/41221138-9df0-45f2-a0a4-dc9828ee0448" />

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
