### PR TITLE
OLH-2440: raise MinCapacity to 6 for more environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -144,17 +144,17 @@ Mappings:
     staging:
       CPU: 1024
       Memory: 2048
-      MinCapacity: 3
+      MinCapacity: 6
       MaxCapacity: 40
     integration:
       CPU: 1024
       Memory: 2048
-      MinCapacity: 3
+      MinCapacity: 6
       MaxCapacity: 40
     production:
       CPU: 1024
       Memory: 2048
-      MinCapacity: 3
+      MinCapacity: 6
       MaxCapacity: 40
   EnvironmentVariables:
     ### These environment variables are referenced further down the file.


### PR DESCRIPTION
## Proposed changes

### What changed

Raised ECS `MinCapacity` from 3 to 6 for staging, integration and production environments in the SAM template.

### Why did it change

The build environment change proved effective in the last performance test, preventing a significant number of overload-protection 503s during ramp-up. Applying the same minimum task count across all remaining route-to-live environments.

Once passkeys performance testing is done we can dial back down on build env again.

### Related links

- #3077

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

Infra-only change to ECS scaling mappings. Verify the diff only touches `MinCapacity` for the three environments.