### PR TITLE
OLH-4453: update RP registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4851,7 +4851,7 @@
     },
     "node_modules/di-account-management-rp-registry": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#e798a7e6c9d0153ab071da61448f61ec66a23d4c",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#eb06f80d14bac3853e7282921f9985dd54f80ee4",
       "license": "ISC"
     },
     "node_modules/dijkstrajs": {


### PR DESCRIPTION
Updates the RP registry to the latest version which includes the `DfE: Register for a National Professional Development (NPD) course` service