### PR TITLE
OLH-3111: Set content ID for logout password page

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -95,6 +95,9 @@ const getOplValues = (): OplSettingsLookupObject => ({
     ...MFA_COMMON_OPL_SETTINGS,
     contentId: "acef67be-40e5-4ebf-83d6-b8bc8c414304",
   },
+  [UserJourney.GlobalLogout]: {
+    contentId: "cefa908b-d774-4da4-b8df-3d4bc6ec3323",
+  },
 });
 
 const getRenderOptions = (req: Request, requestType: UserJourney) => {


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Set content ID for the global logout password page. The default level 2 taxonomy (`home`) is fine here so we don't need to set a journey-specific one. Check the Jira ticket for the ID from Temi.

### Why did it change

So we can track the journey in GA.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

