### PR TITLE
BAU: Sign out button double underline fix

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -150,11 +150,6 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
   color: govuk-colour("white");
   @include govuk-link-style-inverse;
 
-  &:focus {
-    outline: none;
-    @include govuk-focused-text;
-  }
-
   &:not(:hover) {
     text-decoration: none;
   }
@@ -166,6 +161,11 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
     @if $govuk-link-underline-offset {
       text-underline-offset: $govuk-link-underline-offset;
     }
+  }
+
+  &:focus {
+    outline: none;
+    @include govuk-focused-text;
   }
 }
 


### PR DESCRIPTION

## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

I noticed a double thickness underline is applied to the sign out button when both focus and hover are applied. Moving the focus rule after the hover rule should fix this seeing as `govuk-focused-text` removes `text-decoration`.

#### Before

https://github.com/user-attachments/assets/96970186-2cd4-4e20-a32e-5a6015c3788f

#### After

https://github.com/user-attachments/assets/e5c01416-ecbe-4368-955b-0a377fb81805

