### PR TITLE
OLH-4196 Fix: remove passkey back button

### DIFF
--- a/integration-tests/tests/features/@manage-passkeys.feature
+++ b/integration-tests/tests/features/@manage-passkeys.feature
@@ -46,3 +46,17 @@ Scenario: remove a passkey without a name
   Then I click the "Remove passkey" button
   And the page has finished loading
   Then the page looks as expected
+
+Scenario: pressing back from remove passkey confirmation redirects to your services
+  Given I go to the "Root" page
+  And I sign in as the "fourPasskeys" user
+  And I go to the "Security" page
+  Then I click the "Manage your sign in details" link
+  Then I click the "Remove iCloud Keychain (Managed) passkey" link
+  Then I enter and submit my password "qwerty"
+  And the page has finished loading
+  Then I click the "Remove passkey" button
+  And the page has finished loading
+  Then I navigate back
+  And the page has finished loading
+  Then the page title is prefixed with "Your services"

--- a/integration-tests/tests/steps/shared.ts
+++ b/integration-tests/tests/steps/shared.ts
@@ -39,6 +39,10 @@ Given("I click the {string} button", async ({ page }, name: string) => {
   await page.getByRole("button", { name, exact: true }).click();
 });
 
+Given("I navigate back", async ({ page }) => {
+  await page.goBack();
+});
+
 Given("the page has finished loading", async ({ page }) => {
   // eslint-disable-next-line playwright/no-networkidle
   await page.waitForLoadState("networkidle");

--- a/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
+++ b/src/components/update-confirmation/tests/update-confirmation-controller.test.ts
@@ -465,15 +465,7 @@ describe("removePasskeyConfirmationGet", () => {
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
 
     req = new RequestBuilder()
-      .withSession({
-        mfaMethods: [
-          {
-            method: {
-              mfaMethodType: "APP",
-            },
-          },
-        ],
-      })
+      .withSessionUserState({ removePasskey: { value: "CHANGE_VALUE" } })
       .withTranslate(vi.fn((id) => id))
       .build();
 
@@ -500,15 +492,7 @@ describe("removePasskeyConfirmationGet", () => {
     vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
 
     req = new RequestBuilder()
-      .withSession({
-        mfaMethods: [
-          {
-            method: {
-              mfaMethodType: "SMS",
-            },
-          },
-        ],
-      })
+      .withSessionUserState({ removePasskey: { value: "CHANGE_VALUE" } })
       .withTranslate(vi.fn((id) => id))
       .build();
 
@@ -524,5 +508,23 @@ describe("removePasskeyConfirmationGet", () => {
       panelText: "pages.removePasskeyConfirmation.panelText",
       summaryText: "pages.removePasskeyConfirmation.summaryTextNoPasskeys",
     });
+  });
+
+  it("should clear the removePasskey state", async () => {
+    const mockClient: Partial<MfaClient> = {
+      getPasskeys: vi.fn().mockResolvedValue({ data: { passkeys: [] } }),
+    };
+    vi.mocked(createMfaClient).mockResolvedValue(mockClient as MfaClient);
+
+    req = new RequestBuilder()
+      .withSessionUserState({ removePasskey: { value: "CHANGE_VALUE" } })
+      .withTranslate(vi.fn((id) => id))
+      .build();
+
+    res = { render: vi.fn(), locals: {} };
+
+    await removePasskeyConfirmationGet(req as Request, res as Response);
+
+    expect(req.session.user.state.removePasskey).toBeUndefined();
   });
 });

--- a/src/components/update-confirmation/update-confirmation-controller.ts
+++ b/src/components/update-confirmation/update-confirmation-controller.ts
@@ -376,6 +376,8 @@ export async function removePasskeyConfirmationGet(
     res
   );
 
+  delete req.session.user.state.removePasskey;
+
   res.render("update-confirmation/index.njk", {
     pageTitle: req.t("pages.removePasskeyConfirmation.title"),
     panelText: req.t("pages.removePasskeyConfirmation.panelText"),


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
[OLH-4196] remove passkey back button fix

### What changed

Delete `req.session.user.state.removePasskey` in `removePasskeyConfirmationGet` before rendering, so that pressing back  redirects to /your-services. Update unit tests to use withSessionUserState and add an integration test scenario covering the back-button behaviour.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Application configuration is up-to-date
- [ ] Documented in the README
- [ ] Added to deployment steps
- [ ] Added to local startup config

### Testing

<!-- When working with feature flags, features that are flagged off should not be made available in production -->
<!-- Delete if changes do NOT include any feature flags -->

- [ ] Automated test coverage includes features that are flagged off

### Sign-offs

<!-- New Node.JS/NPM dependencies need to be approved by a Lead Developer or Lead SRE: https://govukverify.atlassian.net/wiki/spaces/DIWAY/pages/4335697997/Library+approval+process -->
<!-- Delete if changes do NOT include any new libraries -->

- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE
  <!-- Design updates should be signed off by a UCD person prior to the PR being open for dev review -->
  <!-- Delete if changes do NOT include any design updates -->
- [ ] Design updates have been signed off by a member of the UCD team
<!-- Delete if changes do NOT include any analytics updates -->
- [ ] Analytics updates have been signed off by a PA

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-4196]: https://govukverify.atlassian.net/browse/OLH-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ