### PR TITLE
BAU: Fix FlexSearch Worker thread memory leak

### DIFF
--- a/src/components/search-services/search-services-controller.ts
+++ b/src/components/search-services/search-services-controller.ts
@@ -3,6 +3,7 @@ import { getAppEnv, getClientsToShowInSearch } from "../../config.js";
 import { LOCALE } from "../../app.constants.js";
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { Worker, Index } from "flexsearch";
+import { Worker as ThreadWorker } from "node:worker_threads";
 import { getTranslations } from "di-account-management-rp-registry";
 import i18next, { TFunction } from "i18next";
 import { safeTranslate } from "../../utils/safeTranslate.js";
@@ -62,7 +63,11 @@ export const getAllServices = (translate: Request["t"], locale: LOCALE) => {
     });
 };
 
-const indexes: Record<string, Index<true, false, true>> = {};
+type WorkerIndex = Index<true, false, true> & {
+  worker?: ThreadWorker;
+};
+
+const indexes: Record<string, WorkerIndex> = {};
 
 export const createSearchIndex = async (
   locale: LOCALE,
@@ -96,6 +101,9 @@ export const createSearchIndex = async (
       })
     );
 
+    if (indexes[locale]) {
+      await indexes[locale].worker?.terminate();
+    }
     indexes[locale] = index;
   }
 };

--- a/src/components/search-services/tests/search-services-controller.test.ts
+++ b/src/components/search-services/tests/search-services-controller.test.ts
@@ -346,6 +346,23 @@ describe("createSearchIndex", () => {
 
     expect(i18nextStub).not.toHaveBeenCalled();
   });
+
+  it("should terminate the old worker thread when recreating an index", async () => {
+    const mockTranslate = vi.fn((key: string) => key);
+    i18nextStub.mockReturnValue(mockTranslate as any);
+    safeTranslateStub.mockImplementation((translate, key) => translate(key));
+    vi.spyOn(config, "getClientsToShowInSearch").mockReturnValue([]);
+
+    await createSearchIndex(LOCALE.CY, true, false);
+
+    const { Worker: NodeWorker } = await import("worker_threads");
+    const terminateSpy = vi.spyOn(NodeWorker.prototype, "terminate");
+
+    await createSearchIndex(LOCALE.CY, false, true);
+
+    expect(terminateSpy).toHaveBeenCalled();
+    terminateSpy.mockRestore();
+  });
 });
 
 describe("searchServices", () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Terminate the old FlexSearch Worker thread before replacing the search index during hourly recreation.

### Why did it change

`recreateSearchIndexes()` creates a new FlexSearch `Worker` (a `node:worker_threads` thread) every hour per locale. The old Worker reference was overwritten without terminating the thread. Worker threads are not garbage collected when dereferenced - they must be explicitly terminated. This caused a steady memory leak of one orphaned thread per locale per hour.

### Related links

- https://github.com/nextapps-de/flexsearch
- FlexSearch does not expose a `destroy()` method on Worker instances despite the type definitions suggesting otherwise. The underlying `worker_threads.Worker.terminate()` must be called directly.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

- Unit test added verifying `terminate()` is called on the Worker prototype during index recreation

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

Single commit. The fix is 3 lines plus a type definition to properly type the internal `worker` property that FlexSearch exposes at runtime but not in its type definitions.