### PR TITLE
BAU: use correct alg in client assertion header

### DIFF
--- a/src/components/amc-callback/amc-callback-utils.ts
+++ b/src/components/amc-callback/amc-callback-utils.ts
@@ -108,7 +108,7 @@ export async function exchangeCodeForToken(
   const now = Math.floor(Date.now() / 1000);
 
   const header = {
-    alg: "RS256",
+    alg: "RS512",
     typ: "JWT",
     kid: kmsService.getPublicKey(),
   };


### PR DESCRIPTION
Use the correct alg in the client assertion header so it actually matches the algorithm used to sign it