### PR TITLE
OLH-4461: Add eslint, zizmor, and cfn-lint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,12 @@ repos:
         language: system
         files: ^integration-tests/
         pass_filenames: false
+
+      - id: cfnlint
+        name: Lint CloudFormation
+        entry: cfn-lint deploy/template.yaml -r eu-west-2
+        language: system
+        exclude: .*
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,15 @@ repos:
         entry: "npm run audit"
         language: system
 
+      - id: eslint
+        name: ESLint
+        entry: npm run lint
+        language: system
+        exclude: .*
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: integration-tests-check
         name: Integration tests check
         entry: npm --prefix integration-tests run validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,12 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
         stages: [pre-commit]
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # pragma: allowlist secret
+    hooks:
+      - id: zizmor
+        stages: [pre-commit]
+
   - repo: local
     hooks:
       - id: npm-audit


### PR DESCRIPTION
Added three pre-commit hooks:
  
1. `eslint` local hook running `npm run lint` (already in CI, now also local pre-commit)
2. `zizmor` official `zizmorcore/zizmor-pre-commit` managed hook
3. `cfn-lint` local hook running CloudFormation linting on `deploy/template.yaml -r eu-west-2`
  
These checks exist in other repos' pre-commit configs but were missing here. Adding them gives developers local feedback and prepares for running pre-commit in CI (next PR), which will replace standalone workflows. This is part of a process to standardise our linting setup across Home owned repos.

No CI changes in this PR, purely additive to local developer experience using pre-commit.
