### PR TITLE
BAU: fix cookie domain scoping

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -168,6 +168,7 @@ Mappings:
       AUTHFRONTENDURL: "signin.staging.account.gov.uk"
       ANALYTICSCOOKIEDOMAIN: "dev.account.gov.uk"
       SERVICEDOMAIN: "dev.account.gov.uk"
+      ROOTDOMAIN: "account.gov.uk"
       LOGSLEVEL: "debug"
       WEBCHATSOURCEURL: "https://dev-chat-loader-hgsgds.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
@@ -205,6 +206,7 @@ Mappings:
       AUTHFRONTENDURL: "signin.build.account.gov.uk"
       ANALYTICSCOOKIEDOMAIN: "build.account.gov.uk"
       SERVICEDOMAIN: "build.account.gov.uk"
+      ROOTDOMAIN: "account.gov.uk"
       LOGSLEVEL: "debug"
       WEBCHATSOURCEURL: "https://uat-chat-loader-hgsgds.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
@@ -242,6 +244,7 @@ Mappings:
       AUTHFRONTENDURL: "signin.staging.account.gov.uk"
       ANALYTICSCOOKIEDOMAIN: "staging.account.gov.uk"
       SERVICEDOMAIN: "staging.account.gov.uk"
+      ROOTDOMAIN: "account.gov.uk"
       LOGSLEVEL: "info"
       WEBCHATSOURCEURL: "https://uat-chat-loader-hgsgds.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
@@ -279,6 +282,7 @@ Mappings:
       AUTHFRONTENDURL: "signin.integration.account.gov.uk"
       ANALYTICSCOOKIEDOMAIN: "integration.account.gov.uk"
       SERVICEDOMAIN: "integration.account.gov.uk"
+      ROOTDOMAIN: "account.gov.uk"
       LOGSLEVEL: "info"
       WEBCHATSOURCEURL: "https://uat-chat-loader-hgsgds.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
@@ -316,6 +320,7 @@ Mappings:
       AUTHFRONTENDURL: "signin.account.gov.uk"
       ANALYTICSCOOKIEDOMAIN: "account.gov.uk"
       SERVICEDOMAIN: "account.gov.uk"
+      ROOTDOMAIN: "account.gov.uk"
       LOGSLEVEL: "info"
       WEBCHATSOURCEURL: "https://chat-loader-hgsgds.smartagent.app"
       SUPPORTWEBCHATCONTACT: "1"
@@ -822,6 +827,9 @@ Resources:
                   !Ref Environment,
                   SERVICEDOMAIN,
                 ]
+            - Name: "ROOT_DOMAIN"
+              Value:
+                !FindInMap [EnvironmentVariables, !Ref Environment, ROOTDOMAIN]
             - Name: "LOGS_LEVEL"
               Value:
                 !FindInMap [EnvironmentVariables, !Ref Environment, LOGSLEVEL]

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,6 +123,10 @@ export function getServiceDomain(): string {
   return process.env.SERVICE_DOMAIN ?? "";
 }
 
+export function getRootDomain(): string {
+  return process.env.ROOT_DOMAIN ?? "";
+}
+
 export function getAccessibilityStatementUrl(): string {
   return process.env.ACCESSIBILITY_STATEMENT_URL;
 }

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,5 +1,5 @@
 import { LOCALE } from "../app.constants.js";
-import { getServiceDomain } from "../config.js";
+import { getRootDomain } from "../config.js";
 import type { InitOptions } from "i18next";
 
 export function i18nextConfigurationOptions(): InitOptions {
@@ -15,7 +15,7 @@ export function i18nextConfigurationOptions(): InitOptions {
       caches: ["cookie"],
       ignoreCase: true,
       cookieSecure: true,
-      cookieDomain: getServiceDomain(),
+      cookieDomain: getRootDomain(),
       cookieSameSite: "",
     },
   };

--- a/src/utils/initiateAmcRedirect.test.ts
+++ b/src/utils/initiateAmcRedirect.test.ts
@@ -20,7 +20,7 @@ vi.mock("../config.js", () => ({
   getAmcAuthorizeUrl: vi.fn(() => "https://amc.example.com/authorize"),
   getAmcClientId: vi.fn(() => "test-client-id"),
   getHomeBaseUrl: vi.fn(() => "https://home.example.com"),
-  getServiceDomain: vi.fn(() => "example.com"),
+  getRootDomain: vi.fn(() => "example.com"),
   getAmcCallbackBaseUrl: vi.fn(() => "https://home.example.com"),
 }));
 
@@ -127,8 +127,8 @@ describe("initiateAmcRedirect", () => {
     );
   });
 
-  it("should set the cookie domain from getServiceDomain()", async () => {
-    vi.spyOn(config, "getServiceDomain").mockReturnValue("account.gov.uk");
+  it("should set the cookie domain from getRootDomain()", async () => {
+    vi.spyOn(config, "getRootDomain").mockReturnValue("account.gov.uk");
 
     await initiateAmcRedirect("openid email", req as Request, res as Response);
 

--- a/src/utils/initiateAmcRedirect.ts
+++ b/src/utils/initiateAmcRedirect.ts
@@ -5,7 +5,7 @@ import {
   getAmcAuthorizeUrl,
   getAmcCallbackBaseUrl,
   getAmcClientId,
-  getServiceDomain,
+  getRootDomain,
 } from "../config.js";
 import { PATH_DATA } from "../app.constants.js";
 
@@ -50,7 +50,7 @@ export async function initiateAmcRedirect(
     secure: true,
     httpOnly: true,
     sameSite: "strict",
-    domain: getServiceDomain(),
+    domain: getRootDomain(),
   });
 
   res.redirect(url.toString());

--- a/src/utils/test/initiateAmcRedirect-integration.test.ts
+++ b/src/utils/test/initiateAmcRedirect-integration.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../config.js", () => ({
   getAmcAuthorizeUrl: vi.fn(() => "https://amc.example.com/authorize"),
   getAmcClientId: vi.fn(() => "test-client-id"),
   getHomeBaseUrl: vi.fn(() => "https://home.example.com"),
-  getServiceDomain: vi.fn(() => "example.com"),
+  getRootDomain: vi.fn(() => "example.com"),
   getAmcCallbackBaseUrl: vi.fn(() => "https://home.example.com"),
 }));
 

--- a/test/unit/config/i18next.test.ts
+++ b/test/unit/config/i18next.test.ts
@@ -14,7 +14,7 @@ describe("i18next config", () => {
 
   describe("i18nextConfigurationOptions", () => {
     it("should return configuration object", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -23,7 +23,7 @@ describe("i18next config", () => {
     });
 
     it("should have debug set to false", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -31,7 +31,7 @@ describe("i18next config", () => {
     });
 
     it("should have fallbackLng set to EN", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -39,7 +39,7 @@ describe("i18next config", () => {
     });
 
     it("should have preload set to EN only", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -47,7 +47,7 @@ describe("i18next config", () => {
     });
 
     it("should have supportedLngs with EN and CY", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -55,7 +55,7 @@ describe("i18next config", () => {
     });
 
     it("should have detection configuration with lookupCookie", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -63,7 +63,7 @@ describe("i18next config", () => {
     });
 
     it("should have detection configuration with lookupQuerystring", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -71,7 +71,7 @@ describe("i18next config", () => {
     });
 
     it("should have detection order set to querystring then cookie", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -79,7 +79,7 @@ describe("i18next config", () => {
     });
 
     it("should have detection caches set to cookie", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -87,7 +87,7 @@ describe("i18next config", () => {
     });
 
     it("should have ignoreCase set to true", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -95,15 +95,15 @@ describe("i18next config", () => {
     });
 
     it("should have cookieSecure set to true", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
       expect(result.detection?.cookieSecure).toBe(true);
     });
 
-    it("should set cookieDomain from getServiceDomain", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("test.gov.uk");
+    it("should set cookieDomain from getRootDomain", () => {
+      vi.spyOn(config, "getRootDomain").mockReturnValue("test.gov.uk");
 
       const result = i18nextConfigurationOptions();
 
@@ -111,9 +111,7 @@ describe("i18next config", () => {
     });
 
     it("should handle different service domains", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue(
-        "another-domain.com"
-      );
+      vi.spyOn(config, "getRootDomain").mockReturnValue("another-domain.com");
 
       const result = i18nextConfigurationOptions();
 
@@ -121,16 +119,16 @@ describe("i18next config", () => {
     });
 
     it("should have cookieSameSite set to empty string", () => {
-      vi.spyOn(config, "getServiceDomain").mockReturnValue("example.com");
+      vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
 
       const result = i18nextConfigurationOptions();
 
       expect(result.detection?.cookieSameSite).toBe("");
     });
 
-    it("should call getServiceDomain once", () => {
+    it("should call getRootDomain once", () => {
       const spy = vi
-        .spyOn(config, "getServiceDomain")
+        .spyOn(config, "getRootDomain")
         .mockReturnValue("example.com");
 
       i18nextConfigurationOptions();


### PR DESCRIPTION
Scope the `amc` cookie and `lng` cookie to `account.gov.uk` no matter what the environment to mirror the auth behaviour and prevent weird behaviours caused by having multiple cookies with the same name but different domains.