### PR TITLE
OLH-4366: set x-Permitted-Cross-Domain-Policies header to none

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -52,7 +52,9 @@ export const helmetConfiguration: HelmetOptions = {
     includeSubDomains: true,
   },
   referrerPolicy: false,
-  permittedCrossDomainPolicies: false,
+  permittedCrossDomainPolicies: {
+    permittedPolicies: "none",
+  },
 };
 
 const baseCspDirectives = (

--- a/test/unit/config/helmet.test.ts
+++ b/test/unit/config/helmet.test.ts
@@ -150,8 +150,10 @@ describe("helmet config", () => {
       expect(helmetConfiguration.referrerPolicy).toBe(false);
     });
 
-    it("should have permittedCrossDomainPolicies disabled", () => {
-      expect(helmetConfiguration.permittedCrossDomainPolicies).toBe(false);
+    it("should have permittedCrossDomainPolicies set to none", () => {
+      expect(helmetConfiguration.permittedCrossDomainPolicies).toStrictEqual({
+        permittedPolicies: "none",
+      });
     });
   });
 
@@ -364,10 +366,10 @@ describe("helmet config", () => {
       expect(webchatHelmetConfiguration.referrerPolicy).toBe(false);
     });
 
-    it("should have permittedCrossDomainPolicies disabled", () => {
-      expect(webchatHelmetConfiguration.permittedCrossDomainPolicies).toBe(
-        false
-      );
+    it("should have permittedCrossDomainPolicies set to none", () => {
+      expect(helmetConfiguration.permittedCrossDomainPolicies).toStrictEqual({
+        permittedPolicies: "none",
+      });
     });
   });
 });


### PR DESCRIPTION
Setting X-Permitted-Cross-Domain-Policies: none tells Adobe Flash and Acrobat (and similar cross-domain-capable clients) that they are not allowed to load any data from your domain, even if a `crossdomain.xml` file is present.

Previously, with `permittedCrossDomainPolicies: false`, helmet was not sending this header at all — meaning there was no explicit instruction to those clients, and they could potentially respect a `crossdomain.xml` file if one existed.

In practice, this is a defence-in-depth measure. Flash is effectively dead, but the header is still recommended as a security best practice to prevent any legacy or niche cross-domain policy abuse.