### PR TITLE
OLH-2955: fix session redirect race condition

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -96,6 +96,7 @@ const APP_VIEWS = [
 
 async function createApp(): Promise<express.Application> {
   const app: express.Application = express();
+
   const isDeployedEnvironment = !isLocalEnv();
   app.use(metricsMiddleware());
   app.enable("trust proxy");
@@ -153,6 +154,20 @@ async function createApp(): Promise<express.Application> {
       ),
     })
   );
+
+  app.use((req, res, next) => {
+    // Here we monkey-patch res.redirect to defer calling it until after the session has been saved.
+    // This prevents race conditions where the user follows a redirect response and the
+    // subsequent request reads session before the changes to the session made in the previous
+    // request have been saved.
+    const originalRedirect = res.redirect;
+    res.redirect = (...args: [number, string] | [string]) => {
+      req.session.save(() => {
+        originalRedirect.call(res, ...args);
+      });
+    };
+    next();
+  });
 
   app.locals.sessionStore = sessionStore;
 


### PR DESCRIPTION
Monkey-patch res.redirect to defer calling it until after the session has been saved. This prevents race conditions where the user follows a redirect response and the subsequent request reads the session before the changes to the session made in the previous request have been saved.

The fix has been tested by using our integration testing setup to make many simultaneous requests to the change email address journey which in several places writes to the session before redirecting. Before this change many of these requests failed due to race conditions. With this change all the requests succeed.