### PR TITLE
OLH-2440: Improve ECS scaling resilience and overload protection

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -438,53 +438,6 @@ Resources:
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
 
-  ALBRequestCountScaleOutPolicy:
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: ALBRequestCountScaleOutPolicy
-      PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref ECSCluster
-          - !GetAtt ContainerService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      StepScalingPolicyConfiguration:
-        AdjustmentType: ChangeInCapacity
-        Cooldown: 30
-        StepAdjustments:
-          - MetricIntervalLowerBound: 0
-            MetricIntervalUpperBound: 100
-            ScalingAdjustment: 1 # Add 1 task if requests are 201–300
-          - MetricIntervalLowerBound: 100
-            MetricIntervalUpperBound: 300
-            ScalingAdjustment: 2 # Add 2 tasks if requests are 301–500
-          - MetricIntervalLowerBound: 300
-            ScalingAdjustment: 3 # Add 3 tasks if requests > 500
-
-  ALBRequestCountScaleInPolicy:
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: ALBRequestCountScaleInPolicy
-      PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref ECSCluster
-          - !GetAtt ContainerService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      StepScalingPolicyConfiguration:
-        AdjustmentType: ChangeInCapacity
-        Cooldown: 30
-        StepAdjustments:
-          - MetricIntervalUpperBound: -100
-            ScalingAdjustment: -2 # Requests < 100
-          - MetricIntervalLowerBound: -100
-            MetricIntervalUpperBound: 0
-            ScalingAdjustment: -1 # Requests between 100–200
-
   ECSStepScaleOutPolicy:
     DependsOn: ContainerAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
@@ -582,50 +535,6 @@ Resources:
       Statistic: "Average"
       Period: "60"
       Threshold: "30"
-
-  ALBRequestCountScaleOutAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: "ALB-RequestCount-High"
-      MetricName: "RequestCount"
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref ALBRequestCountScaleOutPolicy
-      AlarmDescription: "ALB-RequestCount-Above-200"
-      DatapointsToAlarm: "1"
-      Namespace: AWS/ApplicationELB
-      ComparisonOperator: "GreaterThanThreshold"
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !GetAtt ApplicationLoadBalancer.LoadBalancerFullName
-      Statistic: Sum
-      Period: "60"
-      EvaluationPeriods: 1
-      Threshold: "2000"
-      TreatMissingData: "notBreaching"
-
-  ALBRequestCountScaleInAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: "ALB-RequestCount-Normal"
-      MetricName: "RequestCountPerTarget"
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref ALBRequestCountScaleInPolicy
-      AlarmDescription: "ALB-RequestCount-Below-200"
-      DatapointsToAlarm: "1"
-      Namespace: AWS/ApplicationELB
-      ComparisonOperator: "LessThanThreshold"
-      Dimensions:
-        - Name: LoadBalancer
-          Value: !GetAtt ApplicationLoadBalancer.LoadBalancerFullName
-        - Name: TargetGroup
-          Value: !Ref ContainerAutoScalingTarget
-      Statistic: Sum
-      Period: "60"
-      EvaluationPeriods: 1
-      Threshold: "1000"
-      TreatMissingData: "notBreaching"
 
   ContainerServiceSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -526,7 +526,7 @@ Resources:
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
-        Cooldown: 60
+        Cooldown: 300
         StepAdjustments: # Bounds are calculated based on difference from alarm threshold
           - MetricIntervalLowerBound: -10 #20%
             MetricIntervalUpperBound: 0 #30%
@@ -567,16 +567,16 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref ECSStepScaleInPolicy
-      AlarmDescription: "ECSClusterUnder40PercentCPU"
+      AlarmDescription: "ECSClusterUnder30PercentCPU"
       ComparisonOperator: "LessThanThreshold"
-      DatapointsToAlarm: "1"
+      DatapointsToAlarm: "5"
       Dimensions:
         - Name: ClusterName
           Value: !Ref ECSCluster
         - Name: ServiceName
           Value: !GetAtt ContainerService.Name
       Unit: "Percent"
-      EvaluationPeriods: "1"
+      EvaluationPeriods: "5"
       MetricName: "CPUUtilization"
       Namespace: "AWS/ECS"
       Statistic: "Average"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -500,15 +500,16 @@ Resources:
       ServiceNamespace: ecs
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
-        Cooldown: 30
+        Cooldown: 60
+        MinAdjustmentMagnitude: 10
         StepAdjustments: # Bounds are calculated based on difference from alarm threshold
-          - MetricIntervalUpperBound: 10 #50%
-            ScalingAdjustment: 50
-          - MetricIntervalLowerBound: 10 #50%
-            MetricIntervalUpperBound: 30 #70%
-            ScalingAdjustment: 100
-          - MetricIntervalLowerBound: 30 #70%
-            ScalingAdjustment: 200
+          - MetricIntervalUpperBound: 10 #30-40% CPU
+            ScalingAdjustment: 300
+          - MetricIntervalLowerBound: 10 #40-60% CPU
+            MetricIntervalUpperBound: 30
+            ScalingAdjustment: 600
+          - MetricIntervalLowerBound: 30 #60%+ CPU
+            ScalingAdjustment: 1000
 
   ECSStepScaleInPolicy:
     DependsOn: ContainerAutoScalingTarget
@@ -543,8 +544,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref ECSStepScaleOutPolicy
-      AlarmDescription: "ECSClusterOver40PercentCPU"
-      ComparisonOperator: "GreaterThanThreshold"
+      AlarmDescription: "ECSClusterOver30PercentCPU"
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
       DatapointsToAlarm: "1"
       Dimensions:
         - Name: ClusterName
@@ -557,7 +558,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "40"
+      Threshold: "30"
 
   ECSStepScaleInAlarm:
     DependsOn: ContainerAutoScalingTarget

--- a/src/middleware/overload-protection-middleware.ts
+++ b/src/middleware/overload-protection-middleware.ts
@@ -5,7 +5,7 @@ export const applyOverloadProtection = (isProduction: boolean) => {
     production: isProduction,
     clientRetrySecs: 3,
     sampleInterval: 10,
-    maxEventLoopDelay: 500,
+    maxEventLoopDelay: 700,
     maxHeapUsedBytes: 0,
     maxRssBytes: 0,
     errorPropagationMode: false,

--- a/test/unit/middleware/overload-protection-middleware.test.ts
+++ b/test/unit/middleware/overload-protection-middleware.test.ts
@@ -13,9 +13,8 @@ describe("applyOverloadProtection", () => {
       default: overloadProtectionStub,
     }));
 
-    const module = await import(
-      "../../../src/middleware/overload-protection-middleware.js"
-    );
+    const module =
+      await import("../../../src/middleware/overload-protection-middleware.js");
     applyOverloadProtection = module.applyOverloadProtection;
   });
 
@@ -43,7 +42,7 @@ function expectedOverloadProtectionConfig(isProduction: boolean) {
     production: isProduction,
     clientRetrySecs: 3,
     sampleInterval: 10,
-    maxEventLoopDelay: 500,
+    maxEventLoopDelay: 700,
     maxHeapUsedBytes: 0,
     maxRssBytes: 0,
     errorPropagationMode: false,


### PR DESCRIPTION
## Proposed changes

### What changed

- Raised `maxEventLoopDelay` threshold from 500ms to 700ms in overload-protection middleware
- Replaced ECS step scaling policy: +50/100/200% → +300/600/1000% with `MinAdjustmentMagnitude: 10`
- Lowered CPU scale-out alarm threshold from 40% to 30%
- Slowed scale-in: requires 5 consecutive minutes below threshold (was 1), cooldown 60s → 300s
- Removed redundant ALB request count scaling policies (threshold was above our peak NFR volume, so they never fired)

### Why did it change

Performance test on 2026-06-18 failed with cascading 503s. Investigation found:
1. Overload protection was too sensitive at 500ms. The auth team hit the same issue and raised to 700ms. Our NFR is based on a proportion of their NFR so we match their configuration.
2. Step scaling was too slow — from 3 tasks, +50% increments took ~4.5 minutes of compounding cycles to reach max. Tasks saturated and returned 503s for the entire window.
3. Scale-in was too aggressive — single datapoint with 60s cooldown risked oscillation.

Our NFR states we need to handle a proportion of sign-in volumes, making our scaling requirements a direct derivative of the auth frontend's. Matching their scaling resilience is appropriate. The scaling approach aligns with ADR 0140 which recommends step scaling with percentage-based adjustments for frontends, and specifically recommends 5 datapoints for scale-in evaluation.

A further performance test will be run to evaluate these changes. Future work may involve raising the minimum running tasks.

### Related links

- https://github.com/govuk-one-login/authentication-frontend/commit/b74444bf313524b95e802d5075c75657bb0736d4 (auth team raising to 700ms)
- https://github.com/govuk-one-login/authentication-frontend/commit/98c574c73f625c7be63f3e376e838ee2ced837be (auth team scaling config)
- https://github.com/govuk-one-login/architecture/blob/main/adr/0140-fargate-scaling.md (ADR 0140)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

- Unit tests updated and passing (overload-protection-middleware)
- Deployed to dev successfully

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues