### PR TITLE
OLH-3033 turn on splunk in build and turn off in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -121,7 +121,7 @@ Conditions:
     Fn::Or:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
-      - !Equals [!Ref Environment, staging]
+      - !Equals [!Ref Environment, build]
 
 Mappings:
   ElasticLoadBalancerAccountIds:


### PR DESCRIPTION
## Proposed changes
OLH-3033 turn on splunk in build and turn off in build

### What changed

turn on splunk in build and turn off in build

### Why did it change

So that we can run perf test against build and see the stats in splunk

### Related links


## Checklists


### Environment variables or secrets


### Testing


### Sign-offs


## How to review
