### PR TITLE
OLH-4470: fix link analytics

### DIFF
--- a/src/components/security/index.njk
+++ b/src/components/security/index.njk
@@ -17,7 +17,7 @@
       actions: {
         items: [
           {
-            href: enterPasswordUrl + "&type=changeEmail",
+            href: enterPasswordUrlForFormChangeResponseEvent + "&type=changeEmail",
             text: 'pages.security.accountDetails.summaryList.changeEmail' | translate
           }
         ]
@@ -34,7 +34,7 @@
       actions: {
         items: [
           {
-            href: enterPasswordUrl + "&type=changePassword",
+            href: enterPasswordUrlForFormChangeResponseEvent + "&type=changePassword",
             text: 'pages.security.accountDetails.summaryList.changePassword' | translate
           }
         ]
@@ -67,7 +67,7 @@
               <p class="govuk-body">{{ method.text }}</p>
               <p class="govuk-body"><a href="{{ method.linkHref }}" class="govuk-link"> {{ method.linkText }}</a></p>
               {% if canChangeTypeofPrimary %}
-              <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=changeDefaultMethod" class="govuk-link"> {{ ['pages.security.mfaSection.defaultMethod.change'] | join | translate }}</a></p>
+              <p class="govuk-body"><a href="{{enterPasswordUrlForFormChangeResponseEvent}}&type=changeDefaultMethod" class="govuk-link"> {{ ['pages.security.mfaSection.defaultMethod.change'] | join | translate }}</a></p>
               {% endif %}
             </div>
             {% set foundPrimary = true %}
@@ -81,8 +81,8 @@
               {# 1: backup method exists => display backup method block with options to change backup method or switch primary and backup #}
               <h3 class='govuk-heading-s'>{{ 'pages.security.mfaSection.backup.heading' | translate }}</h3>
               <p class="govuk-body">{{ method.text }}</p>
-              <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=switchBackupMethod" class="govuk-link"> {{ 'pages.security.mfaSection.backup.switchLink' | translate }}</a></p>
-              <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=removeBackup" class="govuk-link"> {{ 'pages.security.mfaSection.backup.removeLink' | translate }}</a></p>
+              <p class="govuk-body"><a href="{{enterPasswordUrlForNavigationEvent}}&type=switchBackupMethod" class="govuk-link"> {{ 'pages.security.mfaSection.backup.switchLink' | translate }}</a></p>
+              <p class="govuk-body"><a href="{{enterPasswordUrlForNavigationEvent}}&type=removeBackup" class="govuk-link"> {{ 'pages.security.mfaSection.backup.removeLink' | translate }}</a></p>
               {% set foundSecondary = true %}
             {% endif %}
           {% endfor %}
@@ -92,7 +92,7 @@
             <p class="govuk-body">{{ 'pages.security.mfaSection.backup.paragraph' | translate }}</p>
             <p class="govuk-body">{{ 'pages.security.mfaSection.backup.paragraph2' | translate }}</p>
             <p class="govuk-body">
-              <a href="{{enterPasswordUrl}}&type=addBackup" class="govuk-link">{{ 'pages.security.mfaSection.backup.link' | translate }}</a>
+              <a href="{{enterPasswordUrlForNavigationEvent}}&type=addBackup" class="govuk-link">{{ 'pages.security.mfaSection.backup.link' | translate }}</a>
             </p>
           {% endif %}
         </div>
@@ -124,6 +124,6 @@
   <div class="summary-list-container">
     <h2 class={{h2Class}}>{{ 'pages.security.deleteAccount.heading' | translate }}</h2>
     <p class="govuk-body">{{ 'pages.security.deleteAccount.info' | translate }}</p>
-    <p class="govuk-body"><a href="{{enterPasswordUrl}}&type=deleteAccount" class="govuk-link">{{ 'pages.security.deleteAccount.link' | translate }}</a></p>
+    <p class="govuk-body"><a href="{{enterPasswordUrlForNavigationEvent}}&type=deleteAccount" class="govuk-link">{{ 'pages.security.deleteAccount.link' | translate }}</a></p>
   </div>
 {% endblock %}

--- a/src/components/security/security-controller.ts
+++ b/src/components/security/security-controller.ts
@@ -11,9 +11,14 @@ import {
 export async function securityGet(req: Request, res: Response): Promise<void> {
   req.metrics?.addMetric("securityGet", MetricUnit.Count, 1);
   const { email } = req.session.user;
-  const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=security&edit=true`;
+  const enterPasswordUrlForNavigationEvent = `${PATH_DATA.ENTER_PASSWORD.url}?from=security`;
+  const enterPasswordUrlForFormChangeResponseEvent = `${enterPasswordUrlForNavigationEvent}&edit=true`;
   const mfaMethods = Array.isArray(req.session.mfaMethods)
-    ? mapMfaMethods(req.session.mfaMethods, enterPasswordUrl, req.t)
+    ? mapMfaMethods(
+        req.session.mfaMethods,
+        enterPasswordUrlForFormChangeResponseEvent,
+        req.t
+      )
     : [];
 
   const denyChangeTypeofPrimary = Array.isArray(req.session.mfaMethods)
@@ -30,7 +35,8 @@ export async function securityGet(req: Request, res: Response): Promise<void> {
   res.render("security/index.njk", {
     email,
     activityLogUrl: PATH_DATA.SIGN_IN_HISTORY.url,
-    enterPasswordUrl,
+    enterPasswordUrlForNavigationEvent,
+    enterPasswordUrlForFormChangeResponseEvent,
     mfaMethods,
     canChangeTypeofPrimary: !denyChangeTypeofPrimary,
     supportGlobalLogout: supportGlobalLogout(),

--- a/src/components/security/tests/security-controller.test.ts
+++ b/src/components/security/tests/security-controller.test.ts
@@ -47,7 +47,9 @@ describe("security controller", () => {
         email: "test@test.com",
         supportGlobalLogout: false,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security&edit=true",
+        enterPasswordUrlForNavigationEvent: "/enter-password?from=security",
+        enterPasswordUrlForFormChangeResponseEvent:
+          "/enter-password?from=security&edit=true",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.defaultMethod.phoneNumber.title",
@@ -118,7 +120,9 @@ describe("security controller", () => {
         email: "test@test.com",
         supportGlobalLogout: false,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security&edit=true",
+        enterPasswordUrlForNavigationEvent: "/enter-password?from=security",
+        enterPasswordUrlForFormChangeResponseEvent:
+          "/enter-password?from=security&edit=true",
         mfaMethods: [],
         canChangeTypeofPrimary: true,
       });
@@ -143,7 +147,9 @@ describe("security controller", () => {
         email: "test@test.com",
         supportGlobalLogout: false,
         activityLogUrl: "/activity-history",
-        enterPasswordUrl: "/enter-password?from=security&edit=true",
+        enterPasswordUrlForNavigationEvent: "/enter-password?from=security",
+        enterPasswordUrlForFormChangeResponseEvent:
+          "/enter-password?from=security&edit=true",
         mfaMethods: [
           {
             text: "pages.security.mfaSection.defaultMethod.app.title",

--- a/src/components/sign-in-details/sign-in-details-controller.ts
+++ b/src/components/sign-in-details/sign-in-details-controller.ts
@@ -22,20 +22,25 @@ export async function signInDetailsGet(
   const mfaClient = await createMfaClient(req, res);
   const passkeys = await mfaClient.getPasskeys();
   const { email } = req.session.user;
-  const enterPasswordUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=sign-in-details&edit=true`;
+  const enterPasswordUrlForNavigationEvent = `${PATH_DATA.ENTER_PASSWORD.url}?from=sign-in-details`;
+  const enterPasswordUrlForFormChangeResponseEvent = `${enterPasswordUrlForNavigationEvent}&edit=true`;
 
   const enterPasswordUrls = {
-    changeEmail: `${enterPasswordUrl}&type=${UserJourney.ChangeEmail}`,
-    createPasskey: `${enterPasswordUrl}&type=${UserJourney.CreatePasskey}`,
-    removePasskey: `${enterPasswordUrl}&type=${UserJourney.RemovePasskey}`,
-    changePassword: `${enterPasswordUrl}&type=${UserJourney.ChangePassword}`,
-    changeDefaultMethod: `${enterPasswordUrl}&type=${UserJourney.ChangeDefaultMethod}`,
-    switchBackupMethod: `${enterPasswordUrl}&type=${UserJourney.SwitchBackupMethod}`,
-    removeBackupMethod: `${enterPasswordUrl}&type=${UserJourney.RemoveBackup}`,
-    addBackupMethod: `${enterPasswordUrl}&type=${UserJourney.addBackup}`,
+    changeEmail: `${enterPasswordUrlForFormChangeResponseEvent}&type=${UserJourney.ChangeEmail}`,
+    createPasskey: `${enterPasswordUrlForNavigationEvent}&type=${UserJourney.CreatePasskey}`,
+    removePasskey: `${enterPasswordUrlForNavigationEvent}&type=${UserJourney.RemovePasskey}`,
+    changePassword: `${enterPasswordUrlForFormChangeResponseEvent}&type=${UserJourney.ChangePassword}`,
+    changeDefaultMethod: `${enterPasswordUrlForFormChangeResponseEvent}&type=${UserJourney.ChangeDefaultMethod}`,
+    switchBackupMethod: `${enterPasswordUrlForNavigationEvent}&type=${UserJourney.SwitchBackupMethod}`,
+    removeBackupMethod: `${enterPasswordUrlForNavigationEvent}&type=${UserJourney.RemoveBackup}`,
+    addBackupMethod: `${enterPasswordUrlForNavigationEvent}&type=${UserJourney.addBackup}`,
   };
   const mfaMethods = Array.isArray(req.session.mfaMethods)
-    ? mapMfaMethods(req.session.mfaMethods, enterPasswordUrl, req.t)
+    ? mapMfaMethods(
+        req.session.mfaMethods,
+        enterPasswordUrlForFormChangeResponseEvent,
+        req.t
+      )
     : [];
 
   const denyChangeTypeofPrimary = Array.isArray(req.session.mfaMethods)

--- a/src/components/sign-in-details/tests/sign-in-details-controller.test.ts
+++ b/src/components/sign-in-details/tests/sign-in-details-controller.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Request, Response } from "express";
-import { RequestBuilder, ResponseBuilder } from "../../../../test/utils/builders.js";
+import {
+  RequestBuilder,
+  ResponseBuilder,
+} from "../../../../test/utils/builders.js";
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { UserJourney } from "../../../utils/state-machine.js";
 import { PATH_DATA } from "../../../app.constants.js";
@@ -48,16 +51,16 @@ describe("signInDetailsGet Controller", () => {
     req.metrics = mockMetrics;
     req.t = mockT;
 
-    res = new ResponseBuilder()
-      .withRender(mockRender)
-      .build();
+    res = new ResponseBuilder().withRender(mockRender).build();
   });
 
   it("should add metrics when called", async () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -70,8 +73,9 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
     expect(mockMetrics.addMetric).toHaveBeenCalledWith(
@@ -85,7 +89,9 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -98,8 +104,9 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
     expect(mockRender).toHaveBeenCalledWith(
@@ -119,7 +126,9 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -132,24 +141,26 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
-    const baseUrl = `${PATH_DATA.ENTER_PASSWORD.url}?from=sign-in-details&edit=true`;
-    
+    const baseUrlForNavigationEvent = `${PATH_DATA.ENTER_PASSWORD.url}?from=sign-in-details`;
+    const baseUrlForFormChangeResponseEvent = `${baseUrlForNavigationEvent}&edit=true`;
+
     expect(mockRender).toHaveBeenCalledWith(
       "sign-in-details/index.njk",
       expect.objectContaining({
         enterPasswordUrls: expect.objectContaining({
-          changeEmail: `${baseUrl}&type=${UserJourney.ChangeEmail}`,
-          createPasskey: `${baseUrl}&type=${UserJourney.CreatePasskey}`,
-          removePasskey: `${baseUrl}&type=${UserJourney.RemovePasskey}`,
-          changePassword: `${baseUrl}&type=${UserJourney.ChangePassword}`,
-          changeDefaultMethod: `${baseUrl}&type=${UserJourney.ChangeDefaultMethod}`,
-          switchBackupMethod: `${baseUrl}&type=${UserJourney.SwitchBackupMethod}`,
-          removeBackupMethod: `${baseUrl}&type=${UserJourney.RemoveBackup}`,
-          addBackupMethod: `${baseUrl}&type=${UserJourney.addBackup}`,
+          changeEmail: `${baseUrlForFormChangeResponseEvent}&type=${UserJourney.ChangeEmail}`,
+          createPasskey: `${baseUrlForNavigationEvent}&type=${UserJourney.CreatePasskey}`,
+          removePasskey: `${baseUrlForNavigationEvent}&type=${UserJourney.RemovePasskey}`,
+          changePassword: `${baseUrlForFormChangeResponseEvent}&type=${UserJourney.ChangePassword}`,
+          changeDefaultMethod: `${baseUrlForFormChangeResponseEvent}&type=${UserJourney.ChangeDefaultMethod}`,
+          switchBackupMethod: `${baseUrlForNavigationEvent}&type=${UserJourney.SwitchBackupMethod}`,
+          removeBackupMethod: `${baseUrlForNavigationEvent}&type=${UserJourney.RemoveBackup}`,
+          addBackupMethod: `${baseUrlForNavigationEvent}&type=${UserJourney.addBackup}`,
         }),
       })
     );
@@ -161,7 +172,9 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -174,8 +187,9 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
     // Should not throw error and continue execution
@@ -189,7 +203,9 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -202,8 +218,9 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
     expect(mockRender).toHaveBeenCalledWith(
@@ -220,7 +237,9 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -233,8 +252,9 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
     expect(mockRender).toHaveBeenCalledWith(
@@ -250,7 +270,9 @@ describe("signInDetailsGet Controller", () => {
     // Mock the dependencies
     vi.doMock("../../../utils/mfaClient/index.js", () => ({
       createMfaClient: vi.fn().mockResolvedValue({
-        getPasskeys: vi.fn().mockResolvedValue({ success: true, data: { passkeys: [] } }),
+        getPasskeys: vi
+          .fn()
+          .mockResolvedValue({ success: true, data: { passkeys: [] } }),
       }),
     }));
 
@@ -263,8 +285,9 @@ describe("signInDetailsGet Controller", () => {
       canChangePrimaryMethod: vi.fn().mockReturnValue(false),
     }));
 
-    const { signInDetailsGet } = await import("../sign-in-details-controller.js");
-    
+    const { signInDetailsGet } =
+      await import("../sign-in-details-controller.js");
+
     await signInDetailsGet(req as Request, res as Response);
 
     expect(mockRender).toHaveBeenCalledWith(


### PR DESCRIPTION
Some links on the security and sign in details pages are sending `form_change_response` events when they should be sending `navigation` events. This is because they have `edit=true` in their query strings. This PR removes `edit=true` so that the following links send the correct events:

- `/enter-password?from=security&edit=true&type=deleteAccount`
- `/enter-password?from=security&edit=true&type=removePasskey&passkeyId={id}`
- `/enter-password?from=security&edit=true&type=createPasskey`
- `/enter-password?from=security&edit=true&type=switchBackupMethod`
- `/enter-password?from=security&edit=true&type=removeBackup`
- `/enter-password?from=security&edit=true&type=addBackup`
- `/enter-password?from=sign-in-details&edit=true&type=removePasskey&passkeyId={id}`
- `/enter-password?from=sign-in-details&edit=true&type=createPasskey`
- `/enter-password?from=sign-in-details&edit=true&type=switchBackupMethod`
- `/enter-password?from=sign-in-details&edit=true&type=removeBackup`
- `/enter-password?from=sign-in-details&edit=true&type=addBackup`