### PR TITLE
OLH-4381: harden publish to dev GitHub Action

### DIFF
--- a/.github/workflows/on-manual-publish-to-dev.yml
+++ b/.github/workflows/on-manual-publish-to-dev.yml
@@ -39,17 +39,17 @@ jobs:
       - name: Fetch Commit SHA
         id: gitRefSHA
         if: github.event.inputs.refType == 'Commit SHA'
-        run: echo GIT_REF_SHA=${{ inputs.gitRef }} >> $GITHUB_ENV
+        run: echo "GIT_REF_SHA=${{ inputs.gitRef }}" >> $GITHUB_ENV
 
       - name: Fetch Commit SHA by Branch name
         id: gitRefBranch
         if: github.event.inputs.refType == 'Branch name'
-        run: echo GIT_REF_SHA=$(git log -1 ${{ inputs.gitRef }} --pretty=format:%H) >> $GITHUB_ENV
+        run: echo "GIT_REF_SHA=$(git log -1 '${{ inputs.gitRef }}' --pretty=format:%H)" >> $GITHUB_ENV
 
       - name: Fetch Commit SHA by Tag
         id: gitRefTag
         if: github.event.inputs.refType == 'Tag'
-        run: echo GIT_REF_SHA=$(git rev-list -n 1 ${{ inputs.gitRef }}) >> $GITHUB_ENV
+        run: echo "GIT_REF_SHA=$(git rev-list -n 1 '${{ inputs.gitRef }}')" >> $GITHUB_ENV
 
       - name: Set tag
         id: vars
@@ -78,8 +78,10 @@ jobs:
 
       - name: Override RP Registry version
         if: inputs.rpRegistryRef != ''
+        env:
+          RP_REGISTRY_REF: ${{ inputs.rpRegistryRef }}
         run: |
-          npm pkg set "dependencies.di-account-management-rp-registry=github:govuk-one-login/di-account-management-rp-registry#${{ inputs.rpRegistryRef }}"
+          npm pkg set "dependencies.di-account-management-rp-registry=github:govuk-one-login/di-account-management-rp-registry#${RP_REGISTRY_REF}"
           npm install --package-lock-only di-account-management-rp-registry
 
       - name: Build & Publish Docker Image as latest


### PR DESCRIPTION
Security hardening of GitHub Actions workflow by properly quoting template strings:

- Added proper quoting around `${{ inputs.gitRef }}` in all git commands to prevent command injection
- Quoted environment variable assignments for `GIT_REF_SHA`
- Added quotes around git command arguments (`git log` and `git rev-list` commands)
- Refactored the `npm pkg set` command to use an environment variable `RP_REGISTRY_REF` instead of directly embedding `${{ inputs.rpRegistryRef }}` to prevent injection attacks

These changes protect against potential security vulnerabilities where malicious input could be used to execute unintended commands through template string interpolation.