### PR TITLE
BAU: disable passkeys in staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -266,7 +266,7 @@ Mappings:
       AMCTOKENURL: "https://2hdyiuvtug.execute-api.eu-west-2.amazonaws.com/v1/token"
       AMCCLIENTID: "63385eefbc1649f9bc50eb9fd7c04de0" # pragma: allowlist secret
       ENABLEPKCE: "1"
-      PASSKEYS: "1"
+      PASSKEYS: "0"
     integration:
       NODEENV: "production"
       APIBASEURL: "https://oidc.integration.account.gov.uk"


### PR DESCRIPTION
Disables passkeys in staging which is currently breaking account management functionality as the passkeys endpoints are not yet available in staging