### PR TITLE
OLH-4449: update journey outcome interface

### DIFF
--- a/src/components/amc-callback/amc-callback-utils.ts
+++ b/src/components/amc-callback/amc-callback-utils.ts
@@ -41,7 +41,8 @@ interface JourneyOutcome {
   success: boolean;
   actions: {
     action: string;
-    timestamp: number;
+    startedAt: number;
+    completedAt: number;
     success: boolean;
     details: {
       aaguid?: string;


### PR DESCRIPTION
In AMC the `timestamp` field on journey outcome actions has been replaced with a `startedAt` field and a `completedAt` field. This PR updates the interface in AMF to reflect this change.