### PR TITLE
BAU: minor sign out link alignment tweak

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -114,7 +114,6 @@
   .govuk-template--rebranded & {
     .govuk-header__logo {
       width: 100%;
-      padding-right: govuk-spacing(9);
     }
   }
 
@@ -202,15 +201,14 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
 
 .account-header-navigation__form {
   position: absolute;
-  padding: 5px;
+  padding: govuk-spacing(2) 0 govuk-spacing(2) 0;
   right: 0;
   bottom: 50%;
   transform: translateY(50%);
 
-  @include govuk-media-query($until: mobile) {
+  @include govuk-media-query($until: 480px) {
     position: relative;
-    float: left;
-    padding-left: 0;
+    padding-top: govuk-spacing(1);
     transform: none;
   }
 }


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

I spotted that there was one breakpoint where the One Login product name was collapsing onto the next line, but the Sign out link was staying absolute positioned and centred on the right hand side ("Before" video below).

In this circumstance, the Sign out link should be going onto the next line, and One Login should be staying inline. 

### Before


https://github.com/user-attachments/assets/77888c17-70df-40c9-90e5-59f6115a5496

### After rebranded, and non-rebranded




https://github.com/user-attachments/assets/63c18d2b-c0ab-4f19-8a4d-bc7b66e5d192


https://github.com/user-attachments/assets/95a0cf1a-22a8-4fea-a314-0f4f4a3163de



<!-- Describe the changes in detail - the "what"-->

### Why did it change
Improve the layout on mobile and bring it in line with intended design.
<!-- Describe the reason these changes were made - the "why" -->
