### PR TITLE
OLH-3086: move phone number in audit events

### DIFF
--- a/src/services/event-service.test.ts
+++ b/src/services/event-service.test.ts
@@ -288,7 +288,7 @@ describe("eventService", () => {
       expect(result.platform.user_agent).to.equal("test-user-agent");
       expect(result.extensions["journey-type"]).to.equal("ACCOUNT_MANAGEMENT");
       expect(result.extensions.phone_number_country_code).to.equal("44");
-      expect(result.extensions.phone).to.equal("+447123456789");
+      expect(result.user.phone).to.equal("+447123456789");
       expect(result.event_timestamp_ms).to.equal(1726099200000);
       expect(result.event_timestamp_ms_formatted).to.equal(
         "2024-09-12T00:00:00.000Z"
@@ -366,7 +366,7 @@ describe("eventService", () => {
       expect(result.extensions["journey-type"]).to.equal("ACCOUNT_MANAGEMENT");
       expect(result.extensions["mfa-type"]).to.equal("SMS");
       expect(result.extensions.phone_number_country_code).to.equal("44");
-      expect(result.extensions.phone).to.equal("+447123456789");
+      expect(result.user.phone).to.equal("+447123456789");
       expect(result.event_timestamp_ms).to.equal(1726099200000);
       expect(result.event_timestamp_ms_formatted).to.equal(
         "2024-09-12T00:00:00.000Z"
@@ -489,7 +489,7 @@ describe("eventService", () => {
       expect(result.extensions["journey-type"]).to.equal("ACCOUNT_MANAGEMENT");
       expect(result.extensions["mfa-type"]).to.equal("SMS");
       expect(result.extensions.phone_number_country_code).to.equal("44");
-      expect(result.extensions.phone).to.equal("+447987654321");
+      expect(result.user.phone).to.equal("+447987654321");
       expect(result.event_timestamp_ms).to.equal(1726099200000);
       expect(result.event_timestamp_ms_formatted).to.equal(
         "2024-09-12T00:00:00.000Z"

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -128,6 +128,12 @@ export function eventService(
               defaultMethod.method.phoneNumber,
               "GB"
             ).countryCallingCode,
+          }
+        : {};
+
+    const defaultPhoneNumberObject =
+      defaultMethod?.method.mfaMethodType === mfaMethodTypes.sms
+        ? {
             phone: defaultMethod.method.phoneNumber,
           }
         : {};
@@ -139,6 +145,12 @@ export function eventService(
               backupMethod.method.phoneNumber,
               "GB"
             ).countryCallingCode,
+          }
+        : {};
+
+    const backupPhoneNumberObject =
+      backupMethod?.method.mfaMethodType === mfaMethodTypes.sms
+        ? {
             phone: backupMethod.method.phoneNumber,
           }
         : {};
@@ -156,6 +168,10 @@ export function eventService(
         break;
 
       case EventName.AUTH_MFA_METHOD_ADD_STARTED:
+        baseEvent.user = {
+          ...baseEvent.user,
+          ...defaultPhoneNumberObject,
+        };
         baseEvent.extensions = {
           "journey-type": "ACCOUNT_MANAGEMENT",
           ...defaultPhoneNumberCountryCodeObject,
@@ -163,6 +179,10 @@ export function eventService(
         break;
 
       case EventName.AUTH_MFA_METHOD_SWITCH_STARTED:
+        baseEvent.user = {
+          ...baseEvent.user,
+          ...defaultPhoneNumberObject,
+        };
         baseEvent.extensions = {
           "journey-type": "ACCOUNT_MANAGEMENT",
           "mfa-type": defaultMethod.method.mfaMethodType,
@@ -171,6 +191,10 @@ export function eventService(
         break;
 
       case EventName.AUTH_MFA_METHOD_DELETE_STARTED:
+        baseEvent.user = {
+          ...baseEvent.user,
+          ...backupPhoneNumberObject,
+        };
         baseEvent.extensions = {
           "journey-type": "ACCOUNT_MANAGEMENT",
           "mfa-type": backupMethod.method.mfaMethodType,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -41,6 +41,7 @@ export interface User {
   email?: string;
   ip_address?: string;
   govuk_signin_journey_id?: string;
+  phone?: string;
 }
 
 export interface Platform {
@@ -56,7 +57,6 @@ export interface Extensions {
   "journey-type"?: "ACCOUNT_MANAGEMENT";
   "mfa-type"?: (typeof mfaMethodTypes)[keyof typeof mfaMethodTypes];
   phone_number_country_code?: string;
-  phone?: string;
 }
 
 export interface CurrentTimeDescriptor {


### PR DESCRIPTION
### What changed

Moves the `phone` property from the `extensions` object and into the `user` object in the following audit events:

AUTH_MFA_METHOD_ADD_STARTED
AUTH_MFA_METHOD_SWITCH_STARTED
AUTH_MFA_METHOD_DELETE_STARTED

### Why did it change

So that the phone number is in the correct location as per the event specs and to prevent leaking of PII.

Event specs:

https://event-catalogue.internal.account.gov.uk/events/AUTH_MFA_METHOD_ADD_STARTED/
https://event-catalogue.internal.account.gov.uk/events/AUTH_MFA_METHOD_SWITCH_STARTED/
https://event-catalogue.internal.account.gov.uk/events/AUTH_MFA_METHOD_DELETE_STARTED/