### PR TITLE
BAU: Increase traffic spike alarm threshold to 2500

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2217,26 +2217,26 @@ Resources:
             Stat: Maximum
 
   # Traffic spike detection (low severity)
-  # Triggers when API Gateway request count increases by >=1000 in the current 5-minute period compared to the previous 5-minute period
-  # and only when the current 5-minute period has >1000 requests to avoid noise on low traffic.
+  # Triggers when API Gateway request count increases by >=2500 in the current 5-minute period compared to the previous 5-minute period
+  # and only when the current 5-minute period has >2500 requests to avoid noise on low traffic.
   ApiGatewayTrafficSpikeAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-ApiGatewayTrafficSpikeAlarm"
-      AlarmDescription: "Alert when API Gateway requests increase by >=1000 vs previous 5 minutes, only if current 5-minute Count > 1000. Period=300s"
+      AlarmDescription: "Alert when API Gateway requests increase by >=2500 vs previous 5 minutes, only if current 5-minute Count > 2500. Period=300s"
       ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: 1000
+      Threshold: 2500
       TreatMissingData: missing
       Metrics:
         - Id: spike
           Label: spikeIncrease
           ReturnData: true
-          Expression: IF((m1>1000) AND (DIFF(m1)>0), DIFF(m1), 0)
+          Expression: IF((m1>2500) AND (DIFF(m1)>0), DIFF(m1), 0)
         - Id: m1
           ReturnData: false
           MetricStat:


### PR DESCRIPTION



## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Increase the threshold on the traffic spike alarm so that it will only alarm if the last 5 minutes have 2500 or more requests than the preceding 5 minutes.

### Why did it change

Hopefully this will mean the alarm only goes off for a 'real' traffic spike.

The alarm was constantly triggering on our normal traffic levels and wasn't useful. I ran the below query in Splunk to see the 5 minute traffic level difference over the last 72 hours. It's often higher than 1000 (as I expected with the alarm triggering) but it never goes above 2500.

```
index=gds_di_production source=*026991849909*
sourcetype="aws:cloudwatchlogs:api-access-logs"
"home.account.gov.uk" |
bucket _time span=5m |
stats count by _time |
delta count |
where isnotnull(count)
```

<img width="1725" height="319" alt="image" src="https://github.com/user-attachments/assets/6bc0ddfd-14b5-4467-a29d-57488f4f89c7" />
Blue is the requests per 5 minutes, and pink is the difference to the previous period.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
