### PR TITLE
OLH-4070: GET passkeys data shape fix

### DIFF
--- a/src/components/create-new-passkey/create-new-passkey-controller.ts
+++ b/src/components/create-new-passkey/create-new-passkey-controller.ts
@@ -11,7 +11,7 @@ export async function createNewPasskeyGet(
   const mfaClient = await createMfaClient(req, res);
   const passkeys = await mfaClient.getPasskeys();
 
-  if (passkeys.data.length >= maxNumberOfPasskeys) {
+  if (passkeys.data.passkeys.length >= maxNumberOfPasskeys) {
     res.redirect(PATH_DATA.SIGN_IN_DETAILS.url);
     return;
   }

--- a/src/components/create-new-passkey/tests/create-new-passkey-controller.test.ts
+++ b/src/components/create-new-passkey/tests/create-new-passkey-controller.test.ts
@@ -31,7 +31,7 @@ describe("createNewPasskeyGet", () => {
 
   it("should redirect to start page when passkeys are at max limit", async () => {
     mfaClientStub.getPasskeys.mockResolvedValue({
-      data: new Array(maxNumberOfPasskeys),
+      data: { passkeys: new Array(maxNumberOfPasskeys) },
     });
 
     await createNewPasskeyGet(req as Request, res as Response);
@@ -44,7 +44,7 @@ describe("createNewPasskeyGet", () => {
 
   it("should redirect to start page when passkeys exceed max limit", async () => {
     mfaClientStub.getPasskeys.mockResolvedValue({
-      data: new Array(maxNumberOfPasskeys + 1),
+      data: { passkeys: new Array(maxNumberOfPasskeys + 1) },
     });
 
     await createNewPasskeyGet(req as Request, res as Response);
@@ -57,7 +57,7 @@ describe("createNewPasskeyGet", () => {
 
   it("should initiate AMC redirect with passkey-create scope when under max passkeys", async () => {
     mfaClientStub.getPasskeys.mockResolvedValue({
-      data: [],
+      data: { passkeys: [] },
     });
 
     await createNewPasskeyGet(req as Request, res as Response);
@@ -72,7 +72,7 @@ describe("createNewPasskeyGet", () => {
 
   it("should initiate AMC redirect when passkeys are one below max", async () => {
     mfaClientStub.getPasskeys.mockResolvedValue({
-      data: new Array(maxNumberOfPasskeys - 1),
+      data: { passkeys: new Array(maxNumberOfPasskeys - 1) },
     });
 
     await createNewPasskeyGet(req as Request, res as Response);

--- a/src/components/remove-passkey/remove-passkey-controller.ts
+++ b/src/components/remove-passkey/remove-passkey-controller.ts
@@ -19,7 +19,7 @@ export async function removePasskeyGet(
   const mfaClient = await createMfaClient(req, res);
   const passkeys = await mfaClient.getPasskeys();
 
-  const passkey = passkeys.data.find((p) => p.id === req.query.id);
+  const passkey = passkeys.data.passkeys.find((p) => p.id === req.query.id);
 
   if (!passkey) {
     res.status(404);
@@ -28,7 +28,7 @@ export async function removePasskeyGet(
 
   const formattedPasskey = (await formatPasskeysForRender(req, [passkey]))[0];
 
-  const hasAlternativePasskey = passkeys.data.length > 1;
+  const hasAlternativePasskey = passkeys.data.passkeys.length > 1;
   const defaultMfaMethod = req.session.mfaMethods.find(
     (method) => method.priorityIdentifier === "DEFAULT"
   );

--- a/src/components/remove-passkey/tests/remove-passkey-controller.test.ts
+++ b/src/components/remove-passkey/tests/remove-passkey-controller.test.ts
@@ -28,20 +28,22 @@ describe("removePasskeyGet", () => {
   it("should render remove passkey confirmation page when there is another passkey", async () => {
     const mfaClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [
-          {
-            id: "12345",
-            lastUsedAt: "2024-01-01T00:00:00Z",
-            createdAt: "2024-01-01T00:00:00Z",
-            metadata: { name: "Test Passkey", aaguid: "aaguid" },
-          },
-          {
-            id: "67890",
-            lastUsedAt: "2024-01-01T00:01:00Z",
-            createdAt: "2024-01-01T00:01:00Z",
-            metadata: { name: "Test Passkey 2", aaguid: "aaguid2" },
-          },
-        ],
+        data: {
+          passkeys: [
+            {
+              id: "12345",
+              lastUsedAt: "2024-01-01T00:00:00Z",
+              createdAt: "2024-01-01T00:00:00Z",
+              metadata: { name: "Test Passkey", aaguid: "aaguid" },
+            },
+            {
+              id: "67890",
+              lastUsedAt: "2024-01-01T00:01:00Z",
+              createdAt: "2024-01-01T00:01:00Z",
+              metadata: { name: "Test Passkey 2", aaguid: "aaguid2" },
+            },
+          ],
+        },
       }),
     };
 
@@ -79,14 +81,16 @@ describe("removePasskeyGet", () => {
   it("should render remove passkey confirmation page when there is no other passkey but there is another mfa method", async () => {
     const mfaClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [
-          {
-            id: "12345",
-            lastUsedAt: "2024-01-01T00:00:00Z",
-            createdAt: "2024-01-01T00:00:00Z",
-            metadata: { name: "Test Passkey", aaguid: "aaguid" },
-          },
-        ],
+        data: {
+          passkeys: [
+            {
+              id: "12345",
+              lastUsedAt: "2024-01-01T00:00:00Z",
+              createdAt: "2024-01-01T00:00:00Z",
+              metadata: { name: "Test Passkey", aaguid: "aaguid" },
+            },
+          ],
+        },
       }),
     };
 
@@ -130,7 +134,7 @@ describe("removePasskeyGet", () => {
   it("should return 404 when passkey is not found", async () => {
     const mfaClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [],
+        data: { passkeys: [] },
       }),
     };
 

--- a/src/components/sign-in-details/sign-in-details-controller.ts
+++ b/src/components/sign-in-details/sign-in-details-controller.ts
@@ -42,6 +42,9 @@ export async function signInDetailsGet(
     ? canChangePrimaryMethod(req.session.mfaMethods)
     : false;
 
+  console.log("MHTEST1", passkeys);
+  console.log("MHTEST2", passkeys.data);
+
   const formattedPasskeys = await formatPasskeysForRender(req, passkeys.data);
 
   setOplSettings(

--- a/src/components/sign-in-details/sign-in-details-controller.ts
+++ b/src/components/sign-in-details/sign-in-details-controller.ts
@@ -42,10 +42,10 @@ export async function signInDetailsGet(
     ? canChangePrimaryMethod(req.session.mfaMethods)
     : false;
 
-  console.log("MHTEST1", passkeys);
-  console.log("MHTEST2", passkeys.data);
-  console.log("MHTEST3", JSON.stringify(passkeys.data, null, 2));
-  console.log("MHTEST4", passkeys.status);
+  req.log.info("MHTEST1", passkeys);
+  req.log.info("MHTEST2", passkeys.data);
+  req.log.info("MHTEST3", JSON.stringify(passkeys.data, null, 2));
+  req.log.info("MHTEST4", passkeys.status);
 
   const formattedPasskeys = await formatPasskeysForRender(req, passkeys.data);
 

--- a/src/components/sign-in-details/sign-in-details-controller.ts
+++ b/src/components/sign-in-details/sign-in-details-controller.ts
@@ -44,6 +44,8 @@ export async function signInDetailsGet(
 
   console.log("MHTEST1", passkeys);
   console.log("MHTEST2", passkeys.data);
+  console.log("MHTEST3", JSON.stringify(passkeys.data, null, 2));
+  console.log("MHTEST4", passkeys.status);
 
   const formattedPasskeys = await formatPasskeysForRender(req, passkeys.data);
 

--- a/src/components/sign-in-details/sign-in-details-controller.ts
+++ b/src/components/sign-in-details/sign-in-details-controller.ts
@@ -42,12 +42,10 @@ export async function signInDetailsGet(
     ? canChangePrimaryMethod(req.session.mfaMethods)
     : false;
 
-  req.log.info("MHTEST1", passkeys);
-  req.log.info("MHTEST2", passkeys.data);
-  req.log.info("MHTEST3", JSON.stringify(passkeys.data, null, 2));
-  req.log.info("MHTEST4", passkeys.status);
-
-  const formattedPasskeys = await formatPasskeysForRender(req, passkeys.data);
+  const formattedPasskeys = await formatPasskeysForRender(
+    req,
+    passkeys.data.passkeys
+  );
 
   setOplSettings(
     {

--- a/src/components/sign-in-details/tests/sign-in-details-controller.test.ts
+++ b/src/components/sign-in-details/tests/sign-in-details-controller.test.ts
@@ -12,6 +12,7 @@ describe("signInDetailsGet Controller", () => {
   let mockRender: any;
   let mockMetrics: any;
   let mockT: any;
+  let mockLog: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -22,6 +23,9 @@ describe("signInDetailsGet Controller", () => {
 
     mockRender = vi.fn();
     mockT = vi.fn((key: string) => key);
+    mockLog = {
+      info: vi.fn(),
+    };
 
     req = new RequestBuilder()
       .withSession({
@@ -43,6 +47,7 @@ describe("signInDetailsGet Controller", () => {
           },
         ],
       } as any)
+      .withLog(mockLog)
       .build();
 
     req.metrics = mockMetrics;
@@ -157,6 +162,7 @@ describe("signInDetailsGet Controller", () => {
 
   it("should handle missing metrics gracefully", async () => {
     delete req.metrics;
+    req.log = mockLog; // Ensure log is still available
 
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
@@ -185,6 +191,7 @@ describe("signInDetailsGet Controller", () => {
   it("should handle different email addresses", async () => {
     const testEmail = "different@example.com";
     req.session!.user.email = testEmail;
+    req.log = mockLog; // Ensure log is available
 
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
@@ -216,6 +223,7 @@ describe("signInDetailsGet Controller", () => {
 
   it("should handle non-array MFA methods", async () => {
     req.session!.mfaMethods = null as any;
+    req.log = mockLog; // Ensure log is available
 
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({

--- a/src/components/sign-in-details/tests/sign-in-details-controller.test.ts
+++ b/src/components/sign-in-details/tests/sign-in-details-controller.test.ts
@@ -12,7 +12,6 @@ describe("signInDetailsGet Controller", () => {
   let mockRender: any;
   let mockMetrics: any;
   let mockT: any;
-  let mockLog: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -23,9 +22,6 @@ describe("signInDetailsGet Controller", () => {
 
     mockRender = vi.fn();
     mockT = vi.fn((key: string) => key);
-    mockLog = {
-      info: vi.fn(),
-    };
 
     req = new RequestBuilder()
       .withSession({
@@ -47,7 +43,6 @@ describe("signInDetailsGet Controller", () => {
           },
         ],
       } as any)
-      .withLog(mockLog)
       .build();
 
     req.metrics = mockMetrics;
@@ -62,7 +57,7 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -90,7 +85,7 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -124,7 +119,7 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -162,12 +157,11 @@ describe("signInDetailsGet Controller", () => {
 
   it("should handle missing metrics gracefully", async () => {
     delete req.metrics;
-    req.log = mockLog; // Ensure log is still available
 
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -191,12 +185,11 @@ describe("signInDetailsGet Controller", () => {
   it("should handle different email addresses", async () => {
     const testEmail = "different@example.com";
     req.session!.user.email = testEmail;
-    req.log = mockLog; // Ensure log is available
 
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -223,12 +216,11 @@ describe("signInDetailsGet Controller", () => {
 
   it("should handle non-array MFA methods", async () => {
     req.session!.mfaMethods = null as any;
-    req.log = mockLog; // Ensure log is available
 
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -258,7 +250,7 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 

--- a/src/components/sign-in-details/tests/sign-in-details-integration.test.ts
+++ b/src/components/sign-in-details/tests/sign-in-details-integration.test.ts
@@ -98,9 +98,8 @@ describe("Integration:: signInDetails", () => {
 });
 
 const appWithMiddlewareSetup = async (config: any = {}) => {
-  const sessionMiddleware = await import(
-    "../../../middleware/requires-auth-middleware.js"
-  );
+  const sessionMiddleware =
+    await import("../../../middleware/requires-auth-middleware.js");
   const oidc = await import("../../../utils/oidc.js");
   const mfa = await import("../../../utils/mfaClient/index.js");
 
@@ -184,7 +183,9 @@ const appWithMiddlewareSetup = async (config: any = {}) => {
 
   const stubMfaClient = {
     retrieve: vi.fn().mockResolvedValue({ success: true, data: mfaMethods }),
-    getPasskeys: vi.fn().mockResolvedValue({ success: true, data: passkeys }),
+    getPasskeys: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: { passkeys } }),
   };
 
   vi.spyOn(mfa, "createMfaClient").mockResolvedValue(stubMfaClient);

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -347,16 +347,18 @@ describe("createPasskeyConfirmationGet", () => {
   it("should render create passkey confirmation page", async () => {
     const mockClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [
-          {
-            credentialId: "credential-id-1",
-            aaguid: "aaguid",
-          },
-          {
-            credentialId: "credential-id-2",
-            aaguid: "aaguid-2",
-          },
-        ],
+        data: {
+          passkeys: [
+            {
+              credentialId: "credential-id-1",
+              aaguid: "aaguid",
+            },
+            {
+              credentialId: "credential-id-2",
+              aaguid: "aaguid-2",
+            },
+          ],
+        },
       }),
     };
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
@@ -372,16 +374,18 @@ describe("createPasskeyConfirmationGet", () => {
   it("should render create passkey confirmation page with convenience metadata", async () => {
     const mockClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [
-          {
-            credentialId: "credential-id-1",
-            aaguid: "aaguid",
-          },
-          {
-            credentialId: "credential-id-2",
-            aaguid: "aaguid-2",
-          },
-        ],
+        data: {
+          passkeys: [
+            {
+              credentialId: "credential-id-1",
+              aaguid: "aaguid",
+            },
+            {
+              credentialId: "credential-id-2",
+              aaguid: "aaguid-2",
+            },
+          ],
+        },
       }),
     };
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
@@ -408,12 +412,14 @@ describe("createPasskeyConfirmationGet", () => {
   it("should render create passkey confirmation page with extra info for the first passkey", async () => {
     const mockClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [
-          {
-            credentialId: "credential-id-1",
-            aaguid: "aaguid",
-          },
-        ],
+        data: {
+          passkeys: [
+            {
+              credentialId: "credential-id-1",
+              aaguid: "aaguid",
+            },
+          ],
+        },
       }),
     };
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
@@ -446,12 +452,14 @@ describe("removePasskeyConfirmationGet", () => {
   it("should render remove passkey confirmation page when the user has another passkey", async () => {
     const mockClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [
-          {
-            credentialId: "credential-id-1",
-            aaguid: "aaguid",
-          },
-        ],
+        data: {
+          passkeys: [
+            {
+              credentialId: "credential-id-1",
+              aaguid: "aaguid",
+            },
+          ],
+        },
       }),
     };
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
@@ -486,7 +494,7 @@ describe("removePasskeyConfirmationGet", () => {
   it("should render remove passkey confirmation page when the user has no other passkeys but has another mfa method", async () => {
     const mockClient: Partial<MfaClient> = {
       getPasskeys: vi.fn().mockResolvedValue({
-        data: [],
+        data: { passkeys: [] },
       }),
     };
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -319,7 +319,8 @@ export async function createPasskeyConfirmationGet(
   req.metrics?.addMetric("createPasskeyConfirmationGet", MetricUnit.Count, 1);
 
   const mfaClient = await createMfaClient(req, res);
-  const isFirstPasskey = (await mfaClient.getPasskeys()).data.length === 1;
+  const isFirstPasskey =
+    (await mfaClient.getPasskeys()).data.passkeys.length === 1;
 
   const passkeyName = (
     await getPasskeyConvenienceMetadataByAaguid(
@@ -361,7 +362,7 @@ export async function removePasskeyConfirmationGet(
   req.metrics?.addMetric("removePasskeyConfirmationGet", MetricUnit.Count, 1);
 
   const mfaClient = await createMfaClient(req, res);
-  const hasPasskeys = (await mfaClient.getPasskeys()).data.length > 0;
+  const hasPasskeys = (await mfaClient.getPasskeys()).data.passkeys.length > 0;
 
   const summaryText = hasPasskeys
     ? req.t("pages.removePasskeyConfirmation.summaryText")

--- a/src/utils/mfaClient/index.ts
+++ b/src/utils/mfaClient/index.ts
@@ -102,10 +102,9 @@ export class MfaClient implements MfaClientInterface {
   }
 
   async getPasskeys() {
-    const response = await this.http.client.get<Passkey[]>(
-      `/passkeys/${this.publicSubjectId}`,
-      this.requestConfig
-    );
+    const response = await this.http.client.get<{
+      passkeys: Passkey[];
+    }>(`/passkeys/${this.publicSubjectId}`, this.requestConfig);
 
     return buildResponse(response);
   }

--- a/src/utils/mfaClient/types.ts
+++ b/src/utils/mfaClient/types.ts
@@ -10,7 +10,7 @@ export interface MfaClientInterface {
   ) => Promise<ApiResponse<MfaMethod[]>>;
   delete: (method: MfaMethod) => Promise<ApiResponse<any>>;
   makeDefault: (mfaIdentifier: string) => Promise<ApiResponse<MfaMethod[]>>;
-  getPasskeys: () => Promise<ApiResponse<Passkey[]>>;
+  getPasskeys: () => Promise<ApiResponse<{ passkeys: Passkey[] }>>;
   deletePasskey: (passkeyIdentifier: string) => Promise<ApiResponse<any>>;
 }
 

--- a/test/utils/builders.ts
+++ b/test/utils/builders.ts
@@ -169,7 +169,6 @@ export class RequestBuilder {
       query: this.query as Request["query"],
       t: this.t as any,
       ip: this.ip,
-      log: this.log,
     };
   }
 }

--- a/test/utils/builders.ts
+++ b/test/utils/builders.ts
@@ -169,6 +169,7 @@ export class RequestBuilder {
       query: this.query as Request["query"],
       t: this.t as any,
       ip: this.ip,
+      log: this.log,
     };
   }
 }


### PR DESCRIPTION
Fix to handle GET passkeys response data in the format `{ passkeys: [...] }`. Before we were expecting a bare array which was incorrect and not in-line with the API spec