### PR TITLE
OLH-4368: reduce unsafe-inline surface area

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,10 +8,7 @@ import { fileURLToPath } from "url";
 import { dirname } from "path";
 import { configureNunjucks } from "./config/nunjucks.js";
 import { i18nextConfigurationOptions } from "./config/i18next.js";
-import {
-  helmetConfiguration,
-  webchatHelmetConfiguration,
-} from "./config/helmet.js";
+import { helmetConfiguration } from "./config/helmet.js";
 import { csrfSynchronisedProtection } from "./config/csrf.js";
 import helmet from "helmet";
 import session from "express-session";
@@ -23,7 +20,6 @@ import {
   getSessionExpiry,
   getSessionSecret,
   supportSearchableList,
-  supportWebchatContact,
   supportGlobalLogout,
   passkeysEnabled,
 } from "./config.js";
@@ -242,11 +238,7 @@ async function createApp(): Promise<express.Application> {
   app.use(i18nextMiddleware.handle(i18next));
   app.use(frontendUiMiddleware);
 
-  if (supportWebchatContact()) {
-    app.use(helmet(webchatHelmetConfiguration));
-  } else {
-    app.use(helmet(helmetConfiguration));
-  }
+  app.use(helmet(helmetConfiguration));
 
   app.use((req, res, next) => {
     const translate = req.t.bind(req);

--- a/src/components/contact-govuk-one-login/contact-govuk-one-login-routes.ts
+++ b/src/components/contact-govuk-one-login/contact-govuk-one-login-routes.ts
@@ -1,9 +1,13 @@
 import * as express from "express";
+import helmet from "helmet";
 import { contactGet } from "./contact-govuk-one-login-controller.js";
 import { PATH_DATA } from "../../app.constants.js";
 import { updateSessionMiddleware } from "../../middleware/update-session-middleware.js";
+import { webchatHelmetConfiguration } from "../../config/helmet.js";
 
 const router = express.Router();
+
+router.use(PATH_DATA.CONTACT.url, helmet(webchatHelmetConfiguration));
 
 router.get(PATH_DATA.CONTACT.url, updateSessionMiddleware, contactGet);
 

--- a/src/components/contact-govuk-one-login/tests/csp-scoping.test.ts
+++ b/src/components/contact-govuk-one-login/tests/csp-scoping.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import helmet from "helmet";
+import {
+  helmetConfiguration,
+  webchatHelmetConfiguration,
+} from "../../../config/helmet.js";
+import { PATH_DATA } from "../../../app.constants.js";
+
+function createTestApp() {
+  const app = express();
+
+  app.use((req, res, next) => {
+    res.locals.scriptNonce = "test-nonce";
+    res.locals.missionLabWebSocketAddress = "wss://test.example.com";
+    next();
+  });
+
+  app.use(helmet(helmetConfiguration));
+  app.use(PATH_DATA.CONTACT.url, helmet(webchatHelmetConfiguration));
+
+  app.get(PATH_DATA.CONTACT.url, (req, res) => res.send("contact"));
+  app.get(PATH_DATA.HEALTHCHECK.url, (req, res) => res.send("ok"));
+
+  return app;
+}
+
+describe("CSP header scoping", () => {
+  const app = createTestApp();
+
+  describe("contact page uses webchat CSP", () => {
+    it("should include script-src-attr with unsafe-inline", async () => {
+      const res = await request(app).get(PATH_DATA.CONTACT.url);
+      const csp = res.headers["content-security-policy"];
+
+      expect(csp).toContain("script-src-attr");
+      expect(csp).toContain("'unsafe-inline'");
+    });
+
+    it("should include strict-dynamic in script-src", async () => {
+      const res = await request(app).get(PATH_DATA.CONTACT.url);
+      const csp = res.headers["content-security-policy"];
+
+      expect(csp).toContain("'strict-dynamic'");
+    });
+
+    it("should include smartagent.app in script-src", async () => {
+      const res = await request(app).get(PATH_DATA.CONTACT.url);
+      const csp = res.headers["content-security-policy"];
+
+      expect(csp).toContain("*.smartagent.app");
+    });
+
+    it("should include frame-src with smartagent.app", async () => {
+      const res = await request(app).get(PATH_DATA.CONTACT.url);
+      const csp = res.headers["content-security-policy"];
+
+      expect(csp).toContain("frame-src");
+      expect(csp).toContain("*.smartagent.app");
+    });
+  });
+
+  describe("non-contact pages use strict CSP", () => {
+    it("should not include unsafe-inline or webchat sources", async () => {
+      const res = await request(app).get(PATH_DATA.HEALTHCHECK.url);
+      const csp = res.headers["content-security-policy"];
+
+      expect(csp).not.toContain("'unsafe-inline'");
+      expect(csp).not.toContain("'strict-dynamic'");
+      expect(csp).not.toContain("smartagent.app");
+    });
+  });
+});

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -1,10 +1,14 @@
 import { HelmetOptions } from "helmet";
 import { Request, Response } from "express";
+
+type CspDirectiveValue = string | ((req: Request, res: Response) => string);
+
 // Helmet does not export the config type - This is the way the recommend getting it on GitHub.
 export const helmetConfiguration: HelmetOptions = {
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
+      styleSrc: ["'self'"],
       scriptSrc: [
         "'self'",
         (req: Request, res: Response): string =>
@@ -51,50 +55,36 @@ export const helmetConfiguration: HelmetOptions = {
   permittedCrossDomainPolicies: false,
 };
 
+const baseCspDirectives = (
+  helmetConfiguration.contentSecurityPolicy as { directives: unknown }
+).directives as Record<string, CspDirectiveValue[]>;
+
 export const webchatHelmetConfiguration: HelmetOptions = {
+  ...helmetConfiguration,
   contentSecurityPolicy: {
     directives: {
-      defaultSrc: ["'self'"],
+      ...baseCspDirectives,
       styleSrc: [
+        ...baseCspDirectives.styleSrc,
         (req: Request, res: Response): string =>
           `'nonce-${res.locals.scriptNonce}'`,
-        "'self'",
         "https://*.smartagent.app",
         "https://fonts.cdnfonts.com",
       ],
       scriptSrc: [
-        "'self'",
-        (req: Request, res: Response): string =>
-          `'nonce-${res.locals.scriptNonce}'`,
-        "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
-        "https://*.googletagmanager.com",
-        "https://*.google-analytics.com",
-        "https://*.analytics.google.com",
+        ...baseCspDirectives.scriptSrc,
         "https://*.g.doubleclick.net",
         "https://*.smartagent.app",
-        "https://*.ruxit.com",
-        "https://*.dynatrace.com",
         "'strict-dynamic'",
       ],
       scriptSrcAttr: ["'self'", "'unsafe-inline'"],
       imgSrc: [
-        "'self'",
-        "data:",
-        "https://*.googletagmanager.com",
-        "https://*.google-analytics.com",
-        "https://*.analytics.google.com",
-        "https://*.g.doubleclick.net",
+        ...baseCspDirectives.imgSrc,
         "https://*.s3.eu-west-2.amazonaws.com",
       ],
-      objectSrc: ["'none'"],
       connectSrc: [
-        "'self'",
-        "https://*.google-analytics.com",
-        "https://*.analytics.google.com",
-        "https://*.g.doubleclick.net",
+        ...baseCspDirectives.connectSrc,
         "https://*.smartagent.app",
-        "https://*.ruxit.com",
-        "https://*.dynatrace.com",
         "https://participant.connect.eu-west-2.amazonaws.com",
         (req: Request, res: Response): string =>
           `${res.locals.missionLabWebSocketAddress}`,
@@ -102,22 +92,8 @@ export const webchatHelmetConfiguration: HelmetOptions = {
         " https://api.rollbar.com",
       ],
       workerSrc: ["blob:"],
-      formAction: ["'self'", "https://*.account.gov.uk"],
       mediaSrc: ["'self'", "https://*.s3.eu-west-2.amazonaws.com"],
       frameSrc: ["'self'", "https://*.smartagent.app"],
     },
   },
-  dnsPrefetchControl: {
-    allow: false,
-  },
-  frameguard: {
-    action: "deny",
-  },
-  hsts: {
-    maxAge: 31536000, // 1 Year
-    preload: true,
-    includeSubDomains: true,
-  },
-  referrerPolicy: false,
-  permittedCrossDomainPolicies: false,
 };

--- a/test/unit/config/helmet.test.ts
+++ b/test/unit/config/helmet.test.ts
@@ -29,6 +29,7 @@ describe("helmet config", () => {
         "imgSrc",
         "objectSrc",
         "scriptSrc",
+        "styleSrc",
       ]);
     });
 
@@ -103,9 +104,10 @@ describe("helmet config", () => {
       expect(directives?.formAction).toContain("https://*.account.gov.uk");
     });
 
-    it("should not have styleSrc directive", () => {
+    it("should have correct styleSrc directive", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
-      expect(directives?.styleSrc).toBeUndefined();
+      expect(directives?.styleSrc).toHaveLength(1);
+      expect(directives?.styleSrc).toContain("'self'");
     });
 
     it("should not have scriptSrcAttr directive", () => {

--- a/test/unit/config/helmet.test.ts
+++ b/test/unit/config/helmet.test.ts
@@ -5,6 +5,12 @@ import {
 } from "../../../src/config/helmet.js";
 import { Request, Response } from "express";
 
+function getNonceFunction(
+  entries: any[]
+): (req: Request, res: Response) => string {
+  return entries.find((item) => typeof item === "function");
+}
+
 describe("helmet config", () => {
   describe("helmetConfiguration", () => {
     it("should have contentSecurityPolicy defined", () => {
@@ -14,36 +20,60 @@ describe("helmet config", () => {
       ).toBeDefined();
     });
 
+    it("should only have expected directives", () => {
+      const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(Object.keys(directives!).sort()).toEqual([
+        "connectSrc",
+        "defaultSrc",
+        "formAction",
+        "imgSrc",
+        "objectSrc",
+        "scriptSrc",
+      ]);
+    });
+
     it("should have correct defaultSrc directive", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
       expect(directives?.defaultSrc).toEqual(["'self'"]);
     });
 
-    it("should have scriptSrc with nonce function", () => {
+    it("should have correct scriptSrc directive", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
       const scriptSrc = directives?.scriptSrc as any[];
 
-      expect(scriptSrc).toBeDefined();
-      expect(scriptSrc.length).toBeGreaterThan(0);
-      expect(typeof scriptSrc[1]).toBe("function");
+      expect(scriptSrc).toHaveLength(8);
+      expect(scriptSrc).toContain("'self'");
+      expect(scriptSrc).toContain(
+        "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='" // pragma: allowlist secret
+      );
+      expect(scriptSrc).toContain("https://*.googletagmanager.com");
+      expect(scriptSrc).toContain("https://*.google-analytics.com");
+      expect(scriptSrc).toContain("https://*.analytics.google.com");
+      expect(scriptSrc).toContain("https://*.ruxit.com");
+      expect(scriptSrc).toContain("https://*.dynatrace.com");
+      expect(getNonceFunction(scriptSrc)).toBeDefined();
     });
 
     it("should generate nonce in scriptSrc function", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
       const scriptSrc = directives?.scriptSrc as any[];
-      const nonceFunc = scriptSrc[1];
+      const nonceFunc = getNonceFunction(scriptSrc);
 
       const req = {} as Request;
       const res = { locals: { scriptNonce: "test-nonce-123" } } as Response;
 
-      const result = nonceFunc(req, res);
-      expect(result).toBe("'nonce-test-nonce-123'");
+      expect(nonceFunc(req, res)).toBe("'nonce-test-nonce-123'");
     });
 
     it("should have correct imgSrc directive", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.imgSrc).toHaveLength(6);
       expect(directives?.imgSrc).toContain("'self'");
       expect(directives?.imgSrc).toContain("data:");
+      expect(directives?.imgSrc).toContain("https://*.googletagmanager.com");
+      expect(directives?.imgSrc).toContain("https://*.google-analytics.com");
+      expect(directives?.imgSrc).toContain("https://*.analytics.google.com");
+      expect(directives?.imgSrc).toContain("https://*.g.doubleclick.net");
     });
 
     it("should have objectSrc set to none", () => {
@@ -53,13 +83,49 @@ describe("helmet config", () => {
 
     it("should have correct connectSrc directive", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.connectSrc).toHaveLength(6);
       expect(directives?.connectSrc).toContain("'self'");
+      expect(directives?.connectSrc).toContain(
+        "https://*.google-analytics.com"
+      );
+      expect(directives?.connectSrc).toContain(
+        "https://*.analytics.google.com"
+      );
+      expect(directives?.connectSrc).toContain("https://*.g.doubleclick.net");
+      expect(directives?.connectSrc).toContain("https://*.ruxit.com");
+      expect(directives?.connectSrc).toContain("https://*.dynatrace.com");
     });
 
     it("should have correct formAction directive", () => {
       const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.formAction).toHaveLength(2);
       expect(directives?.formAction).toContain("'self'");
       expect(directives?.formAction).toContain("https://*.account.gov.uk");
+    });
+
+    it("should not have styleSrc directive", () => {
+      const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.styleSrc).toBeUndefined();
+    });
+
+    it("should not have scriptSrcAttr directive", () => {
+      const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.scriptSrcAttr).toBeUndefined();
+    });
+
+    it("should not have workerSrc directive", () => {
+      const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.workerSrc).toBeUndefined();
+    });
+
+    it("should not have mediaSrc directive", () => {
+      const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.mediaSrc).toBeUndefined();
+    });
+
+    it("should not have frameSrc directive", () => {
+      const directives = helmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.frameSrc).toBeUndefined();
     });
 
     it("should have dnsPrefetchControl disabled", () => {
@@ -95,95 +161,183 @@ describe("helmet config", () => {
       ).toBeDefined();
     });
 
+    it("should only have expected directives", () => {
+      const directives =
+        webchatHelmetConfiguration.contentSecurityPolicy?.directives;
+      expect(Object.keys(directives!).sort()).toEqual([
+        "connectSrc",
+        "defaultSrc",
+        "formAction",
+        "frameSrc",
+        "imgSrc",
+        "mediaSrc",
+        "objectSrc",
+        "scriptSrc",
+        "scriptSrcAttr",
+        "styleSrc",
+        "workerSrc",
+      ]);
+    });
+
     it("should have correct defaultSrc directive", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
       expect(directives?.defaultSrc).toEqual(["'self'"]);
     });
 
-    it("should have styleSrc with nonce function", () => {
+    it("should have correct styleSrc directive", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
       const styleSrc = directives?.styleSrc as any[];
 
-      expect(styleSrc).toBeDefined();
-      expect(typeof styleSrc[0]).toBe("function");
+      expect(styleSrc).toHaveLength(4);
+      expect(styleSrc).toContain("'self'");
+      expect(styleSrc).toContain("https://*.smartagent.app");
+      expect(styleSrc).toContain("https://fonts.cdnfonts.com");
+      expect(getNonceFunction(styleSrc)).toBeDefined();
     });
 
     it("should generate nonce in styleSrc function", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
       const styleSrc = directives?.styleSrc as any[];
-      const nonceFunc = styleSrc[0];
+      const nonceFunc = getNonceFunction(styleSrc);
 
       const req = {} as Request;
       const res = { locals: { scriptNonce: "test-nonce-456" } } as Response;
 
-      const result = nonceFunc(req, res);
-      expect(result).toBe("'nonce-test-nonce-456'");
+      expect(nonceFunc(req, res)).toBe("'nonce-test-nonce-456'");
     });
 
-    it("should have scriptSrc with nonce function", () => {
+    it("should have correct scriptSrc directive", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
       const scriptSrc = directives?.scriptSrc as any[];
 
-      expect(scriptSrc).toBeDefined();
-      expect(typeof scriptSrc[1]).toBe("function");
+      expect(scriptSrc).toHaveLength(11);
+      expect(scriptSrc).toContain("'self'");
+      expect(scriptSrc).toContain(
+        "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='" // pragma: allowlist secret
+      );
+      expect(scriptSrc).toContain("https://*.googletagmanager.com");
+      expect(scriptSrc).toContain("https://*.google-analytics.com");
+      expect(scriptSrc).toContain("https://*.analytics.google.com");
+      expect(scriptSrc).toContain("https://*.g.doubleclick.net");
+      expect(scriptSrc).toContain("https://*.smartagent.app");
+      expect(scriptSrc).toContain("https://*.ruxit.com");
+      expect(scriptSrc).toContain("https://*.dynatrace.com");
+      expect(scriptSrc).toContain("'strict-dynamic'");
+      expect(getNonceFunction(scriptSrc)).toBeDefined();
     });
 
     it("should generate nonce in scriptSrc function", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
       const scriptSrc = directives?.scriptSrc as any[];
-      const nonceFunc = scriptSrc[1];
+      const nonceFunc = getNonceFunction(scriptSrc);
 
       const req = {} as Request;
       const res = { locals: { scriptNonce: "webchat-nonce" } } as Response;
 
-      const result = nonceFunc(req, res);
-      expect(result).toBe("'nonce-webchat-nonce'");
+      expect(nonceFunc(req, res)).toBe("'nonce-webchat-nonce'");
     });
 
-    it("should have scriptSrcAttr directive", () => {
+    it("should have correct scriptSrcAttr directive", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.scriptSrcAttr).toHaveLength(2);
       expect(directives?.scriptSrcAttr).toContain("'self'");
       expect(directives?.scriptSrcAttr).toContain("'unsafe-inline'");
     });
 
-    it("should have workerSrc directive", () => {
+    it("should have correct imgSrc directive", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
-      expect(directives?.workerSrc).toEqual(["blob:"]);
+      expect(directives?.imgSrc).toHaveLength(7);
+      expect(directives?.imgSrc).toContain("'self'");
+      expect(directives?.imgSrc).toContain("data:");
+      expect(directives?.imgSrc).toContain("https://*.googletagmanager.com");
+      expect(directives?.imgSrc).toContain("https://*.google-analytics.com");
+      expect(directives?.imgSrc).toContain("https://*.analytics.google.com");
+      expect(directives?.imgSrc).toContain("https://*.g.doubleclick.net");
+      expect(directives?.imgSrc).toContain(
+        "https://*.s3.eu-west-2.amazonaws.com"
+      );
     });
 
-    it("should have mediaSrc directive", () => {
+    it("should have objectSrc set to none", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
-      expect(directives?.mediaSrc).toContain("'self'");
+      expect(directives?.objectSrc).toEqual(["'none'"]);
     });
 
-    it("should have frameSrc directive", () => {
+    it("should have correct connectSrc directive", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
-      expect(directives?.frameSrc).toContain("'self'");
-      expect(directives?.frameSrc).toContain("https://*.smartagent.app");
+      const connectSrc = directives?.connectSrc as any[];
+
+      expect(connectSrc).toHaveLength(11);
+      expect(connectSrc).toContain("'self'");
+      expect(connectSrc).toContain("https://*.google-analytics.com");
+      expect(connectSrc).toContain("https://*.analytics.google.com");
+      expect(connectSrc).toContain("https://*.g.doubleclick.net");
+      expect(connectSrc).toContain("https://*.smartagent.app");
+      expect(connectSrc).toContain("https://*.ruxit.com");
+      expect(connectSrc).toContain("https://*.dynatrace.com");
+      expect(connectSrc).toContain(
+        "https://participant.connect.eu-west-2.amazonaws.com"
+      );
+      expect(connectSrc).toContain(
+        "wss://*.transport.connect.eu-west-2.amazonaws.com"
+      );
+      expect(connectSrc).toContain(" https://api.rollbar.com");
+      expect(getNonceFunction(connectSrc)).toBeDefined();
     });
 
     it("should generate websocket address in connectSrc function", () => {
       const directives =
         webchatHelmetConfiguration.contentSecurityPolicy?.directives;
       const connectSrc = directives?.connectSrc as any[];
-      const wsFunc = connectSrc.find((item) => typeof item === "function");
+      const wsFunc = getNonceFunction(connectSrc);
 
       const req = {} as Request;
       const res = {
         locals: { missionLabWebSocketAddress: "wss://test.websocket.com" },
       } as Response;
 
-      const result = wsFunc(req, res);
-      expect(result).toBe("wss://test.websocket.com");
+      expect(wsFunc(req, res)).toBe("wss://test.websocket.com");
+    });
+
+    it("should have correct workerSrc directive", () => {
+      const directives =
+        webchatHelmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.workerSrc).toEqual(["blob:"]);
+    });
+
+    it("should have correct formAction directive", () => {
+      const directives =
+        webchatHelmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.formAction).toHaveLength(2);
+      expect(directives?.formAction).toContain("'self'");
+      expect(directives?.formAction).toContain("https://*.account.gov.uk");
+    });
+
+    it("should have correct mediaSrc directive", () => {
+      const directives =
+        webchatHelmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.mediaSrc).toHaveLength(2);
+      expect(directives?.mediaSrc).toContain("'self'");
+      expect(directives?.mediaSrc).toContain(
+        "https://*.s3.eu-west-2.amazonaws.com"
+      );
+    });
+
+    it("should have correct frameSrc directive", () => {
+      const directives =
+        webchatHelmetConfiguration.contentSecurityPolicy?.directives;
+      expect(directives?.frameSrc).toHaveLength(2);
+      expect(directives?.frameSrc).toContain("'self'");
+      expect(directives?.frameSrc).toContain("https://*.smartagent.app");
     });
 
     it("should have dnsPrefetchControl disabled", () => {


### PR DESCRIPTION
## Summary

Scopes the relaxed `Content-Security-Policy` (containing `'unsafe-inline'` in `script-src-attr`) to only the contact page where the SmartAgent webchat widget is loaded, rather than applying it globally.

## Changes

1. Iterated helmet config tests. Asserts exact directive values and keys so accidental CSP changes are caught in preparation for the following refactor...
2. Derive webchat CSP from base config. Removes duplication, adds explicit `styleSrc: ['self']` to override helmet's insecure default of `style-src 'self' https: 'unsafe-inline';`, which is needed as the webchat CSP was previously applied to all pages, which included the more secure `style-src` that would be reverted if we used the base CSP as was.
3. Scope webchat CSP to contact page only, which moves the relaxed CSP from global middleware in `app.ts` to the contact page router.

## What was tested

- Unit tests for both helmet config objects
- Existing app and contact controller tests still pass
- Tested on dev, comparing contact and non-contact pages in prod to those on dev with this branch deployed and main deployed. Behaviours match and the different CSP response header values seen as expected.