### PR TITLE
OLH-3075 Remove usage of monkey patching middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -83,7 +83,6 @@ import { getTranslations } from "di-account-management-rp-registry";
 import { readFileSync } from "node:fs";
 import { metricsMiddleware } from "./middleware/metrics-middlware";
 import { globalLogoutRouter } from "./components/global-logout/global-logout-routes";
-import { monkeyPatchRedirectToSaveSessionMiddleware } from "./middleware/monkey-patch-redirect-to-save-session-middleware";
 import {
   setBaseTranslations,
   setFrontendUiTranslations,
@@ -151,7 +150,6 @@ async function createApp(): Promise<express.Application> {
       ),
     })
   );
-  app.use(monkeyPatchRedirectToSaveSessionMiddleware);
 
   app.locals.sessionStore = sessionStore;
 

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -38,7 +38,6 @@ describe("Integration::enter password", () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     const sessionMiddleware = require("../../../middleware/requires-auth-middleware");
-    const monkeyPatchRedirectToSaveSessionMiddleware = require("../../../middleware/monkey-patch-redirect-to-save-session-middleware");
     sandbox = sinon.createSandbox();
     sandbox
       .stub(sessionMiddleware, "requiresAuthMiddleware")
@@ -83,14 +82,6 @@ describe("Integration::enter password", () => {
             return url;
           },
         };
-        next();
-      });
-    sandbox
-      .stub(
-        monkeyPatchRedirectToSaveSessionMiddleware,
-        "monkeyPatchRedirectToSaveSessionMiddleware"
-      )
-      .callsFake(function (req: any, res: any, next: any): void {
         next();
       });
 


### PR DESCRIPTION
## Proposed changes

OLH-3075 Remove usage of monkey patching middleware

### What changed

Remove usage of monkey patching middleware

### Why did it change

To eliminate as we think its the root cause for the crashing service

### Related links


## Checklists


### Environment variables or secrets


### Testing


### Sign-offs


## How to review

