### PR TITLE
OLH-4020: Update rp registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5526,7 +5526,7 @@
     },
     "node_modules/di-account-management-rp-registry": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#7af0fe5c7c3c5d4d5f1cd6b05dc8966568e56492",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#749cd8c4e211f2b362301d1bb638a68993d45964",
       "license": "ISC"
     },
     "node_modules/dijkstrajs": {


### PR DESCRIPTION
Bump rp registry to latest version including this update https://github.com/govuk-one-login/di-account-management-rp-registry/pull/255 