### PR TITLE
OLH-3098: Remind us to monitor risky changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,18 +35,24 @@
 
 <!-- When working with feature flags, features that are flagged off should not be made available in production -->
 <!-- Delete if changes do NOT include any feature flags -->
+
 - [ ] Automated test coverage includes features that are flagged off
 
 ### Sign-offs
+
 <!-- New Node.JS/NPM dependencies need to be approved by a Lead Developer or Lead SRE: https://govukverify.atlassian.net/wiki/spaces/DIWAY/pages/4335697997/Library+approval+process -->
 <!-- Delete if changes do NOT include any new libraries -->
-- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE 
-<!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
-<!-- Delete if changes do NOT include any design updates -->
+
+- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE
+  <!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
+  <!-- Delete if changes do NOT include any design updates -->
 - [ ] Design updates have been signed off by a member of the UCD team
 <!-- Delete if changes do NOT include any analytics updates -->
 - [ ] Analytics updates have been signed off by a PA
 
+### Monitoring
+
+- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues
 
 ## How to review
 


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add a checklist item in the PR template for extra risky PRs. I also formatted the template file with Prettier; it must be excluded from our normal linting checks.

### Why did it change

This is an action coming out of a recent retro. Hopefully having this will remind us to flag any particularly risky changes at the review stage so we can:

1. Review even more carefully
2. Be aware when we merge it and keep a close eye on the deployment
