### PR TITLE
OLH-4233: More integration test tweaks

### DIFF
--- a/integration-tests/tests/features/@change-email-address.feature
+++ b/integration-tests/tests/features/@change-email-address.feature
@@ -28,5 +28,6 @@ Feature: Change email address
     Then I enter and submit my password "Pa55w0rd!"
     Then I enter and submit my new email address "fail.email.check@test.com"
     Then I enter and submit the code "123456" sent to my new email address "fail.email.check@test.com"
+    And the page has finished loading
     Then I am shown an error message explaining that this email address can't be used
     And the page looks as expected

--- a/integration-tests/tests/features/@change-phone-number.feature
+++ b/integration-tests/tests/features/@change-phone-number.feature
@@ -35,6 +35,7 @@ Feature: Change phone number
         Then the page meets our accessibility standards
         And the page title is prefixed with "Enter your new UK mobile phone number"
         Given I enter and submit my new mobile phone number "33645453322"
+        And the page has finished loading
         Then the page meets our accessibility standards
         And the page title is prefixed with "Error - Enter your new UK mobile phone number"
         And I am shown an error message saying "There is a problem"

--- a/integration-tests/tests/steps/@sign-in-details.ts
+++ b/integration-tests/tests/steps/@sign-in-details.ts
@@ -4,7 +4,7 @@ import { bdd } from "./fixtures";
 const { Then } = bdd;
 
 Then("the option to create a passkey is hidden", async ({ page }) => {
-  await expect(page.getByTestId("create-passkey-box")).not.toBeVisible();
+  await expect(page.getByTestId("create-passkey-box")).toBeHidden();
 });
 
 Then(

--- a/integration-tests/tests/steps/shared.ts
+++ b/integration-tests/tests/steps/shared.ts
@@ -68,13 +68,13 @@ Given(
 
 Then(
   "the page title is prefixed with {string}",
-  async ({ page }, pageTitle: string) => {
-    expect(await page.title()).toBe(`${pageTitle} - GOV.UK One Login`);
+  async ({ page }, pageTitlePrefix: string) => {
+    await expect(page).toHaveTitle(`${pageTitlePrefix} - GOV.UK One Login`);
   }
 );
 
 Then("the page title is {string}", async ({ page }, pageTitle: string) => {
-  expect(await page.title()).toBe(pageTitle);
+  await expect(page).toHaveTitle(pageTitle);
 });
 
 Then("I am on the sign in page", async ({ page }) => {


### PR DESCRIPTION


## Proposed changes

Amend definition for "page title is prefixed with" to (hopefully) allow Playwright auto-waiting on tests including this step.

Add back "And the page has finished loading" on pages where there is flakiness due to progressively enhanced error summary component (focus is added with Javascript).
