### PR TITLE
OLH-4139: Navigational content updates on AM subjourneys

### DIFF
--- a/integration-tests/tests/steps/@change-default-method.ts
+++ b/integration-tests/tests/steps/@change-default-method.ts
@@ -81,7 +81,7 @@ Then(
       page.getByText("If you want to use a different authenticator app:")
     ).toBeVisible();
     await expect(
-      page.getByRole("listitem").getByText("Go back to Security")
+      page.getByRole("listitem").getByText("Go back to sign in details")
     ).toBeVisible();
     await expect(
       page.getByRole("listitem").getByText("Select Change authenticator app")

--- a/src/components/change-default-method/index.njk
+++ b/src/components/change-default-method/index.njk
@@ -40,7 +40,7 @@
 
   <p class="govuk-body">
     <a href="{{ cancelAMJourneyHref }}" class="govuk-link">
-      {{ cancelAMJourneyTextKey | translate }}
+      {{ "general.cancelAndGoBackText" | translate }}
     </a>
   </p>
 {% endblock %}

--- a/src/components/change-email/index.njk
+++ b/src/components/change-email/index.njk
@@ -22,7 +22,7 @@
       preventDoubleClick: true
     }) }}
     <p class="govuk-body">
-      <a href='{{ cancelAMJourneyHref }}' class="govuk-link" rel="noreferrer noopener">{{ cancelAMJourneyTextKey | translate }}</a>
+      <a href='{{ cancelAMJourneyHref }}' class="govuk-link" rel="noreferrer noopener">{{ "general.cancelAndGoBackText" | translate }}</a>
     </p>
   </form>
 {% endblock %}

--- a/src/components/change-password/index.njk
+++ b/src/components/change-password/index.njk
@@ -40,5 +40,5 @@
         preventDoubleClick: true
     }) }}
   </form>
-  <a href='{{ cancelAMJourneyHref }}' class="govuk-link govuk-body" rel="noreferrer noopener">{{ cancelAMJourneyTextKey | translate }}</a>
+  <a href='{{ cancelAMJourneyHref }}' class="govuk-link govuk-body" rel="noreferrer noopener">{{ "general.cancelAndGoBackText" | translate }}</a>
 {% endblock %}

--- a/src/components/choose-backup/index.njk
+++ b/src/components/choose-backup/index.njk
@@ -85,6 +85,6 @@
     {% endif %}
 
     <p class="govuk-body">
-      <a href="{{ cancelAMJourneyHref }}" class="govuk-link">{{ cancelAMJourneyTextKey | translate }}</a>
+      <a href="{{ cancelAMJourneyHref }}" class="govuk-link">{{ "general.cancelAndGoBackText" | translate }}</a>
     </p>
 {% endblock %}

--- a/src/components/common/mfa/add-auth-app.njk
+++ b/src/components/common/mfa/add-auth-app.njk
@@ -59,6 +59,6 @@
     </li>
   </ol>
   <a href="{{ cancelAMJourneyHref }}" class="govuk-link govuk-body">
-    {{ cancelAMJourneyTextKey | translate }}
+    {{ "general.cancelAndGoBackText" | translate }}
   </a>
 {% endblock %}

--- a/src/components/common/mfa/add-phone-number.njk
+++ b/src/components/common/mfa/add-phone-number.njk
@@ -50,7 +50,7 @@
 
   <p class="govuk-body">
     <a href="{{ cancelAMJourneyHref }}" class="govuk-link">
-      {{cancelAMJourneyTextKey | translate}}
+      {{"general.cancelAndGoBackText" | translate}}
     </a>
   </p>
 {% endblock %}

--- a/src/components/delete-account/index.njk
+++ b/src/components/delete-account/index.njk
@@ -29,8 +29,8 @@
         <p class="govuk-body">{{ 'pages.deleteAccount.englishServicesInWelshExplanation.body' | translate }}</p>
       {% endset %}
 
-      {{ govukDetails({ 
-        summaryText: 'pages.deleteAccount.englishServicesInWelshExplanation.title' | translate, 
+      {{ govukDetails({
+        summaryText: 'pages.deleteAccount.englishServicesInWelshExplanation.title' | translate,
         html: englishServicesInWelshExplanationHtml
       }) }}
     {% endif %}
@@ -40,7 +40,7 @@
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph3' | translate }}</p>
 
   <h2 class="govuk-heading-m">{{'pages.deleteAccount.heading2a' | translate}}</h2>
-  
+
   <p class="govuk-body">{{ 'pages.deleteAccount.explanationList' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>{{ 'pages.deleteAccount.explanationListItem1' | translate }}</li>
@@ -64,7 +64,7 @@
 <form action="{{'DELETE_ACCOUNT' | getPath }}" method="post" novalidate>
   <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
   <input type="hidden" name="fromSecurity" value="{{fromSecurity}}"/>
-  
+
   <p class="govuk-body">{{ 'pages.deleteAccount.paragraph5' | translate }}</p>
 
   {{ govukButton({
@@ -76,7 +76,7 @@
 
 {% if fromSecurity %}
   <a href='{{ "SECURITY" | getPath }}' class="govuk-link govuk-body">
-    {{ 'pages.deleteAccount.doNotDeleteAccount' | translate }}
+    {{ 'general.cancelAndGoBackText' | translate }}
   </a>
 {% endif %}
 {% endblock %}

--- a/src/components/delete-mfa-method/index.njk
+++ b/src/components/delete-mfa-method/index.njk
@@ -28,6 +28,6 @@
           }
         }) }}
 
-        <p class="govuk-body"> <a href="{{ cancelAMJourneyHref }}" class="govuk-link" rel="noreferrer noopener">{{ cancelAMJourneyTextKey | translate }}</a></p>
+        <p class="govuk-body"> <a href="{{ cancelAMJourneyHref }}" class="govuk-link" rel="noreferrer noopener">{{ "general.cancelAndGoBackText" | translate }}</a></p>
     </div>
 {% endblock %}

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -61,11 +61,11 @@ const VALID_BACK_ROUTES: Record<
 > = {
   security: {
     url: PATH_DATA.SECURITY.url,
-    translationKey: "general.cancelAndBackToSecurityText",
+    translationKey: "general.cancelAndGoBackText",
   },
   "sign-in-details": {
     url: PATH_DATA.SIGN_IN_DETAILS.url,
-    translationKey: "general.cancelAndBackToSignInDetailsText",
+    translationKey: "general.cancelAndGoBackText",
   },
 };
 

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -101,8 +101,9 @@ describe("enter password controller", () => {
 
       const eventServiceStub = vi.fn().mockReturnValue(mockEventService);
 
-      const eventServiceModule =
-        await import("../../../services/event-service");
+      const eventServiceModule = await import(
+        "../../../services/event-service"
+      );
       vi.spyOn(eventServiceModule, "eventService", "get").mockReturnValue(
         eventServiceStub
       );
@@ -133,8 +134,9 @@ describe("enter password controller", () => {
 
       const eventServiceStub = vi.fn().mockReturnValue(mockEventService);
 
-      const eventServiceModule =
-        await import("../../../services/event-service");
+      const eventServiceModule = await import(
+        "../../../services/event-service"
+      );
       vi.spyOn(eventServiceModule, "eventService", "get").mockReturnValue(
         eventServiceStub
       );
@@ -165,8 +167,9 @@ describe("enter password controller", () => {
 
       const eventServiceStub = vi.fn().mockReturnValue(mockEventService);
 
-      const eventServiceModule =
-        await import("../../../services/event-service");
+      const eventServiceModule = await import(
+        "../../../services/event-service"
+      );
       vi.spyOn(eventServiceModule, "eventService", "get").mockReturnValue(
         eventServiceStub
       );
@@ -197,8 +200,9 @@ describe("enter password controller", () => {
 
       const eventServiceStub = vi.fn().mockReturnValue(mockEventService);
 
-      const eventServiceModule =
-        await import("../../../services/event-service");
+      const eventServiceModule = await import(
+        "../../../services/event-service"
+      );
       vi.spyOn(eventServiceModule, "eventService", "get").mockReturnValue(
         eventServiceStub
       );
@@ -323,7 +327,7 @@ describe("enter password controller", () => {
         requestType: "changeEmail",
         from: "security",
         fromDetails: {
-          translationKey: "general.cancelAndBackToSecurityText",
+          translationKey: "general.cancelAndGoBackText",
           url: "/security",
         },
         formAction:

--- a/src/components/no-uk-mobile-phone/index.njk
+++ b/src/components/no-uk-mobile-phone/index.njk
@@ -41,7 +41,7 @@
 
 
   <ol class="govuk-list govuk-list--number">
-    <li >{{ 'pages.noUkPhoneNumber.listItem1' | translate | safe }}</li>
+    <li >{{ 'pages.noUkPhoneNumber.listItem1SignInDetails' | translate | safe if passkeysEnabled else 'pages.noUkPhoneNumber.listItem1Security' | translate | safe }}</li>
     {% if hasAuthApp %}
       <li >{{ 'pages.noUkPhoneNumber.listItem2hasAuthApp' | translate | safe }}</li>
     {% elif hasBackupAuthApp %}

--- a/src/components/resend-phone-code/index.njk
+++ b/src/components/resend-phone-code/index.njk
@@ -29,6 +29,6 @@
     </form>
 
     <a href="{{ cancelAMJourneyHref }}" class="govuk-link govuk-body">
-        {{cancelAMJourneyTextKey | translate}}
+        {{"general.cancelAndGoBackText" | translate}}
     </a>
 {% endblock %}

--- a/src/components/switch-backup-method/index.njk
+++ b/src/components/switch-backup-method/index.njk
@@ -36,6 +36,6 @@
   </form>
 
   <p class="govuk-body">
-    <a href="{{ cancelAMJourneyHref }}" class="govuk-link">{{ cancelAMJourneyTextKey | translate }}</a>
+    <a href="{{ cancelAMJourneyHref }}" class="govuk-link">{{ "general.cancelAndGoBackText" | translate }}</a>
   </p>
 {% endblock %}

--- a/src/config/nunjucks.ts
+++ b/src/config/nunjucks.ts
@@ -37,12 +37,6 @@ export function configureNunjucks(
     "cancelAMJourneyHref",
     passkeysEnabled() ? PATH_DATA.SIGN_IN_DETAILS.url : PATH_DATA.SECURITY.url
   );
-  nunjucksEnv.addGlobal(
-    "cancelAMJourneyTextKey",
-    passkeysEnabled()
-      ? "general.cancelAndBackToSignInDetailsText"
-      : "general.cancelAndBackToSecurityText"
-  );
 
   nunjucksEnv.addFilter("getPath", function (route: string) {
     if (!PATH_DATA[route]) {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -16,7 +16,7 @@
     "backToSignInDetailsButtonText": "Yn ôl i fanylion mewngofnodi",
     "cancelAndGoBackText": "Canslo a mynd yn ôl",
     "backSecurity": "Yn ôl i Diogelwch",
-    "backSignInDetails": "Go back to sign in details",
+    "backSignInDetails": "Ewch yn ôl i fanylion mewngofnodi",
     "backToGovUKButtonText": "Ewch i hafan GOV.UK",
     "noWelshNoticeInline": "This service is not available in Welsh.",
     "noWelshNoticeGlobal": "Os nad yw gwasanaeth rydych wedi cael mynediad iddo ar gael yn Gymraeg, bydd yn ymddangos yma yn Saesneg.",
@@ -526,7 +526,8 @@
       "detailTextLine2": "Gallwch ddefnyddio ap dilysydd ar eich ffôn clyfar, tabled neu gyfrifiadur. Lawrlwythwch ap dilysu ar gyfer eich ffôn clyfar neu dabled o'ch siop apiau neu chwiliwch ar-lein am ap dilysu ar gyfer eich cyfrifiadur.",
       "paragraph3": "I sefydlu ap dilysu i gael codau diogelwch:",
       "paragraph3hasBackupAuthApp": "I gael codau diogelwch gan ddefnyddio'ch ap dilysu:",
-      "listItem1": "Ewch yn ôl i <strong>Diogelwch</strong>",
+      "listItem1Security": "Ewch yn ôl i <strong>Diogelwch</strong>",
+      "listItem1SignInDetails": "Ewch yn ôl i <strong>fanylion mewngofnodi</strong>",
       "listItem2": "Dewiswch <strong>Defnyddio dull diofyn gwahanol</strong>",
       "listItem2hasBackupAuthApp": "Dewiswch <strong>Newid dulliau wrth gefn a diofyn</strong>",
       "listItem2hasAuthApp": "Dewiswch <strong>Newid ap dilysu</strong>"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -14,10 +14,9 @@
     "no": "Na",
     "backToSecurityButtonText": "Yn ôl i’r dudalen Ddiogelwch",
     "backToSignInDetailsButtonText": "Yn ôl i fanylion mewngofnodi",
-    "cancelAndBackToSecurityText": "Canslo a mynd yn ôl i Diogelwch",
-    "cancelAndBackToSignInDetailsText": "Canslo a mynd yn ôl",
+    "cancelAndGoBackText": "Canslo a mynd yn ôl",
     "backSecurity": "Yn ôl i Diogelwch",
-    "backSignInDetails": "Go back to Sign in details",
+    "backSignInDetails": "Go back to sign in details",
     "backToGovUKButtonText": "Ewch i hafan GOV.UK",
     "noWelshNoticeInline": "This service is not available in Welsh.",
     "noWelshNoticeGlobal": "Os nad yw gwasanaeth rydych wedi cael mynediad iddo ar gael yn Gymraeg, bydd yn ymddangos yma yn Saesneg.",
@@ -348,9 +347,7 @@
       "removePasskey": {
         "header": "Rhowch eich cyfrinair",
         "paragraph": "Mae angen i ni wneud yn siŵr mai chi yw chi cyn y gallwch dynnu'ch allwedd mynediad."
-      },
-      "cancelTextSecurity": "Canslo a mynd yn ôl i Diogelwch",
-      "cancelTextSignInDetails": "Canslo a mynd yn ôl"
+      }
     },
     "changeEmail": {
       "title": "Rhowch eich cyfeiriad e-bost newydd",
@@ -490,7 +487,6 @@
       "explanationListItem2": "y cofnod o ba wasanaethau rydych wedi cael mynediad iddynt gyda GOV.UK One Login a phryd",
       "details": "Os ydych yn defnyddio'r ap GOV.UK One Login, bydd unrhyw ddogfennau digidol ynddo yn cael eu tynnu i ffwrdd. Er enghraifft, Cerdyn Cyn-filwr digidol.",
       "deleteAccount": "Dileu eich GOV.UK One Login",
-      "doNotDeleteAccount": "Canslo a mynd yn ôl i’r dudalen Ddiogelwch",
       "englishServicesInWelshExplanation": {
         "title": "Pam fod rhai gwasanaethau wedi eu rhestru yn Saesneg?",
         "body": "Os nad yw gwasanaeth rydych wedi cael mynediad iddo ar gael yn Gymraeg, bydd yn ymddangos yma yn Saesneg."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,10 +14,9 @@
     "no": "No",
     "backToSecurityButtonText": "Back to Security",
     "backToSignInDetailsButtonText": "Back to sign in details",
-    "cancelAndBackToSecurityText": "Cancel and go back to Security",
-    "cancelAndBackToSignInDetailsText": "Cancel and go back",
+    "cancelAndGoBackText": "Cancel and go back",
     "backSecurity": "Go back to Security",
-    "backSignInDetails": "Go back to Sign in details",
+    "backSignInDetails": "Go back to sign in details",
     "backToGovUKButtonText": "Go to the GOV.UK homepage",
     "noWelshNoticeInline": "This service is not available in Welsh.",
     "noWelshNoticeGlobal": "If a service you’ve accessed is not available in Welsh it will appear here in English.",
@@ -495,9 +494,7 @@
       "removePasskey": {
         "header": "Enter your password",
         "paragraph": "We need to make sure it’s you before you can remove your passkey."
-      },
-      "cancelTextSecurity": "Cancel and go back to Security",
-      "cancelTextSignInDetails": "Cancel and go back"
+      }
     },
     "changeEmail": {
       "title": "Enter your new email address",
@@ -661,7 +658,6 @@
       "explanationListItem2": "the record of which services you’ve accessed with GOV.UK One Login and when",
       "details": "If you use the GOV.UK One Login app, any digital documents in it will be removed. For example, a digital Veteran Card.",
       "deleteAccount": "Delete your GOV.UK One Login",
-      "doNotDeleteAccount": "Cancel and go back to Security",
       "englishServicesInWelshExplanation": {
         "title": "Why are some services listed in English?",
         "body": "If a service you’ve accessed is not available in Welsh it will appear here in English."
@@ -702,7 +698,8 @@
       "detailTextLine2": "You can use an authenticator app on your smartphone, tablet or desktop computer. Download an authenticator app for your smartphone or tablet from your app store or search online for an authenticator app for your computer.",
       "paragraph3": "To set up an authenticator app to get security codes:",
       "paragraph3hasBackupAuthAppp": "To get security codes using your authenticator app:",
-      "listItem1": "Go back to <strong>Security</strong>",
+      "listItem1Security": "Go back to <strong>Security</strong>",
+      "listItem1SignInDetails": "Go back to <strong>sign in details</strong>",
       "listItem2": "Select <strong>Use a different default method</strong>",
       "listItem2hasBackupAuthApp": "Select <strong>Switch back-up and default methods</strong>",
       "listItem2hasAuthApp": "Select <strong>Change authenticator app</strong>"

--- a/test/unit/config/nunjucks.test.ts
+++ b/test/unit/config/nunjucks.test.ts
@@ -117,9 +117,6 @@ describe("configureNunjucks", () => {
       expect(nunjucksEnv.getGlobal("cancelAMJourneyHref")).toEqual(
         PATH_DATA.SECURITY.url
       );
-      expect(nunjucksEnv.getGlobal("cancelAMJourneyTextKey")).toEqual(
-        "general.cancelAndBackToSecurityText"
-      );
     });
 
     it("should navigate back to sign in details when passkey flag is on", () => {
@@ -128,9 +125,6 @@ describe("configureNunjucks", () => {
       nunjucksEnv = configureNunjucks(app, ["./views"]);
       expect(nunjucksEnv.getGlobal("cancelAMJourneyHref")).toEqual(
         PATH_DATA.SIGN_IN_DETAILS.url
-      );
-      expect(nunjucksEnv.getGlobal("cancelAMJourneyTextKey")).toEqual(
-        "general.cancelAndBackToSignInDetailsText"
       );
     });
   });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Bring the "Cancel" links on the pre existing account management subjourneys (email/mfa/password update) in line with the passkey journeys:
- the text for the "Cancel" link in the middle of a journey will always be "Cancel and go back" whether a journey has started from Security or from Sign in details
- the button at the end of a journey will always either say "Back to Security" if a journey has started from security (i.e. now before the passkeys feature is live) or "Back to sign in details" if a journey has started from Sign in details. The delete journey is the exception to this rule
- on the Delete journey, the button at the end of the journey stays as is (linking back to the GOVUK homepage)

Additionally, the content on the "no uk mobile phone number" page (reachable via "change default mfa" journey) should be updated to reflect the current journey as well (if the passkeys flag is on, the content should say "back to sign in details"). 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

Some new navigational patterns are introduced soon as part of the passkeys journeys, such as a new Sign in page nestled under Security, where account management journeys will be starting from, and slightly different wording around navigation.

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
### Testing

<!-- When working with feature flags, features that are flagged off should not be made available in production -->
<!-- Delete if changes do NOT include any feature flags -->

- [x] Automated test coverage includes features that are flagged off

### Sign-offs

- [x] Design updates have been signed off by a member of the UCD team

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review
This has been reviewed by UCD in the dev environment. 

It might be useful to:
- check any translation keys which have been removed aren't actually needed 
- double check that content on the "no uk mobile phone number" page has remains as-is (referencing the security page) when the passkeys flag is off
- double check the confirmation page Back buttons still specify "Back to Security" when the passkey flag is off

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
