### PR TITLE
BAU: check session exists before save

### DIFF
--- a/src/middleware/monkey-patch-redirect-to-save-session-middleware.ts
+++ b/src/middleware/monkey-patch-redirect-to-save-session-middleware.ts
@@ -11,9 +11,13 @@ export function monkeyPatchRedirectToSaveSessionMiddleware(
   // request have been saved.
   const originalRedirect = res.redirect;
   res.redirect = (...args: [number, string] | [string]) => {
-    req.session.save(() => {
+    if (req.session) {
+      req.session.save(() => {
+        originalRedirect.call(res, ...args);
+      });
+    } else {
       originalRedirect.call(res, ...args);
-    });
+    }
   };
   next();
 }

--- a/test/unit/middleware/monkey-patch-redirect-to-save-session-middleware.test.ts
+++ b/test/unit/middleware/monkey-patch-redirect-to-save-session-middleware.test.ts
@@ -93,5 +93,20 @@ describe("monkey-patch-redirect-to-save-session-middleware", () => {
 
       expect(originalRedirect).to.have.been.calledOnceWith("/test-url");
     });
+
+    it("should call original redirect immediately when session is not available", () => {
+      req.session = undefined;
+
+      monkeyPatchRedirectToSaveSessionMiddleware(
+        req as Request,
+        res as Response,
+        next
+      );
+
+      res.redirect!("/test-url");
+
+      expect(sessionSave).to.not.have.been.called;
+      expect(originalRedirect).to.have.been.calledOnceWith("/test-url");
+    });
   });
 });


### PR DESCRIPTION
Updates the `src/middleware/monkey-patch-redirect-to-save-session-middleware.ts` middleware to check that `req.session` is not undefined prior to calling it. This is to address an issue identified in the performance tests.