### PR TITLE
BAU: enable passkeys for live proving in production and integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -310,7 +310,7 @@ Mappings:
       AMCTOKENURL: "https://votf1tvl36.execute-api.eu-west-2.amazonaws.com/v1/token"
       AMCCLIENTID: "home"
       ENABLEPKCE: "1"
-      PASSKEYS: "0"
+      PASSKEYS: "1"
     production:
       NODEENV: "production"
       APIBASEURL: "https://oidc.account.gov.uk"
@@ -349,7 +349,7 @@ Mappings:
       AMCTOKENURL: "https://h06vqhfzgi.execute-api.eu-west-2.amazonaws.com/v1/token"
       AMCCLIENTID: "home"
       ENABLEPKCE: "1"
-      PASSKEYS: "0"
+      PASSKEYS: "1"
 
 Resources:
   #


### PR DESCRIPTION
Enables passkeys for live proving in integration and production. In order to see passkeys functionality it will be necessary to have the live proving cookie set.