### PR TITLE
BAU: Bump govuk-frontend to most recent version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "express-validator": "^7.2.1",
         "fast-memoize": "^2.5.2",
         "flexsearch": "^0.8.205",
-        "govuk-frontend": "^5.11.1",
+        "govuk-frontend": "^5.11.2",
         "helmet": "8.1.0",
         "i18next": "^24.2.3",
         "i18next-fs-backend": "^2.6.0",
@@ -6676,9 +6676,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
-      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
+      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "express-validator": "^7.2.1",
     "fast-memoize": "^2.5.2",
     "flexsearch": "^0.8.205",
-    "govuk-frontend": "^5.11.1",
+    "govuk-frontend": "^5.11.2",
     "helmet": "8.1.0",
     "i18next": "^24.2.3",
     "i18next-fs-backend": "^2.6.0",


### PR DESCRIPTION
This version introduces several minor bug fixes as per the [release notes](https://github.com/alphagov/govuk-frontend/releases). 

The only change that is relevant to us is https://github.com/alphagov/govuk-frontend/pull/6184 

