### PR TITLE
OLH-2956: use private account management API in staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -233,7 +233,7 @@ Mappings:
     staging:
       NODEENV: "production"
       APIBASEURL: "https://oidc.staging.account.gov.uk"
-      AMAPIBASEURL: "https://manage.staging.account.gov.uk"
+      AMAPIBASEURL: "https://a3bnrbtiga-vpce-0c9ce65be09f99db7.execute-api.eu-west-2.amazonaws.com/staging"
       BASEURL: "home.staging.account.gov.uk"
       SESSIONEXPIRY: "7200000"
       AMYOURACCOUNTURL: "https://www.staging.publishing.service.gov.uk/account/home"


### PR DESCRIPTION
Updates the `AMAPIBASEURL` in staging to point at auth's private account management API