### PR TITLE
OLH-2440: raise build MinCapacity to 6

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -139,7 +139,7 @@ Mappings:
     build:
       CPU: 1024
       Memory: 2048
-      MinCapacity: 3
+      MinCapacity: 6
       MaxCapacity: 40
     staging:
       CPU: 1024


### PR DESCRIPTION
## Summary

Raises minimum ECS task count in build from 3 to 6 to test whether additional capacity prevents overload-protection 503s during performance test ramp-up.

## Context

Performance tests ramp from zero load simultaneously across all ECS tasks, causing event loop delay spikes >700ms that trigger overload-protection 503s. Doubling minimum tasks halves per-node load during ramp-up.

## Rollout

- Build only for now to validate the approach
- May be rolled out to other environments including production later

## Changes

- `deploy/template.yaml`: build `MinCapacity: 3` → `MinCapacity: 6`