### PR TITLE
BAU: change integration test action triggers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,8 @@
 name: "Integration tests"
 
 on:
-  push:
-    branches-ignore:
-      - main
+  pull_request:
+  merge_group:
 
 jobs:
   end_to_end_tests:


### PR DESCRIPTION
### What changed and why

Update triggers for the integration tests GitHub Action so that it runs for pull requests and also prior to a group of changes being merged via the merge queue. By running the integration tests in the merge queue it helps to ensure that changes being merged into `main` haven't caused regressions.