### PR TITLE
OLH-3095 alarm when there is a traffic spike

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2116,6 +2116,39 @@ Resources:
             Period: 60
             Stat: Maximum
 
+  # Traffic spike detection (low severity)
+  # Triggers when API Gateway request count increases by >=1000 in the current 5-minute period compared to the previous 5-minute period
+  # and only when the current 5-minute period has >1000 requests to avoid noise on low traffic.
+  ApiGatewayTrafficSpikeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ApiGatewayTrafficSpikeAlarm"
+      AlarmDescription: "Alert when API Gateway requests increase by >=1000 vs previous 5 minutes, only if current 5-minute Count > 1000. Period=300s"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1000
+      TreatMissingData: missing
+      Metrics:
+        - Id: spike
+          Label: spikeIncrease
+          ReturnData: true
+          Expression: IF((m1>1000) AND (DIFF(m1)>0), DIFF(m1), 0)
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGateway
+            Period: 300
+            Stat: Sum
+
   LoggerErrorsFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -2126,6 +2159,39 @@ Resources:
           MetricNamespace: !Sub "${AWS::StackName}/Logger"
           MetricValue: "1"
           Unit: Count
+
+  # ALB traffic spike detection (low severity)
+  # Triggers when ALB RequestCount increases by >=1000 in the current 5-minute period compared to the previous 5-minute period
+  # and only when the current 5-minute period has >1000 requests to avoid noise on low traffic.
+  ALBTrafficSpikeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ALBTrafficSpikeAlarm"
+      AlarmDescription: "Alert when ALB RequestCount increases by >=1000 vs previous 5 minutes, only if current 5-minute count > 1000. Period=300s"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1000
+      TreatMissingData: missing
+      Metrics:
+        - Id: spike
+          Label: spikeIncrease
+          ReturnData: true
+          Expression: IF((m1>1000) AND (DIFF(m1)>0), DIFF(m1), 0)
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: RequestCount
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref ApplicationLoadBalancer
+            Period: 300
+            Stat: Sum
 
   LoggerErrorRateAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes

### What changed

Add new alarms when we experience a traffic spike

### Why did it change

On 30th July, Home was being used a springboard to initiate nefarious activity in One Login. During that time our requests increased from 1000 requests in 5 mins to 7500 requests in 5mins.  Therefore, we want to create a Low Severity alarms to be aware of large increase in traffic to be able to proactively be made aware of the occurance

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

### Testing

I created the alarms in dev, ran a load test and verified that the alarm was triggered 

<img width="885" height="603" alt="Screenshot 2025-09-03 at 16 23 21" src="https://github.com/user-attachments/assets/18211a03-5706-4b25-bad8-db43d6950fc3" />

I also verified that the notification was sent to the slack channel

<img width="755" height="464" alt="Screenshot 2025-09-03 at 16 26 14" src="https://github.com/user-attachments/assets/7b38b3dc-48ae-4a5d-9d5b-f970ede6d8a2" />

I waited a few minutes, and verified that the alarm returned to an OK state

<img width="895" height="623" alt="Screenshot 2025-09-03 at 16 28 54" src="https://github.com/user-attachments/assets/00ea3c9b-ea3c-4744-ab43-44195498d0ae" />

### Sign-offs

<!-- New Node.JS/NPM dependencies need to be approved by a Lead Developer or Lead SRE: https://govukverify.atlassian.net/wiki/spaces/DIWAY/pages/4335697997/Library+approval+process -->
<!-- Delete if changes do NOT include any new libraries -->

- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE
  <!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
  <!-- Delete if changes do NOT include any design updates -->
- [ ] Design updates have been signed off by a member of the UCD team
<!-- Delete if changes do NOT include any analytics updates -->
- [ ] Analytics updates have been signed off by a PA

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
