### PR TITLE
BAU: Move error summary partial into base-page.njk

### DIFF
--- a/src/components/change-email/index.njk
+++ b/src/components/change-email/index.njk
@@ -1,13 +1,10 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitleName = 'pages.changeEmail.title' | translate %}
 
 {% block pageContent %}
-
-{% include "common/errors/errorSummary.njk" %}
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{'pages.changeEmail.header' | translate}}</h1>
 

--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -1,14 +1,11 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitleName = 'pages.changePassword.title' | translate %}
 
 {% block pageContent %}
-
-{% include "common/errors/errorSummary.njk" %}
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{'pages.changePassword.header' | translate}}</h1>
 

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -3,16 +3,12 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitleName = 'pages.checkYourEmail.title' | translate %}
 
 {% set backLink = 'pages.checkYourEmail.changeEmailLinkHref' | translate %}
 
 {% block pageContent %}
-
-{% include "common/errors/errorSummary.njk" %}
-
 <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>
 
 {{ govukInsetText({

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -3,14 +3,10 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitleName = 'pages.checkYourPhone.title' | translate %}
 
 {% block pageContent %}
-
-    {% include "common/errors/errorSummary.njk" %}
-
     <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate}}</h1>
     {{ govukInsetText({
         text: 'pages.checkYourPhone.text' | translate | replace("[mobile]", phoneNumber) | safe

--- a/src/components/choose-backup/index.njk
+++ b/src/components/choose-backup/index.njk
@@ -2,7 +2,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set helpText %}
     <p class="govuk-body">{{ 'pages.addBackup.app.help.text1' | translate }}</p>
@@ -27,8 +26,8 @@
 {% endif %}
 
 {% set pageTitleName = 'pages.addBackup.backup.title' | translate %}
+
 {% block pageContent %}
-    {% include "common/errors/errorSummary.njk" %}
     <form action="{{ "ADD_MFA_METHOD" | getPath }}" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% if showSingleMethod %}

--- a/src/components/common/layout/base-page.njk
+++ b/src/components/common/layout/base-page.njk
@@ -2,6 +2,7 @@
 {% block content %}
 <div class="govuk-grid-row" {% if rowContainerId %} id="{{ rowContainerId }}" data-test-id="{{ rowContainerId }}"{% endif %}>
   <div class="govuk-grid-column-two-thirds">
+  {% include "common/errors/errorSummary.njk" %}
   {% block pageContent %}
   {% endblock %}
   </div>

--- a/src/components/common/mfa/add-auth-app.njk
+++ b/src/components/common/mfa/add-auth-app.njk
@@ -2,13 +2,10 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitleName = 'pages.addBackupApp.title' | translate %}
 
 {% block pageContent %}
-  {% include "common/errors/errorSummary.njk" %}
-
   <h1 class="govuk-heading-xl">{{ 'pages.addBackupApp.title' | translate }}</h1>
   <ol class="govuk-list">
     <li>

--- a/src/components/common/mfa/add-phone-number.njk
+++ b/src/components/common/mfa/add-phone-number.njk
@@ -7,8 +7,6 @@
 {% set pageTitleName = pathToTitleString | translate or 'pages.changePhoneNumber.title' | translate %}
 
 {% block pageContent %}
-  {% include "common/errors/errorSummary.njk" %}
-
   <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{ pathToHeadingString | translate or 'pages.changePhoneNumber.header' |
     translate}}</h1>
 

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -1,14 +1,10 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageTitleName = 'pages.deleteAccount.title' | translate %}
 
 {% block pageContent %}
-
-{% include "common/errors/errorSummary.njk" %}
-
 <h1 class="govuk-heading-l">{{'pages.deleteAccount.header' | translate}}</h1>
 
 <p class="govuk-body">{{'pages.deleteAccount.paragraph1' | translate}}</p>

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -1,7 +1,6 @@
 {% extends "common/layout/base-page.njk" %}
 {% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set paragraph = ['pages.enterPassword.', requestType, '.paragraph'] | join | translate %}
 {% set cancelText = 'pages.enterPassword.cancelText' | translate %}
 {% set header = ['pages.enterPassword.', requestType, '.header'] | join | translate %}
@@ -16,8 +15,6 @@
 {% endif %}
 
 {% block pageContent %}
-{% include "common/errors/errorSummary.njk" %}
-
     <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{header}}</h1>
 
     <form action="{{formAction}}" method="post" novalidate>
@@ -41,7 +38,7 @@
         {{ govukButton({
           text: 'general.continue.label' | translate,
           preventDoubleClick: true
-        }) }}
+        })}}
         {% if fromSecurity %}
         <p class="govuk-body"> <a href='{{ "SECURITY" | getPath }}' class="govuk-link" rel="noreferrer noopener">{{cancelText}}</a></p>
         {% endif %}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Move `errorSummary.njk` from the individual `index.njk` templates into the shared `base-page.njk` layout file.
<!-- Describe the changes in detail - the "what"-->
`errorSummary.njk` only displays an error if the relevant locals ([primarily, `errorList`](https://github.com/govuk-one-login/di-account-management-frontend/blob/main/src/components/common/errors/errorSummary.njk#L5)) exist within the context of the page.
Therefore moving repeated calls to the `errorSummary` partial into the shared `base-page.njk` should be a relatively risk free operation.

Nothing should have changed visually speaking.

### Why did it change
Reduce repetition
<!-- Describe the reason these changes were made - the "why" -->

## How to review
Visit any pages that do not contain input fields (for ex contact page, your services, security), and check that error messages do not appear. 

Visit pages that do contain input fields, and check that error messages do appear if you do something wrong. 
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
