### PR TITLE
OLH-3025: Add an alarm for OIDC errors

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2145,6 +2145,24 @@ Resources:
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
 
+  OidcCallbackErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-OidcCallbackErrorsAlarm"
+      AlarmDescription: "Alarm when OIDC callback errors exceed 5 per minute for 3 minutes out of the last 5 minutes"
+      Namespace: !Sub "${AWS::StackName}/Account Home"
+      MetricName: oidcCallbackError
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 3
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+
   #
   # Canary Deployment
   #

--- a/src/components/oidc-callback/call-back-utils.ts
+++ b/src/components/oidc-callback/call-back-utils.ts
@@ -4,6 +4,7 @@ import { LOG_MESSAGES, PATH_DATA } from "../../app.constants";
 import { logger } from "../../utils/logger";
 import { deleteExpressSession } from "../../utils/session-store";
 import xss from "xss";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 
 const COOKIES_PREFERENCES_SET = "cookies_preferences_set";
 
@@ -92,6 +93,7 @@ export async function handleOidcCallbackError(
       "OIDC callback error received"
     );
   }
+  req.metrics?.addMetric("oidcCallbackError", MetricUnit.Count, 1);
   await deleteExpressSession(req);
   return res.redirect(PATH_DATA.SESSION_EXPIRED.url);
 }


### PR DESCRIPTION



## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Emit a new custom metric when we get an error on the OIDC callback, and use that to trigger an alarm if we see too many.

I've looked at the production logs and right now we get 1 or 2 `access_denied` or `server_error` responses per day. I've configured the alarm to trigger if 3 out of the last 5 minutes have more than 5 of these errors. This should be well above the base threshold and so should only trigger if there's a problem.

### Why did it change

So we get alerted if something goes wrong when users are signing in. We've chosen to keep these log lines at WARN level because there are legitimate reasons we get returned an error from the IdP, which means our generic ERROR level alarm wouldn't catch them.

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
