### PR TITLE
OLH-3033 Turn on Splunk to view stats for performance

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -121,6 +121,7 @@ Conditions:
     Fn::Or:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
+      - !Equals [!Ref Environment, staging]
 
 Mappings:
   ElasticLoadBalancerAccountIds:


### PR DESCRIPTION
## Proposed changes

OLH-3033 Turn on Splunk to view stats for performance

### What changed

Update template to turn on splunk in staging

### Why did it change

To be able to view request per minutes stats in splunk for staging when a performance test is ran

### Related links

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Testing


### Sign-offs


## How to review
