### PR TITLE
OLH-4233: Fix passkey tests timing out sporadically (hopefully 🤞🏼)

### DIFF
--- a/integration-tests/tests/features/@manage-passkeys.feature
+++ b/integration-tests/tests/features/@manage-passkeys.feature
@@ -7,6 +7,7 @@ Scenario: add a passkey
   Then I click the "Manage your sign in details" link
   Then I click the "Set up a passkey" link
   Then I enter and submit my password "qwerty"
+  And the page has finished loading
   Then I click the "passkey-create success" link
   Then the page contains the text "Your passkey is saved to Windows Hello."
 
@@ -17,6 +18,7 @@ Scenario: add a passkey with no name
   Then I click the "Manage your sign in details" link
   Then I click the "Set up a passkey" link
   Then I enter and submit my password "qwerty"
+  And the page has finished loading
   Then I click the "passkey-create success (passkey has no display name)" link
   And the page has finished loading
   Then the page does not contain the text "Your passkey is saved to Windows Hello."


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
The Manage passkey tests ocasionally time out during local integration test runs, but mostly when running in GitHub Actions. 
This seems to be happening before the step where an outcome is selected on the stub page where the request doesn't seem to complete before the test times out.
An example of a failing run: https://github.com/govuk-one-login/di-account-management-frontend/actions/runs/27531318492/job/81369842925 

Adding "And the page has finished loading" before the outcome selection step _should_ hopefully fix this.
<!-- Describe the changes in detail - the "what"-->

## How to review
It might be a challenge to confirm that this has worked as the failures were only happening on and off before.  
I'd noticed these tests failing locally when I was connected to the VPN, which I haven't been able to replicate after making this tweak (however, this could be a coincidence). 
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
