### PR TITLE
OLH-4142: Add context to password input macro import

### DIFF
--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -1,5 +1,5 @@
 {% extends "common/layout/base-page.njk" %}
-{% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
+{% from "common/show-password/macro.njk" import govukInputWithShowPassword with context %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageTitleName = 'pages.changePassword.title' | translate %}

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -1,5 +1,5 @@
 {% extends "common/layout/base-page.njk" %}
-{% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
+{% from "common/show-password/macro.njk" import govukInputWithShowPassword with context %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% set paragraph = ['pages.enterPassword.', requestType, '.paragraph'] | join | translate %}
 {% set header = ['pages.enterPassword.', requestType, '.header'] | join | translate %}
@@ -21,7 +21,6 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
         <p class="govuk-body">{{paragraph}}</p>
-
         {{ govukInputWithShowPassword({
           label: 'pages.enterPassword.password.label' | translate,
           id: "password",


### PR DESCRIPTION


## Proposed changes

Using the "with context" keyword passes the current Nunjucks context into the macro, ensuring the output of the translate filter is in line with the current language.

This fixes a bug where the text for the Show/Hide password button was always shown in English regardless of the current language selection.

### After (button reflects current language)
https://github.com/user-attachments/assets/e2a1a6d8-03c9-422c-b1d1-13a8b8cd7e02



### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review
Spin up locally. Test on **Enter password** or **Change password** templates
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
