### PR TITLE
OLH-2440: enable Nunjucks template caching in deployed environments

### DIFF
--- a/src/config/nunjucks.ts
+++ b/src/config/nunjucks.ts
@@ -5,6 +5,7 @@ import i18next, { TFunction } from "i18next";
 import { EXTERNAL_URLS, LOCALE, PATH_DATA } from "../app.constants.js";
 import { addLanguageParam } from "@govuk-one-login/frontend-ui";
 import { safeTranslate } from "../utils/safeTranslate.js";
+import { isLocalEnv } from "../config.js";
 
 export function configureNunjucks(
   app: express.Application,
@@ -13,7 +14,7 @@ export function configureNunjucks(
   const nunjucksEnv: nunjucks.Environment = nunjucks.configure(viewsPath, {
     autoescape: true,
     express: app,
-    noCache: true,
+    noCache: isLocalEnv(),
   });
 
   nunjucksEnv.addFilter(


### PR DESCRIPTION
## Proposed changes

### What changed

Set Nunjucks `noCache` to `isLocalEnv()` instead of unconditional `true`. Templates are now cached in memory in all deployed environments.

### Why did it change

Local profiling with clinic flame and autocannon revealed that `readFileSync` in Nunjucks `getSource` accounted for ~54% of CPU self-time under load. Every request was re-reading template files from disk and re-compiling them synchronously, blocking the event loop.

With caching enabled:
- Compiled template ASTs are held in memory and reused
- Synchronous disk reads are eliminated after first request
- Local benchmark showed ~37% throughput improvement

This allows Nunjucks to cache the compiled template, not the rendered output. This option is defaulted to false usually, https://mozilla.github.io/nunjucks/api.html.

### Related links

- #3078 (MinCapacity increase)
- Performance test iteration 10 report

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

Single line change in `src/config/nunjucks.ts`. Verify the diff only changes `noCache: true` to `noCache: isLocalEnv()` with the import added.