### PR TITLE
OLH-3076: redirect monkey patch improvements

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -90,6 +90,7 @@ import {
   frontendUiTranslationCy,
   frontendUiTranslationEn,
 } from "@govuk-one-login/frontend-ui";
+import { monkeyPatchRedirectToSaveSessionMiddleware } from "./middleware/monkey-patch-redirect-to-save-session-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -152,6 +153,7 @@ async function createApp(): Promise<express.Application> {
       ),
     })
   );
+  app.use(monkeyPatchRedirectToSaveSessionMiddleware);
 
   app.locals.sessionStore = sessionStore;
 

--- a/src/components/choose-backup/choose-backup-controller.ts
+++ b/src/components/choose-backup/choose-backup-controller.ts
@@ -107,5 +107,4 @@ export function chooseBackupPost(
   );
 
   res.redirect(selectedMfaMethod.path.url);
-  res.end();
 }

--- a/src/middleware/monkey-patch-redirect-to-save-session-middleware.ts
+++ b/src/middleware/monkey-patch-redirect-to-save-session-middleware.ts
@@ -27,7 +27,13 @@ export function monkeyPatchRedirectToSaveSessionMiddleware(
     };
 
     if (req.session) {
-      req.session.save(() => {
+      req.session.save((err) => {
+        if (err) {
+          logger.warn(
+            { trace: res?.locals?.trace, stack, path: req.path, err },
+            "Unable to save session"
+          );
+        }
         redirect();
       });
     } else {

--- a/src/middleware/monkey-patch-redirect-to-save-session-middleware.ts
+++ b/src/middleware/monkey-patch-redirect-to-save-session-middleware.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import { logger } from "../utils/logger";
 
 export function monkeyPatchRedirectToSaveSessionMiddleware(
   req: Request,
@@ -10,13 +11,27 @@ export function monkeyPatchRedirectToSaveSessionMiddleware(
   // subsequent request reads session before the changes to the session made in the previous
   // request have been saved.
   const originalRedirect = res.redirect;
+
   res.redirect = (...args: [number, string] | [string]) => {
+    const stack = new Error().stack;
+
+    const redirect = () => {
+      if (!res.headersSent) {
+        originalRedirect.call(res, ...args);
+      } else {
+        logger.warn(
+          { trace: res?.locals?.trace, stack, path: req.path },
+          "Unable to redirect as headers are already sent"
+        );
+      }
+    };
+
     if (req.session) {
       req.session.save(() => {
-        originalRedirect.call(res, ...args);
+        redirect();
       });
     } else {
-      originalRedirect.call(res, ...args);
+      redirect();
     }
   };
   next();


### PR DESCRIPTION
### What changed

- Removes unnecessary `res.end` call which was preventing redirect headers from being written to the response
- Reinstates the redirect monkey patch middleware
- Updates the redirect monkey patching logic to only redirect if headers have not already been sent, and to add more logging

### Why did it change

Monkey-patch res.redirect to defer calling it until after the session has been saved to prevent race conditions where the user follows a redirect response and the subsequent request reads the session before the changes to the session made in the previous request have been saved.

The removal of `res.end` and checking whether headers have already been sent ensure that the monkey patching middleware won't try to write headers when they've already been sent, which was causing fatal exceptions.