### PR TITLE
OLH-2801: global logout analytics

### DIFF
--- a/src/components/global-logout/global-logout-controller.ts
+++ b/src/components/global-logout/global-logout-controller.ts
@@ -3,8 +3,15 @@ import { eventService } from "../../services/event-service";
 import { EventName, LogoutState } from "../../app.constants";
 import { handleLogout } from "../../utils/logout";
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import { setOplSettings } from "../../utils/opl";
 
 export function globalLogoutGet(req: Request, res: Response): void {
+  setOplSettings(
+    {
+      contentId: "2b095344-f460-4e7c-a7e8-51e882447750",
+    },
+    res
+  );
   res.render("global-logout/index.njk", {});
 }
 

--- a/src/components/global-logout/index.njk
+++ b/src/components/global-logout/index.njk
@@ -15,7 +15,11 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         {{ govukButton({
             text: 'pages.globalLogout.button' | translate,
-            classes: "govuk-button--warning" 
+            classes: "govuk-button--warning",
+            attributes: {
+                "data-nav": true,
+                "data-link": "GLOBAL_LOGOUT" | getPath
+            }
         }) }}
     </form>
     <a href='{{ "SIGN_IN_HISTORY" | getPath }}' class="govuk-link govuk-body">


### PR DESCRIPTION
### What changed

Adds the analytics content ID to the global logout confirmation page and also adds attributes to the global logout confirmation button to ensure tracking events are sent when it is clicked.

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed