### PR TITLE
OLH-3047 Add request count alarms and policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -390,6 +390,53 @@ Resources:
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
 
+  ALBRequestCountScaleOutPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ALBRequestCountScaleOutPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref ECSCluster
+          - !GetAtt ContainerService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 30
+        StepAdjustments:
+          - MetricIntervalLowerBound: 0
+            MetricIntervalUpperBound: 100
+            ScalingAdjustment: 1 # Add 1 task if requests are 201–300
+          - MetricIntervalLowerBound: 100
+            MetricIntervalUpperBound: 300
+            ScalingAdjustment: 2 # Add 2 tasks if requests are 301–500
+          - MetricIntervalLowerBound: 300
+            ScalingAdjustment: 3 # Add 3 tasks if requests > 500
+
+  ALBRequestCountScaleInPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ALBRequestCountScaleInPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref ECSCluster
+          - !GetAtt ContainerService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 30
+        StepAdjustments:
+          - MetricIntervalUpperBound: -100
+            ScalingAdjustment: -2 # Requests < 100
+          - MetricIntervalLowerBound: -100
+            MetricIntervalUpperBound: 0
+            ScalingAdjustment: -1 # Requests between 100–200
+
   ECSStepScaleOutPolicy:
     DependsOn: ContainerAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
@@ -486,6 +533,50 @@ Resources:
       Statistic: "Average"
       Period: "60"
       Threshold: "30"
+
+  ALBRequestCountScaleOutAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: "ALB-RequestCount-High"
+      MetricName: "RequestCount"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref ALBRequestCountScaleOutPolicy
+      AlarmDescription: "ALB-RequestCount-Above-200"
+      DatapointsToAlarm: "1"
+      Namespace: AWS/ApplicationELB
+      ComparisonOperator: "GreaterThanThreshold"
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApplicationLoadBalancer.LoadBalancerFullName
+      Statistic: Sum
+      Period: "60"
+      EvaluationPeriods: 1
+      Threshold: "2000"
+      TreatMissingData: "notBreaching"
+
+  ALBRequestCountScaleInAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: "ALB-RequestCount-Normal"
+      MetricName: "RequestCountPerTarget"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref ALBRequestCountScaleInPolicy
+      AlarmDescription: "ALB-RequestCount-Below-200"
+      DatapointsToAlarm: "1"
+      Namespace: AWS/ApplicationELB
+      ComparisonOperator: "LessThanThreshold"
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ApplicationLoadBalancer.LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !Ref ContainerAutoScalingTarget
+      Statistic: Sum
+      Period: "60"
+      EvaluationPeriods: 1
+      Threshold: "1000"
+      TreatMissingData: "notBreaching"
 
   ContainerServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
## Proposed changes

OLH-3047 Add ALB Request count scaling alarm and policies

### What changed

Added metric and alarms for when requests per minute on an ALB target is above a given threshold
Added scale out an din policy when the alarms are triggered

### Why did it change

So that we can pro-actively scale out based on an increased request count

### Related links


## Checklists

### Environment variables or secrets


### Testing

Ensure deployment to dev is successful
Verify the scaling policy on the dev environment by looking at the auto scaling configuration in the AWS console

### Sign-offs

## How to review