### PR TITLE
OLH-3169: recreate search index on each request

### DIFF
--- a/src/components/search-services/search-services-controller.ts
+++ b/src/components/search-services/search-services-controller.ts
@@ -45,12 +45,6 @@ export const getAllServices = (translate: Request["t"], locale: LOCALE) => {
 
 const indexes: Record<string, Index<true, false, true>> = {};
 
-// This is called on every GET request but because the indexes are module
-// scoped and are only created on the first request for a particular locale this
-// is okay. This first request is slightly slower as the index is created. Index
-// creation with ~10,000 items has been tested and the request time is acceptable.
-// ~100,000 is less acceptable but we are very unlikely to hit 10,000 items let alone
-// 100,000 items.
 export const createSearchIndex = async (
   locale: LOCALE,
   services: ReturnType<typeof getAllServices>
@@ -59,66 +53,15 @@ export const createSearchIndex = async (
     tokenize: "forward",
   });
 
-  const lotsOfServices = [
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-    ...services,
-  ];
-
   await Promise.all(
-    lotsOfServices.map((service, i) => {
+    services.map((service) => {
       const additionalSearchTerms =
         service.additionalSearchTerms !== ""
           ? ` ${service.additionalSearchTerms}`
           : "";
       return index.add(
-        `${service.clientId}_${i}`,
-        `${i}${service.startText}${additionalSearchTerms}`
+        service.clientId,
+        `${service.startText}${additionalSearchTerms}`
       );
     })
   );


### PR DESCRIPTION
No longer reuses the indexes in the module scope but recreates them on every request. This is necessary because the contents of the index may need to change from one request to the next because the date and time for a particular client to show in the searchable list has been reached.

At time of writing these changes are deployed to dev and can be tested at https://home.dev.account.gov.uk/services-using-one-login.