### PR TITLE
BAU: LocalStack DynamoDB tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - SERVICES=kms,sns,dynamodb,sqs,stepfunctions,cloudwatch
       - LOCALSTACK_HOST=localhost
       - DYNAMODB_SHARE_DB=1 # Removes regions and allows NoSQL Workbench to work.
+      - DYNAMODB_REMOVE_EXPIRED_ITEMS=1
+      - DYNAMODB_IN_MEMORY=1
       - DEBUG=${DEBUG:-0}
       - AWS_ACCESS_KEY_ID=na
       - AWS_SECRET_ACCESS_KEY=na


### PR DESCRIPTION
### What changed and why

Set `DYNAMODB_REMOVE_EXPIRED_ITEMS` to `1` when starting LocalStack so that expired sessions are removed from the database as is the case in AWS.

Set `DYNAMODB_IN_MEMORY` to `1` when starting LocalStack so that the database is just held in memory while the container is running. This improves performance significantly and there is no need for changes to be persisted to disk.

