### PR TITLE
OLH-3966: set ADAPI token from userinfo

### DIFF
--- a/src/components/change-email/tests/change-email-controller.test.ts
+++ b/src/components/change-email/tests/change-email-controller.test.ts
@@ -4,6 +4,7 @@ import { changeEmailGet, changeEmailPost } from "../change-email-controller.js";
 import { ChangeEmailServiceInterface } from "../types";
 import { HTTP_STATUS_CODES } from "../../../app.constants";
 import {
+  ACCOUNT_DATA_API_ACCESS_TOKEN,
   CLIENT_SESSION_ID,
   CURRENT_EMAIL,
   ENGLISH,
@@ -93,7 +94,7 @@ describe("change email controller", () => {
       expect(fakeService.sendCodeVerificationNotification).toHaveBeenCalledWith(
         NEW_EMAIL,
         {
-          accountDataApiToken: "TODO",
+          accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
           token: TOKEN,
           sourceIp: SOURCE_IP,
           sessionId: SESSION_ID,

--- a/src/components/change-password/tests/change-password-controller.test.ts
+++ b/src/components/change-password/tests/change-password-controller.test.ts
@@ -14,6 +14,7 @@ import {
   PATH_DATA,
 } from "../../../app.constants";
 import {
+  ACCOUNT_DATA_API_ACCESS_TOKEN,
   CLIENT_SESSION_ID,
   CURRENT_EMAIL,
   ENGLISH,
@@ -72,7 +73,6 @@ describe("change password controller", () => {
   describe("changePasswordPost", () => {
     it("should redirect to /password-updated-confirmation page", async () => {
       // Arrange
-      req.session.user.tokens = { accessToken: "token" } as any;
       req.session.user.state.changePassword.value = "CHANGE_VALUE";
       req.body.password = "Password1";
 
@@ -88,7 +88,7 @@ describe("change password controller", () => {
         CURRENT_EMAIL,
         "Password1",
         {
-          accountDataApiToken: "TODO",
+          accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
           token: TOKEN,
           sourceIp: SOURCE_IP,
           sessionId: SESSION_ID,
@@ -135,7 +135,6 @@ describe("change password controller", () => {
           message: "",
         }),
       };
-      req.session.user.tokens = { accessToken: "token" } as any;
 
       // Act
       await changePasswordPost(fakeFailingChangePasswordService)(

--- a/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
+++ b/src/components/change-phone-number/tests/change-phone-number-controller.test.ts
@@ -17,6 +17,7 @@ import {
   SESSION_ID,
   SOURCE_IP,
   TOKEN,
+  ACCOUNT_DATA_API_ACCESS_TOKEN,
   TXMA_AUDIT_ENCODED,
 } from "../../../../test/utils/builders";
 import * as oidcModule from "../../../utils/oidc.js";
@@ -77,7 +78,7 @@ describe("change phone number controller", () => {
       expect(
         fakeService.sendPhoneVerificationNotification
       ).toHaveBeenCalledWith(CURRENT_EMAIL, "12345678991", "DEFAULT", {
-        accountDataApiToken: "TODO",
+        accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
         token: TOKEN,
         sourceIp: SOURCE_IP,
         sessionId: SESSION_ID,
@@ -99,7 +100,6 @@ describe("change phone number controller", () => {
           code: ERROR_CODES.NEW_PHONE_NUMBER_SAME_AS_EXISTING,
         }),
       };
-      req.session.user.tokens = { accessToken: "token" } as any;
       req.body.phoneNumber = "12345678991";
 
       // Act
@@ -110,7 +110,7 @@ describe("change phone number controller", () => {
       expect(
         fakeService.sendPhoneVerificationNotification
       ).toHaveBeenCalledWith(CURRENT_EMAIL, "12345678991", "DEFAULT", {
-        accountDataApiToken: "TODO",
+        accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
         token: TOKEN,
         sourceIp: SOURCE_IP,
         sessionId: SESSION_ID,
@@ -156,7 +156,7 @@ describe("change phone number controller", () => {
       expect(
         fakeService.sendPhoneVerificationNotification
       ).toHaveBeenCalledWith(CURRENT_EMAIL, "12345678991", "DEFAULT", {
-        accountDataApiToken: "TODO",
+        accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
         token: TOKEN,
         sourceIp: SOURCE_IP,
         sessionId: SESSION_ID,
@@ -203,7 +203,7 @@ describe("change phone number controller", () => {
       expect(
         fakeService.sendPhoneVerificationNotification
       ).toHaveBeenCalledWith(CURRENT_EMAIL, "+33645453322", "DEFAULT", {
-        accountDataApiToken: "TODO",
+        accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
         token: TOKEN,
         sourceIp: SOURCE_IP,
         sessionId: SESSION_ID,

--- a/src/components/oidc-callback/call-back-utils.ts
+++ b/src/components/oidc-callback/call-back-utils.ts
@@ -135,6 +135,7 @@ export function populateSessionWithUserInfo(
       idToken: tokenSet.id_token,
       accessToken: tokenSet.access_token,
       refreshToken: tokenSet.refresh_token,
+      accountDataApiAccessToken: userInfoResponse.account_data_api_access_token,
     },
     isAuthenticated: true,
     state: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ interface UserTokens {
   idToken: string;
   accessToken: string;
   refreshToken: string;
+  accountDataApiAccessToken?: string;
 }
 
 type UserState = Partial<Record<UserJourney, StateAction>>;

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -35,7 +35,7 @@ export function createApiResponse(
 
 export interface RequestConfig {
   token: string;
-  accountDataApiToken?: string;
+  accountDataApiAccessToken?: string;
   validationStatuses?: number[];
   sourceIp?: string;
   persistentSessionId?: string;
@@ -53,7 +53,8 @@ export async function getRequestConfigFromExpress(
 
   return {
     token: req.session.user.tokens.accessToken,
-    accountDataApiToken: "TODO",
+    accountDataApiAccessToken:
+      req.session.user.tokens.accountDataApiAccessToken,
     sourceIp: req.ip,
     sessionId: res.locals.sessionId,
     persistentSessionId: res.locals.persistentSessionId,
@@ -65,7 +66,7 @@ export async function getRequestConfigFromExpress(
 
 export function getRequestConfig({
   token,
-  accountDataApiToken,
+  accountDataApiAccessToken,
   validationStatuses,
   sourceIp,
   persistentSessionId,
@@ -81,8 +82,8 @@ export function getRequestConfig({
     proxy: false,
   };
 
-  if (accountDataApiToken) {
-    config.headers["X-ADAPI-AccessToken"] = accountDataApiToken;
+  if (accountDataApiAccessToken) {
+    config.headers["X-ADAPI-AccessToken"] = accountDataApiAccessToken;
   }
 
   if (validationStatuses) {

--- a/src/utils/test/http.test.ts
+++ b/src/utils/test/http.test.ts
@@ -67,7 +67,7 @@ describe("getRequestConfig", () => {
   it("returns basic config with required headers", () => {
     const config = getRequestConfig({
       token: "test-token",
-      accountDataApiToken: "api-token",
+      accountDataApiAccessToken: "api-token",
     });
 
     expect(config).toEqual({
@@ -79,7 +79,7 @@ describe("getRequestConfig", () => {
     });
   });
 
-  it("returns config without X-ADAPI-AccessToken when accountDataApiToken is not provided", () => {
+  it("returns config without X-ADAPI-AccessToken when accountDataApiAccessToken is not provided", () => {
     const config = getRequestConfig({
       token: "test-token",
     });
@@ -108,7 +108,7 @@ describe("getRequestConfig", () => {
   it("includes optional headers when provided", () => {
     const config = getRequestConfig({
       token: "test-token",
-      accountDataApiToken: "api-token",
+      accountDataApiAccessToken: "api-token",
       sourceIp: "192.168.1.1",
       persistentSessionId: "persistent-123",
       sessionId: "session-123",
@@ -129,7 +129,7 @@ describe("getRequestConfig", () => {
     });
   });
 
-  it("excludes X-ADAPI-AccessToken when accountDataApiToken is not provided", () => {
+  it("excludes X-ADAPI-AccessToken when accountDataApiAccessToken is not provided", () => {
     const config = getRequestConfig({
       token: "test-token",
       sourceIp: "192.168.1.1",
@@ -171,7 +171,10 @@ describe("getRequestConfigFromExpress", () => {
   });
 
   it("returns the expected request config", async () => {
-    (req.session as any).user.tokens = { accessToken: "token" } as any;
+    (req.session as any).user.tokens = {
+      accessToken: "token",
+      accountDataApiAccessToken: "accountDataApiAccessToken",
+    } as any;
 
     const requestConfig = await getRequestConfigFromExpress(
       req as Request,
@@ -180,7 +183,7 @@ describe("getRequestConfigFromExpress", () => {
 
     expect(requestConfig).toEqual({
       token: "token",
-      accountDataApiToken: "TODO",
+      accountDataApiAccessToken: "accountDataApiAccessToken",
       clientSessionId: "clientsessionid",
       persistentSessionId: "persistentsessionid",
       sessionId: "sessionid",

--- a/test/utils/builders.ts
+++ b/test/utils/builders.ts
@@ -6,6 +6,7 @@ import { IncomingHttpHeaders } from "http";
 export const CURRENT_EMAIL = "current-email@dl.com";
 export const NEW_EMAIL = "new-email@test.com";
 export const TOKEN = "token";
+export const ACCOUNT_DATA_API_ACCESS_TOKEN = "accountDataApiAccessToken";
 export const SOURCE_IP = "sourceip";
 export const ENGLISH = "en";
 
@@ -23,6 +24,7 @@ export class RequestBuilder {
         accessToken: TOKEN,
         idToken: "",
         refreshToken: "",
+        accountDataApiAccessToken: ACCOUNT_DATA_API_ACCESS_TOKEN,
       },
       email: CURRENT_EMAIL,
       state: { changeEmail: getInitialState() },


### PR DESCRIPTION
If the `/userinfo` endpoint returns an account data API token claim then save the token to the user's session and then use this token in the `X-ADAPI-AccessToken` header when making API requests.