### PR TITLE
OLH-4443: track sign out with a navigtion event

### DIFF
--- a/src/components/common/layout/header.njk
+++ b/src/components/common/layout/header.njk
@@ -35,7 +35,7 @@
               <nav class="account-header-navigation" aria-label="{{ 'general.header.signOutLink' | translate }}">
                 <form class="account-header-navigation__form" action="{{ accountSignOut }}" method="post">
                   <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-                  <button class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
+                  <button data-nav="true" data-link="{{ accountSignOut }}" class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
                 </form>
               </nav>
             </div>


### PR DESCRIPTION
Adds the necessary attributes to the sign out button so that clicking it sends an analytics navigation event.