### PR TITLE
BAU: pass scope in AMC redirect URI

### DIFF
--- a/src/utils/getAmcJwe.test.ts
+++ b/src/utils/getAmcJwe.test.ts
@@ -15,6 +15,7 @@ vi.mock("../config.js", () => ({
   getAmcAuthorizeUrl: vi.fn(),
   getAmcClientId: vi.fn(),
   getAmcJwksUrl: vi.fn(),
+  getAmcCallbackBaseUrl: vi.fn(),
   getLogLevel: vi.fn(() => "info"),
 }));
 vi.mock("./kms.js");
@@ -59,6 +60,9 @@ describe("getAmcJwe", () => {
     vi.spyOn(config, "getAmcClientId").mockReturnValue("test-client-id");
     vi.spyOn(config, "getAmcJwksUrl").mockReturnValue(
       "https://amc.example.com/.well-known/jwks.json"
+    );
+    vi.spyOn(config, "getAmcCallbackBaseUrl").mockReturnValue(
+      "https://home.example.com"
     );
 
     vi.mocked(kmsModule.kmsService.sign).mockResolvedValue({
@@ -191,8 +195,10 @@ describe("getAmcJwe", () => {
     expect(decodedPayload.exp).toBe(1704067320);
   });
 
-  it("should construct redirect_uri from base URL and callback path", async () => {
-    vi.spyOn(config, "getHomeBaseUrl").mockReturnValue("https://test.gov.uk");
+  it("should construct redirect_uri from callback base URL and path", async () => {
+    vi.spyOn(config, "getAmcCallbackBaseUrl").mockReturnValue(
+      "https://callback.example.com"
+    );
 
     await getAmcJwe("openid", "state-123", mockUser);
 
@@ -203,7 +209,31 @@ describe("getAmcJwe", () => {
     );
 
     expect(decodedPayload.redirect_uri).toBe(
-      "https://test.gov.uk/amc-callback"
+      "https://callback.example.com/amc-callback?scope=openid"
+    );
+  });
+
+  it("should include scope parameter in redirect_uri", async () => {
+    const scope = "openid profile email";
+    await getAmcJwe(scope, "state-123", mockUser);
+
+    const signCall = vi.mocked(kmsModule.kmsService.sign).mock.calls[0][0];
+    const [, payloadPart] = signCall.split(".");
+    const decodedPayload = JSON.parse(
+      Buffer.from(payloadPart, "base64url").toString()
+    );
+
+    expect(decodedPayload.redirect_uri).toBe(
+      "https://home.example.com/amc-callback?scope=openid+profile+email"
+    );
+  });
+
+  it("should return redirect URI in result object", async () => {
+    const scope = "openid email";
+    const result = await getAmcJwe(scope, "state-123", mockUser);
+
+    expect(result.redirectUri).toBe(
+      "https://home.example.com/amc-callback?scope=openid+email"
     );
   });
 

--- a/src/utils/getAmcJwe.ts
+++ b/src/utils/getAmcJwe.ts
@@ -3,9 +3,9 @@ import { kmsService } from "./kms.js";
 import { randomUUID } from "node:crypto";
 import {
   getAmcAuthorizeUrl,
+  getAmcCallbackBaseUrl,
   getAmcClientId,
   getAmcJwksUrl,
-  getHomeBaseUrl,
 } from "../config.js";
 import * as jose from "jose";
 import { PATH_DATA } from "../app.constants.js";
@@ -25,6 +25,10 @@ export const getAmcJwe = async (
   const kid = keyId.includes("/") ? keyId.split("/").pop() : keyId;
   const headers = { alg: "RS512", typ: "JWT", kid };
 
+  const redirectUri = `${getAmcCallbackBaseUrl()}${PATH_DATA.AMC_CALLBACK.url}`;
+  const redirectUrl = new URL(redirectUri);
+  redirectUrl.searchParams.set("scope", scope);
+
   const payload = {
     client_id: getAmcClientId(),
     iss: getAmcClientId(),
@@ -40,7 +44,7 @@ export const getAmcJwe = async (
     public_sub: user.publicSubjectId,
     sub: user.internalPairwiseId,
     state,
-    redirect_uri: getHomeBaseUrl() + PATH_DATA.AMC_CALLBACK.url,
+    redirect_uri: redirectUrl.toString(),
   };
 
   const encodedHeader = jose.base64url.encode(JSON.stringify(headers));
@@ -67,5 +71,6 @@ export const getAmcJwe = async (
   return {
     jws,
     jwe,
+    redirectUri: redirectUrl.toString(),
   };
 };

--- a/src/utils/initiateAmcRedirect.test.ts
+++ b/src/utils/initiateAmcRedirect.test.ts
@@ -59,7 +59,15 @@ describe("initiateAmcRedirect", () => {
     vi.mocked(getAmcJweModule.getAmcJwe).mockResolvedValue({
       jws: "test.jws.value",
       jwe: "test.jwe.value",
+      redirectUri: "https://home.example.com/amc/callback",
     });
+
+    // Reset all config mocks to default values
+    vi.spyOn(config, "getAmcAuthorizeUrl").mockReturnValue(
+      "https://amc.example.com/authorize"
+    );
+    vi.spyOn(config, "getAmcClientId").mockReturnValue("test-client-id");
+    vi.spyOn(config, "getRootDomain").mockReturnValue("example.com");
   });
 
   it("should generate a state and push it into session.amcStates", async () => {
@@ -112,6 +120,40 @@ describe("initiateAmcRedirect", () => {
     );
   });
 
+  it("should use redirectUri from getAmcJwe result", async () => {
+    vi.mocked(getAmcJweModule.getAmcJwe).mockResolvedValue({
+      jws: "test.jws.value", 
+      jwe: "test.jwe.value",
+      redirectUri: "https://custom.domain.com/callback?scope=openid"
+    });
+
+    await initiateAmcRedirect("openid", req as Request, res as Response);
+
+    const redirectUrl = String(vi.mocked(res.redirect).mock.calls[0][0]);
+    const url = new URL(redirectUrl);
+
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://custom.domain.com/callback?scope=openid"
+    );
+  });
+
+  it("should handle different scopes correctly", async () => {
+    const scope = "openid profile email";
+    await initiateAmcRedirect(scope, req as Request, res as Response);
+
+    expect(getAmcJweModule.getAmcJwe).toHaveBeenCalledWith(
+      scope,
+      "test-state-uuid",
+      expect.any(Object),
+      undefined,
+      "test-account-data-token"
+    );
+
+    const redirectUrl = String(vi.mocked(res.redirect).mock.calls[0][0]);
+    const url = new URL(redirectUrl);
+    expect(url.searchParams.get("scope")).toBe(scope);
+  });
+
   it("should set the amc cookie with a SHA256 hash of the JWS", async () => {
     await initiateAmcRedirect("openid email", req as Request, res as Response);
 
@@ -143,6 +185,39 @@ describe("initiateAmcRedirect", () => {
     await initiateAmcRedirect("openid email", req as Request, res as Response);
 
     expect(res.redirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle missing account data token gracefully", async () => {
+    req.session.user.tokens = {};
+
+    await initiateAmcRedirect("openid email", req as Request, res as Response);
+
+    expect(getAmcJweModule.getAmcJwe).toHaveBeenCalledWith(
+      "openid email",
+      "test-state-uuid",
+      {
+        internalPairwiseId: "internal-sub-123",
+        publicSubjectId: "public-sub-456",
+        email: "user@example.com",
+      },
+      undefined,
+      undefined
+    );
+  });
+
+  it("should create SHA256 hash of JWS correctly", async () => {
+    await initiateAmcRedirect("openid email", req as Request, res as Response);
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "amc",
+      "hashed-jws-value",
+      expect.objectContaining({
+        secure: true,
+        httpOnly: true,
+        sameSite: "strict",
+        domain: "example.com",
+      })
+    );
   });
 
   it("should propagate errors thrown by getAmcJwe", async () => {

--- a/src/utils/initiateAmcRedirect.ts
+++ b/src/utils/initiateAmcRedirect.ts
@@ -3,11 +3,9 @@ import { Request, Response } from "express";
 import { getAmcJwe } from "./getAmcJwe.js";
 import {
   getAmcAuthorizeUrl,
-  getAmcCallbackBaseUrl,
   getAmcClientId,
   getRootDomain,
 } from "../config.js";
-import { PATH_DATA } from "../app.constants.js";
 
 export async function initiateAmcRedirect(
   scope: string,
@@ -23,7 +21,7 @@ export async function initiateAmcRedirect(
 
   const { subjectId, publicSubjectId, email } = req.session.user;
 
-  const { jws, jwe } = await getAmcJwe(
+  const { jws, jwe, redirectUri } = await getAmcJwe(
     scope,
     state,
     {
@@ -34,8 +32,6 @@ export async function initiateAmcRedirect(
     undefined,
     req.session.user.tokens.accountDataApiAccessToken
   );
-
-  const redirectUri = `${getAmcCallbackBaseUrl()}${PATH_DATA.AMC_CALLBACK.url}`;
 
   const url = new URL(getAmcAuthorizeUrl());
   url.searchParams.set("client_id", getAmcClientId());

--- a/src/utils/test/initiateAmcRedirect-integration.test.ts
+++ b/src/utils/test/initiateAmcRedirect-integration.test.ts
@@ -8,6 +8,7 @@ vi.mock("../getAmcJwe.js", () => ({
   getAmcJwe: vi.fn().mockResolvedValue({
     jws: "header.payload.signature",
     jwe: "encrypted.jwe.token.value.here",
+    redirectUri: "https://home.example.com/amc/callback",
   }),
 }));
 


### PR DESCRIPTION
Pass the AMC scope in a `scope` query parameter in the redirect URI parameter passed to AMC