### PR TITLE
OLH-4443: remove span from sign out button

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -146,20 +146,14 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
   background-color: transparent;
   padding: 0;
   margin: 0;
+  @include govuk-font($size: 16, $weight: bold);
+  color: govuk-colour("white");
+  @include govuk-link-style-inverse;
 
   &:focus {
     outline: none;
-    span {
-      @include govuk-focused-text;
-    }
+    @include govuk-focused-text;
   }
-}
-
-/* Specific styles for .account-header-navigation__button */
-.account-header-navigation__button-content {
-  @include govuk-font($size: 16);
-  color: govuk-colour("white");
-  @include govuk-link-style-inverse;
 
   &:not(:hover) {
     text-decoration: none;
@@ -172,10 +166,6 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
     @if $govuk-link-underline-offset {
       text-underline-offset: $govuk-link-underline-offset;
     }
-  }
-
-  &:focus {
-    @include govuk-focused-text;
   }
 }
 

--- a/src/components/common/layout/header.njk
+++ b/src/components/common/layout/header.njk
@@ -35,7 +35,7 @@
               <nav class="account-header-navigation" aria-label="{{ 'general.header.signOutLink' | translate }}">
                 <form class="account-header-navigation__form" action="{{ accountSignOut }}" method="post">
                   <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-                  <button data-nav="true" data-link="{{ accountSignOut }}" class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
+                  <button data-nav="true" data-link="{{ accountSignOut }}" class="account-header-navigation__button" type="submit">{{ 'general.header.signOutLink' | translate }}</button>
                 </form>
               </nav>
             </div>


### PR DESCRIPTION
Removes the span from inside the sign out button and styles the button directly. This is necessary because the analytics library won't fire navigation events on buttons which contain child elements.