### PR TITLE
[OLH-3710] Add OPL settings for passkey journeys

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -23,6 +23,7 @@ import {
   CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
   DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
   setOplSettings,
+  PASSKEYS_COMMON_OPL_SETTINGS,
 } from "../../utils/opl.js";
 import {
   mfaMethodTypes,
@@ -114,6 +115,14 @@ const getOplValues = (): OplSettingsLookupObject => ({
   },
   [UserJourney.GlobalLogout]: {
     contentId: "cefa908b-d774-4da4-b8df-3d4bc6ec3323",
+  },
+  [UserJourney.CreatePasskey]: {
+    contentId: "8da218a5-f0a4-4e43-aa0c-a83a389742ee",
+    ...PASSKEYS_COMMON_OPL_SETTINGS,
+  },
+  [UserJourney.RemovePasskey]: {
+    contentId: "87a6d285-f42a-43ba-8d24-88a9febacd1a",
+    ...PASSKEYS_COMMON_OPL_SETTINGS,
   },
 });
 

--- a/src/components/remove-passkey/remove-passkey-controller.ts
+++ b/src/components/remove-passkey/remove-passkey-controller.ts
@@ -7,6 +7,10 @@ import {
 import { formatPasskeysForRender } from "../../utils/passkeys/index.js";
 import { getLastNDigits } from "../../utils/phone-number.js";
 import { EventType, getNextState } from "../../utils/state-machine.js";
+import {
+  PASSKEYS_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl.js";
 
 export async function removePasskeyGet(
   req: Request,
@@ -27,6 +31,14 @@ export async function removePasskeyGet(
   const hasAlternativePasskey = passkeys.data.length > 1;
   const defaultMfaMethod = req.session.mfaMethods.find(
     (method) => method.priorityIdentifier === "DEFAULT"
+  );
+
+  setOplSettings(
+    {
+      ...PASSKEYS_COMMON_OPL_SETTINGS,
+      contentId: "b75a90f1-0f70-4908-8661-fc89fb64c67d",
+    },
+    res
   );
 
   res.render("remove-passkey/index.njk", {

--- a/src/components/remove-passkey/tests/remove-passkey-controller.test.ts
+++ b/src/components/remove-passkey/tests/remove-passkey-controller.test.ts
@@ -57,6 +57,9 @@ describe("removePasskeyGet", () => {
     const res = {
       render: vi.fn(),
       status: vi.fn(),
+      locals: {
+        opl: {},
+      },
     };
 
     await removePasskeyGet(
@@ -107,6 +110,7 @@ describe("removePasskeyGet", () => {
     const res = {
       render: vi.fn(),
       status: vi.fn(),
+      locals: { opl: {} },
     };
 
     await removePasskeyGet(

--- a/src/components/sign-in-details/sign-in-details-controller.ts
+++ b/src/components/sign-in-details/sign-in-details-controller.ts
@@ -9,6 +9,10 @@ import {
   mapMfaMethods,
   canChangePrimaryMethod,
 } from "../../utils/mfa/index.js";
+import {
+  PASSKEYS_COMMON_OPL_SETTINGS,
+  setOplSettings,
+} from "../../utils/opl.js";
 
 export async function signInDetailsGet(
   req: Request,
@@ -39,6 +43,14 @@ export async function signInDetailsGet(
     : false;
 
   const formattedPasskeys = await formatPasskeysForRender(req, passkeys.data);
+
+  setOplSettings(
+    {
+      contentId: "e675b9e8-2bfd-43d8-bf43-1f4868a93630",
+      ...PASSKEYS_COMMON_OPL_SETTINGS,
+    },
+    res
+  );
 
   res.render("sign-in-details/index.njk", {
     email,

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -13,6 +13,7 @@ import {
   CHANGE_PASSWORD_COMMON_OPL_SETTINGS,
   DELETE_ACCOUNT_COMMON_OPL_SETTINGS,
   setOplSettings,
+  PASSKEYS_COMMON_OPL_SETTINGS,
 } from "../../utils/opl.js";
 import {
   mfaMethodTypes,
@@ -338,6 +339,14 @@ export async function createPasskeyConfirmationGet(
     ? summaryHtml + req.t("pages.createPasskeyConfirmation.firstPasskey")
     : summaryHtml;
 
+  setOplSettings(
+    {
+      ...PASSKEYS_COMMON_OPL_SETTINGS,
+      contentId: "f1643694-9bf5-4657-a99b-16f1daee2bc7",
+    },
+    res
+  );
+
   res.render("update-confirmation/index.njk", {
     pageTitle: req.t("pages.createPasskeyConfirmation.title"),
     panelText: req.t("pages.createPasskeyConfirmation.panelText"),
@@ -357,6 +366,14 @@ export async function removePasskeyConfirmationGet(
   const summaryText = hasPasskeys
     ? req.t("pages.removePasskeyConfirmation.summaryText")
     : req.t("pages.removePasskeyConfirmation.summaryTextNoPasskeys");
+
+  setOplSettings(
+    {
+      ...PASSKEYS_COMMON_OPL_SETTINGS,
+      contentId: "fe8c2df3-63b0-47d5-860b-b96a17e527f6",
+    },
+    res
+  );
 
   res.render("update-confirmation/index.njk", {
     pageTitle: req.t("pages.removePasskeyConfirmation.title"),

--- a/src/utils/opl.ts
+++ b/src/utils/opl.ts
@@ -30,6 +30,10 @@ export const ACTIVITY_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
   taxonomyLevel2: "activity",
 };
 
+export const PASSKEYS_COMMON_OPL_SETTINGS: Partial<OplSettings> = {
+  taxonomyLevel3: "passkeys",
+};
+
 export const setOplSettings = (
   settings: Partial<OplSettings> | undefined,
   res: Response


### PR DESCRIPTION
Added OPL settings for passkey journeys, including the creation and removal of passkeys. Updated relevant routes to utilize the new settings.

