### PR TITLE
OLH-4233: Playwright test tweaks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,3 +100,11 @@ jobs:
           echo "PRE_OR_POST_DEPLOY=pre" >> .env
           echo "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:3000/" >> .env
           npm run test
+
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-test-results
+          path: integration-tests/test-results/
+          retention-days: 7

--- a/integration-tests/tests/features/@activity-history.feature
+++ b/integration-tests/tests/features/@activity-history.feature
@@ -4,7 +4,6 @@ Feature: "Activity history" page
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Activity history" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Activity history - Page 1"
     And the page has the "change your password" link
@@ -15,21 +14,15 @@ Feature: "Activity history" page
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Security" page
-    And the page has finished loading
     And I click the "See your activity history" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 1"
     Given I click the "Page 3" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 3"
     And the page has the "change your password" link
     Given I click the "change your password" link
-    And the page has finished loading
     And the page title is prefixed with "Enter your current password"
     Given I enter and submit my password "Pa55w0rd!"
-    And the page has finished loading
     Given I enter and submit my new password "NuPa55w0rd!"
-    And the page has finished loading
     And the page title is prefixed with "You’ve changed your password"
     And the page looks as expected
 
@@ -37,113 +30,77 @@ Feature: "Activity history" page
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Security" page
-    And the page has finished loading
     And I click the "See your activity history" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 1"
     Given I click the "Page 3" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 3"
     Given I click the "Previous page" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
     Given I click the "change your password" link
-    And the page has finished loading
     Given I click the "Back" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
 
   Scenario: Navigate back to paginated Activity history from 'change your password' page using Cancel link
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Activity history" page
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 1"
     Given I click the "Page 3" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 3"
     Given I click the "Previous page" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
     Given I click the "change your password" link
-    And the page has finished loading
     Given I enter and submit my password "Pa55w0rd!"
-    And the page has finished loading
     Given I click the "Cancel and go back" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
 
   Scenario: Navigate back to paginated Activity history from 'change password' success page using "Back to activity history" button
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Security" page
-    And the page has finished loading
     And I click the "See your activity history" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 1"
     Given I click the "Page 3" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 3"
     Given I click the "Previous page" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
     Given I click the "change your password" link
-    And the page has finished loading
     Given I enter and submit my password "Pa55w0rd!"
-    And the page has finished loading
     Given I enter and submit my new password "NuPa55w0rd!"
-    And the page has finished loading
     And the page title is prefixed with "You’ve changed your password"
     Given I click the "Back to activity history" button
-    And the page has finished loading
     And I click the "default" button
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
 
   Scenario: Navigate back to paginated Activity history from 'Enter password' when there has been a form error
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Security" page
-    And the page has finished loading
     And I click the "See your activity history" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 1"
     Given I click the "Page 3" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 3"
     Given I click the "Previous page" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
     Given I click the "change your password" link
-    And the page has finished loading
     Given I enter and submit my password ""
-    And the page has finished loading
     Then the page title is prefixed with "Error - Enter your current password"
     Given I click the "Back" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
 
   Scenario: Navigate back to paginated Activity history from 'Change password' when there has been a form error
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Security" page
-    And the page has finished loading
     And I click the "See your activity history" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 1"
     Given I click the "Page 3" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 3"
     Given I click the "Previous page" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"
     Given I click the "change your password" link
-    And the page has finished loading
     Given I enter and submit my password "Pa55w0rd!"
-    And the page has finished loading
     Given I enter and submit my new password "NuPa55w0rd!" erroneously
-    And the page has finished loading
     Then the page title is prefixed with "Error - Enter your new password"
     Given I click the "Cancel and go back" link
-    And the page has finished loading
     Then the page title is prefixed with "Activity history - Page 2"

--- a/integration-tests/tests/features/@add-backup-method.feature
+++ b/integration-tests/tests/features/@add-backup-method.feature
@@ -5,15 +5,12 @@ Feature: Add Backup SMS MFA Method
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTSms" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Add a back-up method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Add a back-up method"
         And I can see two radio buttons
@@ -21,16 +18,13 @@ Feature: Add Backup SMS MFA Method
         Given I click the detail block "What is an authenticator app"
         Then I can see the explanation details "An authenticator app creates a security code that helps confirm it’s you when you sign in."
         Given I select "UK mobile phone number" and click the "continue" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         Given I enter and submit my new mobile phone number "07890123456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Check your phone"
         And I am shown a message confirming a code has been sent to my new phone number ending "3456"
         Given I enter and submit the code "123456" sent to my new mobile number ending "3456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "You’ve added a back-up method for getting security codes"
         And I am shown a message confirming that I have added a backup method
@@ -42,15 +36,12 @@ Feature: Add Backup SMS MFA Method
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTSms" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Add a back-up method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Add a back-up method"
         And I can see two radio buttons
@@ -58,14 +49,12 @@ Feature: Add Backup SMS MFA Method
         Given I click the detail block "What is an authenticator app"
         Then I can see the explanation details "An authenticator app creates a security code that helps confirm it’s you when you sign in."
         Given I select "UK mobile phone number" and click the "continue" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         And I can see a collapsed detail block "I do not have a UK mobile phone number"
         Given I click the detail block "I do not have a UK mobile phone number"
         Then I can see an explanation and link to start this journey again
         Given I click the "Go back to choose authenticator app" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Add a back-up method"
         And I can see two radio buttons
@@ -76,29 +65,23 @@ Feature: Add Backup SMS MFA Method
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthApp" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Add a back-up method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Add a back-up method"
         And I can see the "Add a UK mobile phone number" button
         Given I click the "Add a UK mobile phone number" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         Given I enter and submit my new mobile phone number "07890123456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Check your phone"
         And I am shown a message confirming a code has been sent to my new phone number ending "3456"
         Given I enter and submit the code "123456" sent to my new mobile number ending "3456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "You’ve added a back-up method for getting security codes"
         And I am shown a message confirming that I have added a backup method
@@ -110,15 +93,12 @@ Feature: Add Backup SMS MFA Method
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthApp" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Add a back-up method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Add a back-up method"
         And I can see the "Add a UK mobile phone number" button
@@ -127,6 +107,5 @@ Feature: Add Backup SMS MFA Method
         Then I can see the explanation details "To get security codes by text message you must use a UK mobile phone number."
         And I can see the explanation details "As you already use an authenticator app to get security codes, you cannot add another one as a back-up method."
         Given I click the "Cancel and go back" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"

--- a/integration-tests/tests/features/@change-default-method.feature
+++ b/integration-tests/tests/features/@change-default-method.feature
@@ -5,28 +5,22 @@ Feature: Change Default MFA Method From Authenticator App
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthApp" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Use a different default method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Use a different default method"
         Given I click the "Add a UK mobile phone number" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         Given I enter and submit my new mobile phone number "07890123456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Check your phone"
         And I am shown a message confirming a code has been sent to my new phone number ending "3456"
         Given I enter and submit the code "123456" sent to my new mobile number ending "3456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "You’ve changed your default method for getting security codes"
         And I am shown a message confirming that my Default Method has been changed
@@ -39,19 +33,15 @@ Feature: Change Default MFA Method From Authenticator App
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthApp" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Use a different default method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Use a different default method"
         Given I click the "I do not have a UK mobile phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "If you do not have a UK mobile phone number"
         And I am shown a message explaining what I can do
@@ -63,23 +53,18 @@ Feature: Change Default MFA Method From Authenticator App
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthApp" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Use a different default method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Use a different default method"
         Given I click the "Add a UK mobile phone number" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         Given I click the "I do not have a UK mobile phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "If you do not have a UK mobile phone number"
         And I am shown a message explaining what I can do
@@ -91,28 +76,22 @@ Feature: Change Default MFA Method From Authenticator App
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthAppBackupSms" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Use a different default method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Use a different default method"
         Given I click the "Add a UK mobile phone number" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         Given I enter and submit my new mobile phone number "07890123456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Check your phone"
         And I am shown a message confirming a code has been sent to my new phone number ending "3456"
         Given I enter and submit the code "123456" sent to my new mobile number ending "3456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "You’ve changed your default method for getting security codes"
         And I am shown a message confirming that my Default Method has been changed
@@ -124,19 +103,15 @@ Feature: Change Default MFA Method From Authenticator App
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthAppBackupSms" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Use a different default method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Use a different default method"
         Given I click the "I do not have a UK mobile phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "If you do not have a UK mobile phone number"
         And I am shown a message explaining what I can do
@@ -148,23 +123,18 @@ Feature: Change Default MFA Method From Authenticator App
         Given I go to the "Root" page
         And I sign in as the "userDEFAULTAuthAppBackupSms" user
         And I go to the "Sign in details" page
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Sign in details"
         Given I click the "Use a different default method" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Use a different default method"
         Given I click the "Add a UK mobile phone number" button
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your UK mobile phone number"
         Given I click the "I do not have a UK mobile phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "If you do not have a UK mobile phone number"
         And I am shown a message explaining what I can do

--- a/integration-tests/tests/features/@change-email-address.feature
+++ b/integration-tests/tests/features/@change-email-address.feature
@@ -7,19 +7,15 @@ Feature: Change email address
     And I go to the "Sign in details" page
     Then the page title is prefixed with "Sign in details"
     Given I click the "Change email address" link
-    And the page has finished loading
     Then the page meets our accessibility standards
     And the page title is prefixed with "Enter your password"
     Given I enter and submit my password "Pa55w0rd!"
-    And the page has finished loading
     Then the page meets our accessibility standards
     And the page title is prefixed with "Enter your new email address"
     Given I enter and submit my new email address "new.email.address@test.com"
-    And the page has finished loading
     Then the page meets our accessibility standards
     And the page title is prefixed with "Check your email"
     Given I enter and submit the code "123456" sent to my new email address "new.email.address@test.com"
-    And the page has finished loading
     Then the page meets our accessibility standards
     And the page title is prefixed with "You’ve changed your email address"
     And I am shown a message confirming that my email address has been changed to "new.email.address@test.com"
@@ -32,6 +28,5 @@ Feature: Change email address
     Then I enter and submit my password "Pa55w0rd!"
     Then I enter and submit my new email address "fail.email.check@test.com"
     Then I enter and submit the code "123456" sent to my new email address "fail.email.check@test.com"
-    And the page has finished loading
     Then I am shown an error message explaining that this email address can't be used
     And the page looks as expected

--- a/integration-tests/tests/features/@change-phone-number.feature
+++ b/integration-tests/tests/features/@change-phone-number.feature
@@ -7,20 +7,16 @@ Feature: Change phone number
         And I go to the "Sign in details" page
         Then the page title is prefixed with "Sign in details"
         Given I click the "Change phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your new UK mobile phone number"
         Given I enter and submit my new mobile phone number "07890123456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Check your phone"
         And I am shown a message confirming a code has been sent to my new phone number ending "3456"
         Given I enter and submit the code "123456" sent to my new mobile number ending "3456"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "You’ve changed your phone number"
         And I am shown a message confirming that my phone number has been changed
@@ -33,15 +29,12 @@ Feature: Change phone number
         And I go to the "Sign in details" page
         Then the page title is prefixed with "Sign in details"
         Given I click the "Change phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your new UK mobile phone number"
         Given I enter and submit my new mobile phone number "33645453322"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Error - Enter your new UK mobile phone number"
         And I am shown an error message saying "There is a problem"
@@ -54,15 +47,12 @@ Feature: Change phone number
         And I go to the "Sign in details" page
         Then the page title is prefixed with "Sign in details"
         Given I click the "Change phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your new UK mobile phone number"
         Given I click the "I do not have a UK mobile phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "If you do not have a UK mobile phone number"
         And I am shown a message explaining what I can do
@@ -76,15 +66,12 @@ Feature: Change phone number
         And I go to the "Sign in details" page
         Then the page title is prefixed with "Sign in details"
         Given I click the "Change phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your password"
         Given I enter and submit my password "f4kePa55wo2d?!"
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your new UK mobile phone number"
         Given I click the "I do not have a UK mobile phone number" link
-        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "If you do not have a UK mobile phone number"
         And I am shown a message explaining what I can do

--- a/integration-tests/tests/features/@healthcheck.feature
+++ b/integration-tests/tests/features/@healthcheck.feature
@@ -3,5 +3,4 @@ Feature: "Healthcheck" page
   @postDeploy
   Scenario: Visit the "Healthcheck" page
     Given I go to the "Healthcheck" page
-    And the page has finished loading
     Then the page looks as expected

--- a/integration-tests/tests/features/@manage-passkeys.feature
+++ b/integration-tests/tests/features/@manage-passkeys.feature
@@ -7,7 +7,6 @@ Scenario: add a passkey
   Then I click the "Manage your sign in details" link
   Then I click the "Set up a passkey" link
   Then I enter and submit my password "qwerty"
-  And the page has finished loading
   Then I click the "passkey-create success" link
   Then the page contains the text "Your passkey is saved to Windows Hello."
 
@@ -18,9 +17,7 @@ Scenario: add a passkey with no name
   Then I click the "Manage your sign in details" link
   Then I click the "Set up a passkey" link
   Then I enter and submit my password "qwerty"
-  And the page has finished loading
   Then I click the "passkey-create success (passkey has no display name)" link
-  And the page has finished loading
   Then the page does not contain the text "Your passkey is saved to Windows Hello."
 
 Scenario: remove a passkey
@@ -30,35 +27,33 @@ Scenario: remove a passkey
   Then I click the "Manage your sign in details" link
   Then I click the "Remove iCloud Keychain (Managed) passkey" link
   Then I enter and submit my password "qwerty"
-  And the page has finished loading
-  Then the page looks as expected
-  Then I click the "Remove passkey" button
-  And the page has finished loading
-  Then the page looks as expected
+  Then the page title is prefixed with "Remove your passkey"
+  And the page looks as expected
+  Given I click the "Remove passkey" button
+  Then the page title is prefixed with "You’ve removed your passkey"
+  And the page looks as expected
 
 Scenario: remove a passkey without a name
   Given I go to the "Root" page
   And I sign in as the "onePasskeyNoDisplayName" user
   And I go to the "Security" page
-  Then I click the "Manage your sign in details" link
-  Then I click the "Remove passkey" link
-  Then I enter and submit my password "qwerty"
-  And the page has finished loading
-  Then the page looks as expected
+  And I click the "Manage your sign in details" link
+  And I click the "Remove passkey" link
+  And I enter and submit my password "qwerty"
+  Then the page title is prefixed with "Remove your passkey"
+  And the page looks as expected
   Then I click the "Remove passkey" button
-  And the page has finished loading
+  Then the page title is prefixed with "You’ve removed your passkey"
   Then the page looks as expected
 
 Scenario: pressing back from remove passkey confirmation redirects to your services
   Given I go to the "Root" page
   And I sign in as the "fourPasskeys" user
   And I go to the "Security" page
-  Then I click the "Manage your sign in details" link
-  Then I click the "Remove iCloud Keychain (Managed) passkey" link
-  Then I enter and submit my password "qwerty"
-  And the page has finished loading
-  Then I click the "Remove passkey" button
-  And the page has finished loading
-  Then I navigate back
-  And the page has finished loading
+  And I click the "Manage your sign in details" link
+  And I click the "Remove iCloud Keychain (Managed) passkey" link
+  And I enter and submit my password "qwerty"
+  Then the page title is prefixed with "Remove your passkey"
+  Given I click the "Remove passkey" button
+  And I navigate back
   Then the page title is prefixed with "Your services"

--- a/integration-tests/tests/features/@security.feature
+++ b/integration-tests/tests/features/@security.feature
@@ -5,7 +5,6 @@ Feature: "Security" page
     Given I go to the "Root" page
     And I sign in as the "default" user
     And I go to the "Security" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Security"
     And the page looks as expected

--- a/integration-tests/tests/features/@services-using-one-login.feature
+++ b/integration-tests/tests/features/@services-using-one-login.feature
@@ -3,7 +3,6 @@ Feature: "Services you can use with GOV.UK One Login" page
   @failMobile @failTarget-integration @failTarget-production
   Scenario: Visit the "Services you can use with GOV.UK One Login" page
     Given I go to the "Services you can use with GOV.UK One Login" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Services you can use with GOV.UK One Login"
     And the page meets our accessibility standards

--- a/integration-tests/tests/features/@sign-in-details.feature
+++ b/integration-tests/tests/features/@sign-in-details.feature
@@ -6,7 +6,6 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "noPasskeys" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Sign in details"
     And there are 0 passkeys in the list
@@ -18,11 +17,10 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "noPasskeys" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     Then the page title is prefixed with "Sign in details"
     And there are 0 passkeys in the list
     And the option to create a passkey is hidden
-    And the page looks as expected    
+    And the page looks as expected
 
   # Expected to fail on mobile due to known accessibility issues
   @failMobile
@@ -30,7 +28,6 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "onePasskey" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Sign in details"
     And there are 1 passkeys in the list
@@ -42,11 +39,10 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "onePasskey" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     Then the page title is prefixed with "Sign in details"
     And there are 1 passkeys in the list
     And the option to create a passkey is hidden
-    And the page looks as expected    
+    And the page looks as expected
 
   # Expected to fail on mobile due to known accessibility issues
   @failMobile
@@ -54,7 +50,6 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "onePasskeyNoDisplayName" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Sign in details"
     And there are 1 passkeys in the list
@@ -66,11 +61,10 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "onePasskeyNoDisplayName" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     Then the page title is prefixed with "Sign in details"
     And there are 1 passkeys in the list
     And the option to create a passkey is hidden
-    And the page looks as expected    
+    And the page looks as expected
 
   # Expected to fail on mobile due to known accessibility issues
   @failMobile
@@ -78,7 +72,6 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "fourPasskeys" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Sign in details"
     And there are 4 passkeys in the list
@@ -90,11 +83,10 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "fourPasskeys" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     Then the page title is prefixed with "Sign in details"
     And there are 4 passkeys in the list
     And the option to create a passkey is hidden
-    And the page looks as expected    
+    And the page looks as expected
 
   # Expected to fail on mobile due to known accessibility issues
   @failMobile
@@ -102,7 +94,6 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "fivePasskeys" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     And I accept cookies
     Then the page title is prefixed with "Sign in details"
     And there are 5 passkeys in the list
@@ -115,8 +106,7 @@ Feature: "Sign in details" page
     Given I go to the "Root" page
     And I sign in as the "fivePasskeys" user
     And I go to the "Sign in details" page
-    And the page has finished loading
     Then the page title is prefixed with "Sign in details"
     And there are 5 passkeys in the list
     And the option to create a passkey is hidden
-    And the page looks as expected    
+    And the page looks as expected

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -97,7 +97,7 @@
       "cancelButton": "Cancel and go back"
     },
     "removePasskeyConfirmation": {
-      "title": "You’ve removed your paskey",
+      "title": "You’ve removed your passkey",
       "panelText": "You’ve removed your passkey",
       "summaryText": "Next time you sign in, you can use another passkey.",
       "summaryTextNoPasskeys": "Next time you sign in, you’ll need to enter your password and a security code."

--- a/src/utils/getAmcJwe.ts
+++ b/src/utils/getAmcJwe.ts
@@ -54,6 +54,11 @@ export const getAmcJwe = async (
   const jwksUrl = new URL(getAmcJwksUrl());
   const jwksResponse = await fetch(jwksUrl);
   const jwks = await jwksResponse.json();
+
+  if (!jwks || !Array.isArray(jwks.keys)) {
+    throw new Error(`Invalid JWKS: ${JSON.stringify(jwks)}`);
+  }
+
   const encryptionJWK = jwks.keys.find((key: any) => key.use === "enc");
   const publicKey = await jose.importJWK(encryptionJWK, encryptionJWK.alg);
 


### PR DESCRIPTION
## Proposed changes

### What changed

`networkidle` (the event the `the page has finished loading` step is configured to wait for) doesn't necessarily verify that the page has loaded in the sense we might expect it. It resolves when there are no network requests for at least 500 ms which might be needed on pages where Javascript or CSS is injected into the DOM dynamically (as is the case for the webchat component on the contact page) but not necessarily useful or necessary on most of our other pages. 

This removes "And the page has finished loading" from most test scenarios, relying on Playwright's built-in auto waiting capabilities instead.

Update integration tests workflow to upload test results as an artifact on Github Actions.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

Speed up integration test runs a little (hopefully).

The test result artifact being attached to integration test action runs (see [Artifacts produced on this run](https://github.com/govuk-one-login/di-account-management-frontend/actions/runs/28584231943)), should help diagnose the issues we are currently having where tests are passing locally yet occasionally failing in Actions. 

<!-- Describe the reason these changes were made - the "why" -->
