### PR TITLE
BAU: fix passkey ordering

### DIFF
--- a/src/utils/passkeys/index.test.ts
+++ b/src/utils/passkeys/index.test.ts
@@ -54,19 +54,19 @@ describe("formatPasskeysForRender", () => {
     ]);
   });
 
-  it("should sort passkeys used on same day by createdAt (desc)", async () => {
+  it("should sort passkeys with lastUsedAt by lastUsedAt only", async () => {
     const passkeys = [
       {
-        id: "same-day-older-created",
+        id: "used-earlier",
         aaguid: "1",
-        createdAt: "2023-01-01T08:00:00Z",
-        lastUsedAt: "2023-05-01T10:00:00Z",
+        createdAt: "2023-01-01T12:00:00Z", // Newer creation date
+        lastUsedAt: "2023-05-01T10:00:00Z", // Earlier use
       },
       {
-        id: "same-day-newer-created",
+        id: "used-later",
         aaguid: "2",
-        createdAt: "2023-01-01T12:00:00Z",
-        lastUsedAt: "2023-05-01T14:00:00Z", // Same day, different time
+        createdAt: "2023-01-01T08:00:00Z", // Older creation date
+        lastUsedAt: "2023-05-01T14:00:00Z", // Later use
       },
     ] as any;
 
@@ -77,8 +77,8 @@ describe("formatPasskeysForRender", () => {
     const result = await formatPasskeysForRender(mockReq, passkeys);
 
     expect(result.map((p) => p.id)).toEqual([
-      "same-day-newer-created", // Should come first due to newer createdAt
-      "same-day-older-created",
+      "used-later", // Should come first due to later lastUsedAt
+      "used-earlier",
     ]);
   });
 

--- a/src/utils/passkeys/index.ts
+++ b/src/utils/passkeys/index.ts
@@ -28,26 +28,9 @@ export async function formatPasskeysForRender(
   const sortedLastUsed = passkeys
     .filter((passkey) => passkey.lastUsedAt)
     .sort((a, b) => {
-      const dateA = new Date(a.lastUsedAt);
-      const dateB = new Date(b.lastUsedAt);
-
-      const dayA = new Date(
-        dateA.getFullYear(),
-        dateA.getMonth(),
-        dateA.getDate()
-      ).getTime();
-      const dayB = new Date(
-        dateB.getFullYear(),
-        dateB.getMonth(),
-        dateB.getDate()
-      ).getTime();
-
-      if (dayB !== dayA) {
-        return dayB - dayA;
-      }
-      const createdA = new Date(a.createdAt).getTime();
-      const createdB = new Date(b.createdAt).getTime();
-      return createdB - createdA;
+      const timeA = new Date(a.lastUsedAt).getTime();
+      const timeB = new Date(b.lastUsedAt).getTime();
+      return timeB - timeA;
     });
   const sortedCreatedAt = passkeys
     .filter((passkey) => !passkey.lastUsedAt)


### PR DESCRIPTION
Fix passkey ordering so that the most recently used passkeys are shown at the top, even those used on the same day