### PR TITLE
OLH-4234: Tweak header CSS

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -97,22 +97,6 @@
   background-color: govuk-colour("light-grey", $legacy: "grey-3");
 }
 
-// the modifier below is in place to remove the non-optional blue border at the bottom of the Design System header component
-// this is not ideal, however since there is no option/flag to remove the border from the component, it is the only way
-.govuk-header--with-account-navigation {
-  border-bottom: 0;
-
-  .govuk-header__container {
-    margin-bottom: 0;
-    border-bottom: 0;
-  }
-
-  .govuk-header__logo {
-    float: left;
-    width: 100%;
-  }
-}
-
 .govuk-header--with-signout {
   .govuk-template--rebranded & {
     .govuk-header__logo {
@@ -205,7 +189,7 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
 
   @include govuk-media-query($until: 480px) {
     position: relative;
-    padding-top: govuk-spacing(1);
+    padding-top: 0;
     transform: none;
   }
 }

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -5,7 +5,6 @@
 {% from "frontend-ui/build/components/footer/macro.njk" import frontendUiFooter %}
 {% from "frontend-ui/build/components/language-select/macro.njk" import frontendUiLanguageSelect %}
 {%- set headerClasses -%}
-{%- if not hideAccountNavigation -%} govuk-header--with-account-navigation {%- endif -%}
 {%- if isUserLoggedIn %} govuk-header--with-signout {%- endif -%}
 {%- endset-%}
 


### PR DESCRIPTION
## Proposed changes


<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Remove redundant `govuk-header--with-account-navigation` modifier and make spacing tweak on mobile.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
It was spotted that the header on AMC looked slightly different from the header on AMF on mobile screens where the Sign out link collapses onto another line.

The reason it looked different was because the `govuk-header--with-account-navigation` modifier class which is applied on AMF was not being applied on AMC. 
After some investigation, however, I determined this modifier class (which was specifically introduced to support having a secondary navigation after the header bar before the rebrand, when the header bar used to have a non-optional border at the bottom and several other CSS rules which needed over-writing to support our custom requirements) was no longer necessary.

The class has been [removed from AMC](https://github.com/govuk-one-login/account-components/pull/883). This PR does the same on AMF.

<!-- Describe the reason these changes were made - the "why" -->

## How to review
Running the app locally and confirming nothing has changed visually as a result of these changes. 

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
