### PR TITLE
OLH-3033 Add ALB Request count scaling alarm and policies

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -446,10 +446,58 @@ Resources:
           - MetricIntervalUpperBound: -20 #10%
             ScalingAdjustment: -50
 
-  ECSStepScaleOutAlarm:
+  ALBRequestCountScaleOutPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ALBRequestCountScaleOutPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref ECSCluster
+          - !GetAtt ContainerService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 30
+        StepAdjustments:
+          - MetricIntervalLowerBound: 0
+            MetricIntervalUpperBound: 100
+            ScalingAdjustment: 1 # Add 1 task if requests are 201–300
+          - MetricIntervalLowerBound: 100
+            MetricIntervalUpperBound: 300
+            ScalingAdjustment: 2 # Add 2 tasks if requests are 301–500
+          - MetricIntervalLowerBound: 300
+            ScalingAdjustment: 3 # Add 3 tasks if requests > 500
+
+  ALBRequestCountScaleInPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ALBRequestCountScaleInPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref ECSCluster
+          - !GetAtt ContainerService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 30
+        StepAdjustments:
+          - MetricIntervalUpperBound: -100
+            ScalingAdjustment: -2 # Requests < 100
+          - MetricIntervalLowerBound: -100
+            MetricIntervalUpperBound: 0
+            ScalingAdjustment: -1 # Requests between 100–200
+
+  ECSCPUUtilizationHighScaleOutAlarm:
     DependsOn: ContainerAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: "ECS-CPU-Utilization-High"
       ActionsEnabled: true
       AlarmActions:
         - !Ref ECSStepScaleOutPolicy
@@ -468,8 +516,9 @@ Resources:
       Statistic: "Average"
       Period: "60"
       Threshold: "40"
+      TreatMissingData: "notBreaching"
 
-  ECSStepScaleInAlarm:
+  ECSCPUUtilizationNormalScaleInAlarm:
     DependsOn: ContainerAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -491,6 +540,51 @@ Resources:
       Statistic: "Average"
       Period: "60"
       Threshold: "30"
+      TreatMissingData: "notBreaching"
+
+  ALBRequestCountHighScaleOutAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: "ALB-RequestCount-High"
+      MetricName: "RequestCount"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref ALBRequestCountScaleOutPolicy
+      AlarmDescription: "ALB-RequestCount-Above-200"
+      DatapointsToAlarm: "1"
+      Namespace: AWS/ApplicationELB
+      ComparisonOperator: "GreaterThanThreshold"
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApplicationLoadBalancer.LoadBalancerFullName
+      Statistic: Sum
+      Period: "60"
+      EvaluationPeriods: 1
+      Threshold: "200"
+      TreatMissingData: "notBreaching"
+
+  ALBRequestCountNormalScaleInAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: "ALB-RequestCount-Normal"
+      MetricName: "RequestCountPerTarget"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref ALBRequestCountScaleInPolicy
+      AlarmDescription: "ALB-RequestCount-Below-200"
+      DatapointsToAlarm: "1"
+      Namespace: AWS/ApplicationELB
+      ComparisonOperator: "LessThanThreshold"
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApplicationLoadBalancer.LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !Ref ContainerAutoScalingTarget
+      Statistic: Sum
+      Period: "60"
+      EvaluationPeriods: 1
+      Threshold: "200"
+      TreatMissingData: "notBreaching"
 
   ContainerServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
## Proposed changes

OLH-3033 Add ALB Request count scaling alarm and policies

### What changed

Added metric and alarms for when requests per minute on an ALB target is above a given threshold
Added scale out an din policy when the alarms are triggered

### Why did it change

So that we can pro-actively scale out based on an increased request count

### Related links


## Checklists

### Environment variables or secrets


### Testing

Ensure deployment to dev is successful
Verify the scaling policy on the dev environment by looking at the auto scaling configuration in the AWS console

### Sign-offs

## How to review
