### PR TITLE
OLH-3048: Show the activity log to all users

### DIFF
--- a/src/components/activity-history/activity-history-routes.ts
+++ b/src/components/activity-history/activity-history-routes.ts
@@ -2,14 +2,12 @@ import * as express from "express";
 import { activityHistoryGet } from "./activity-history-controller";
 import { PATH_DATA } from "../../app.constants";
 import { requiresAuthMiddleware } from "../../middleware/requires-auth-middleware";
-import { checkActivityLogAllowedServicesList } from "../../middleware/check-allowed-services-list";
 
 const router = express.Router();
 
 router.get(
   PATH_DATA.SIGN_IN_HISTORY.url,
   requiresAuthMiddleware,
-  checkActivityLogAllowedServicesList,
   activityHistoryGet
 );
 

--- a/src/components/activity-history/tests/activity-history-integration.test.ts
+++ b/src/components/activity-history/tests/activity-history-integration.test.ts
@@ -91,15 +91,6 @@ describe("Integration:: Activity history", () => {
       });
   });
 
-  it("should redirect if the user does not have allowed services on the list", async () => {
-    const app = await appWithMiddlewareSetup([], {
-      hasAllowedActivityLogServices: false,
-    });
-    const response = await request(app).get(url);
-    expect(response.status).to.equal(302);
-    expect(response.header.location).to.equal(PATH_DATA.SECURITY.url);
-  });
-
   it("should display without pagination when data is less than activityLogItemsPerPage", async () => {
     const dataShort = [
       {
@@ -261,7 +252,6 @@ const appWithMiddlewareSetup = async (data?: any, config?: any) => {
   const reportSuspiciousActivity =
     !config?.reportSuspiciousActivityJourneyDisabled;
   const language = config?.language ?? "en";
-  const checkAllowedServicesList = require("../../../middleware/check-allowed-services-list");
 
   const activity = data ?? [
     {
@@ -314,10 +304,6 @@ const appWithMiddlewareSetup = async (data?: any, config?: any) => {
   sandbox.stub(configFuncs, "reportSuspiciousActivity").callsFake(() => {
     return reportSuspiciousActivity;
   });
-
-  sandbox
-    .stub(checkAllowedServicesList, "hasAllowedActivityLogServices")
-    .resolves(config?.hasAllowedActivityLogServices ?? true);
 
   return await require("../../../app").createApp();
 };

--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -99,13 +99,11 @@
 
   </div>
 
-  {% if hasActivityLog %}
-    <div class="summary-list-container" data-test-id="activity-log-section">
-      <h2 class="govuk-heading-m">{{ 'pages.security.activityHistory.heading' | translate }}</h2>
-      <p class="govuk-body">{{ 'pages.security.activityHistory.info' | translate }}</p>
-      <p class="govuk-body"><a href="{{activityLogUrl}}" class="govuk-link">{{ 'pages.security.activityHistory.link' | translate }}</a></p>
-    </div>
-  {% endif %}
+  <div class="summary-list-container" data-test-id="activity-log-section">
+    <h2 class="govuk-heading-m">{{ 'pages.security.activityHistory.heading' | translate }}</h2>
+    <p class="govuk-body">{{ 'pages.security.activityHistory.info' | translate }}</p>
+    <p class="govuk-body"><a href="{{activityLogUrl}}" class="govuk-link">{{ 'pages.security.activityHistory.link' | translate }}</a></p>
+  </div>
 
   {% if supportGlobalLogout %}
     <div class="summary-list-container" data-test-id="global-logout-section">

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import { supportGlobalLogout } from "../../config";
 import { PATH_DATA } from "../../app.constants";
-import { hasAllowedActivityLogServices } from "../../middleware/check-allowed-services-list";
 import { getLastNDigits } from "../../utils/phone-number";
 import { MfaMethod } from "src/utils/mfaClient/types";
 import { setOplSettings } from "../../utils/opl";
@@ -81,9 +80,6 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
   req.metrics?.addMetric("securityGet", MetricUnit.Count, 1);
   const { email } = req.session.user;
   const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=security&edit=true`;
-
-  const hasActivityLog = await hasAllowedActivityLogServices(req, res);
-
   const mfaMethods = Array.isArray(req.session.mfaMethods)
     ? mapMfaMethods(req.session.mfaMethods, enterPasswordUrl, req.t)
     : [];
@@ -101,7 +97,6 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
 
   res.render("security/index.njk", {
     email,
-    hasActivityLog,
     activityLogUrl: PATH_DATA.SIGN_IN_HISTORY.url,
     enterPasswordUrl,
     mfaMethods,

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -10,7 +10,6 @@ describe("security controller", () => {
   let req: Partial<Request>;
   let res: Partial<Response>;
   let configFuncs: any;
-  let allowedServicesModule: any;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -22,7 +21,6 @@ describe("security controller", () => {
     };
     configFuncs = require("../../../config");
     sandbox.stub(configFuncs, "supportGlobalLogout").returns(false);
-    allowedServicesModule = require("../../../middleware/check-allowed-services-list");
   });
 
   afterEach(() => {
@@ -31,10 +29,6 @@ describe("security controller", () => {
 
   describe("securityGet", () => {
     it("should render security view with SMS MFA method", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(true);
-
       req.session.user = {
         email: "test@test.com",
         phoneNumber: "xxxxxxx7898",
@@ -56,51 +50,6 @@ describe("security controller", () => {
 
       expect(res.render).to.have.calledWith("security/index.njk", {
         email: "test@test.com",
-        hasActivityLog: true,
-        supportGlobalLogout: false,
-        activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security&edit=true",
-        mfaMethods: [
-          {
-            text: "pages.security.mfaSection.defaultMethod.phoneNumber.title",
-            linkHref:
-              "/enter-password?from=security&edit=true&type=changePhoneNumber",
-            linkText:
-              "pages.security.mfaSection.defaultMethod.phoneNumber.change",
-            priorityIdentifier: "DEFAULT",
-          },
-        ],
-        canChangeTypeofPrimary: true,
-      });
-    });
-
-    it("should render security view without activity log when the user doesn't have a supported service", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(false);
-
-      req.session.user = {
-        email: "test@test.com",
-        phoneNumber: "xxxxxxx7898",
-        isPhoneNumberVerified: true,
-      } as any;
-      req.session.mfaMethods = [
-        {
-          mfaIdentifier: 1,
-          priorityIdentifier: "DEFAULT",
-          method: {
-            mfaMethodType: "SMS",
-            PhoneNumber: "xxxxxxx7898",
-          },
-          methodVerified: true,
-        },
-      ] as any;
-
-      await securityGet(req as Request, res as Response);
-
-      expect(res.render).to.have.calledWith("security/index.njk", {
-        email: "test@test.com",
-        hasActivityLog: false,
         supportGlobalLogout: false,
         activityLogUrl: "/activity-history",
         enterPasswordUrl: "/enter-password?from=security&edit=true",
@@ -119,10 +68,6 @@ describe("security controller", () => {
     });
 
     it("throws an error when the mfaMethodType is undefined", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(false);
-
       req.session.user = {
         email: "test@test.com",
         phoneNumber: "xxxxxxx7898",
@@ -146,10 +91,6 @@ describe("security controller", () => {
     });
 
     it("throws an error when the mfaMethodType is not unknown", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(false);
-
       req.session.user = {
         email: "test@test.com",
         phoneNumber: "xxxxxxx7898",
@@ -172,55 +113,7 @@ describe("security controller", () => {
       ).to.eventually.be.rejectedWith("Unexpected mfaMethodType: INVALID");
     });
 
-    it("should render security view with activity log when the user has a supported service and the feature flag is on", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(true);
-
-      req.session.user = {
-        email: "test@test.com",
-        phoneNumber: "xxxxxxx7898",
-        isPhoneNumberVerified: true,
-      } as any;
-      req.session.mfaMethods = [
-        {
-          mfaIdentifier: 1,
-          priorityIdentifier: "DEFAULT",
-          method: {
-            mfaMethodType: "SMS",
-            PhoneNumber: "xxxxxxx7898",
-          },
-          methodVerified: true,
-        },
-      ] as any;
-
-      await securityGet(req as Request, res as Response);
-
-      expect(res.render).to.have.calledWith("security/index.njk", {
-        email: "test@test.com",
-        hasActivityLog: true,
-        supportGlobalLogout: false,
-        activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security&edit=true",
-        mfaMethods: [
-          {
-            text: "pages.security.mfaSection.defaultMethod.phoneNumber.title",
-            linkHref:
-              "/enter-password?from=security&edit=true&type=changePhoneNumber",
-            linkText:
-              "pages.security.mfaSection.defaultMethod.phoneNumber.change",
-            priorityIdentifier: "DEFAULT",
-          },
-        ],
-        canChangeTypeofPrimary: true,
-      });
-    });
-
     it("should render security view with empty MFA methods when no MFA methods are set", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(true);
-
       req.session.user = { email: "test@test.com" } as any;
       req.session.mfaMethods = [];
 
@@ -228,7 +121,6 @@ describe("security controller", () => {
 
       expect(res.render).to.have.been.calledWith("security/index.njk", {
         email: "test@test.com",
-        hasActivityLog: true,
         supportGlobalLogout: false,
         activityLogUrl: "/activity-history",
         enterPasswordUrl: "/enter-password?from=security&edit=true",
@@ -238,10 +130,6 @@ describe("security controller", () => {
     });
 
     it("should render security view with AUTH_APP MFA method", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(true);
-
       req.session.user = { email: "test@test.com" } as any;
       req.session.mfaMethods = [
         {
@@ -258,7 +146,6 @@ describe("security controller", () => {
 
       expect(res.render).to.have.been.calledWith("security/index.njk", {
         email: "test@test.com",
-        hasActivityLog: true,
         supportGlobalLogout: false,
         activityLogUrl: "/activity-history",
         enterPasswordUrl: "/enter-password?from=security&edit=true",
@@ -295,10 +182,6 @@ describe("security controller", () => {
     });
 
     it("should set canChangeTypeofPrimary to false when MFA constraints apply", async () => {
-      sandbox
-        .stub(allowedServicesModule, "hasAllowedActivityLogServices")
-        .resolves(true);
-
       req.session.user = { email: "test@test.com" } as any;
       req.session.mfaMethods = [
         {

--- a/src/components/security/tests/security-integration.test.ts
+++ b/src/components/security/tests/security-integration.test.ts
@@ -88,19 +88,6 @@ describe("Integration:: security", () => {
       });
   });
 
-  it("should not display link to activity log when hasAllowedActivityLogServices is false", async () => {
-    const app = await appWithMiddlewareSetup({
-      hasAllowedActivityLogServices: false,
-    });
-    await request(app)
-      .get(url)
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect(res.status).to.equal(200);
-        expect($(testComponent("activity-log-section")).length).to.equal(0);
-      });
-  });
-
   it("should display link to global logout page when supportGlobalLogout is true", async () => {
     const app = await appWithMiddlewareSetup({ supportGlobalLogout: true });
     await request(app)
@@ -131,7 +118,6 @@ const appWithMiddlewareSetup = async (config: any = {}) => {
   const sandbox = sinon.createSandbox();
   const oidc = require("../../../utils/oidc");
   const configFuncs = require("../../../config");
-  const checkAllowedServicesList = require("../../../middleware/check-allowed-services-list");
   const mfa = require("../../../utils/mfaClient");
   const methods: Record<string, MfaMethod> = {
     SMS: {
@@ -174,10 +160,6 @@ const appWithMiddlewareSetup = async (config: any = {}) => {
   sandbox.stub(configFuncs, "supportGlobalLogout").callsFake(() => {
     return config.supportGlobalLogout;
   });
-
-  sandbox
-    .stub(checkAllowedServicesList, "hasAllowedActivityLogServices")
-    .resolves(config?.hasAllowedActivityLogServices ?? true);
 
   const stubMfaClient: sinon.SinonStubbedInstance<MfaClient> =
     sandbox.createStubInstance(mfa.MfaClient);

--- a/src/middleware/check-allowed-services-list.ts
+++ b/src/middleware/check-allowed-services-list.ts
@@ -27,22 +27,6 @@ export const hasAllowedActivityLogServices = async (
   );
 };
 
-export async function checkActivityLogAllowedServicesList(
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> {
-  if (await hasAllowedActivityLogServices(req, res)) {
-    next();
-  } else {
-    req.log.info(
-      { trace: res.locals.trace },
-      LOG_MESSAGES.ILLEGAL_ATTEMPT_TO_ACCESS_ACTIVITY_LOG
-    );
-    res.redirect(PATH_DATA.SECURITY.url);
-  }
-}
-
 export async function checkRSAAllowedServicesList(
   req: Request,
   res: Response,

--- a/test/unit/middleware/check-allowed-services-list.test.ts
+++ b/test/unit/middleware/check-allowed-services-list.test.ts
@@ -3,7 +3,6 @@ import { describe } from "mocha";
 import { NextFunction } from "express";
 import sinon from "sinon";
 import {
-  checkActivityLogAllowedServicesList,
   checkRSAAllowedServicesList,
   findClientInServices,
 } from "../../../src/middleware/check-allowed-services-list";
@@ -20,96 +19,6 @@ describe("activity history allowlist middleware", () => {
 
   afterEach(() => {
     sandbox.restore();
-  });
-
-  describe("checkActivityLogAllowedServicesList function", () => {
-    it("calls next function if list of user services contains activity history allowlisted RPs", async () => {
-      //  mortgageDeed is on the allow list
-      const yourNewServices = [
-        {
-          client_id: "prisonVisits",
-          count_successful_logins: 1,
-          last_accessed: 14567776,
-          last_accessed_readable_format: "last_accessed_readable_format",
-          hasDetailedCard: true,
-        },
-        {
-          client_id: "mortgageDeed",
-          count_successful_logins: 1,
-          last_accessed: 14567776,
-          last_accessed_readable_format: "last_accessed_readable_format",
-          hasDetailedCard: true,
-        },
-      ];
-      const yourNewAllowlist = ["prisonVisits"];
-      const containsRps = findClientInServices(
-        yourNewAllowlist,
-        yourNewServices
-      );
-      sandbox.stub(yourServices, "getServices").resolves(yourNewServices);
-
-      sandbox.stub(allowListFuncs, "findClientInServices").returns(containsRps);
-      const req: any = {
-        session: {
-          user: {
-            isAuthenticated: false,
-          } as any,
-        },
-        cookies: {
-          lo: "true",
-        },
-        log: {
-          info: sinon.fake(),
-        },
-      };
-
-      const res: any = { locals: {}, redirect: sinon.fake() };
-      expect(containsRps).equal(true);
-      const nextFunction: NextFunction = sinon.fake(() => {});
-      await checkActivityLogAllowedServicesList(req, res, nextFunction);
-      expect(nextFunction).to.have.been.calledOnce;
-    });
-
-    it("redirects if list of user services does not contain activity history allowlisted RPs", async () => {
-      sandbox.stub(yourServices, "getServices").resolves([
-        {
-          client_id: "smokeTests",
-          count_successful_logins: 1,
-          last_accessed: 14567776,
-          last_accessed_readable_format: "last_accessed_readable_format",
-          hasDetailedCard: true,
-        },
-        {
-          client_id: "relyingPartyStub",
-          count_successful_logins: 1,
-          last_accessed: 14567776,
-          last_accessed_readable_format: "last_accessed_readable_format",
-          hasDetailedCard: true,
-        },
-      ]);
-      const req: any = {
-        session: {
-          user: {
-            isAuthenticated: false,
-          } as any,
-        },
-        cookies: {
-          lo: "true",
-        },
-        log: {
-          info: sinon.fake(),
-        },
-      };
-
-      const res: any = { locals: { trace: {} }, redirect: sinon.fake() };
-      const nextFunction: NextFunction = sinon.fake(() => {});
-      await checkActivityLogAllowedServicesList(req, res, nextFunction);
-      expect(res.redirect).to.have.been.calledWith(PATH_DATA.SECURITY.url);
-      expect(req.log.info).to.have.been.calledWith(
-        { trace: {} },
-        LOG_MESSAGES.ILLEGAL_ATTEMPT_TO_ACCESS_ACTIVITY_LOG
-      );
-    });
   });
 
   describe("checkRSAAllowedServicesList function", () => {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Show the activity log to all users by removing the middleware check for an allowed service in the user's history and the conditional from the security page. 

I've left in the similar check for the report suspicious activity journey as it's possible we want to use the same mechanism for a slow rollout of that feature in the future.

### Why did it change

We're not going to turn this feature off again, so we can remove all the conditional checks for an allowed service in a user's history. This will save us several database calls and make it easier to work in the frontend.


## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

I've run the app locally and checked the activity history shows up for users who don't have any history. The simplest way to do this is to sign in as the performance test user as that gets a unique user ID each time, so can't have any sign in history.

