### PR TITLE
OLH-4505: add claims to authorize request

### DIFF
--- a/src/middleware/requires-auth-middleware.ts
+++ b/src/middleware/requires-auth-middleware.ts
@@ -83,7 +83,7 @@ async function generateAuthUrl(req: Request): Promise<string> {
       : undefined,
     code_challenge: codeChallenge,
     jti: randomUUID(),
-    exp: Math.floor(Date.now() / 1000) + 60,
+    exp: Math.floor(Date.now() / 1000) + 120,
   };
   const encodedHeader = base64url.default.encode(JSON.stringify(headers));
   const encodedPayload = base64url.default.encode(JSON.stringify(claims));

--- a/src/middleware/requires-auth-middleware.ts
+++ b/src/middleware/requires-auth-middleware.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { generators } from "openid-client";
+import { randomUUID } from "node:crypto";
 import {
   PATH_DATA,
   VECTORS_OF_TRUST,
@@ -81,6 +82,8 @@ async function generateAuthUrl(req: Request): Promise<string> {
       ? CODE_CHALLENGE_VALUES.CODE_CHALLENGE_METHOD
       : undefined,
     code_challenge: codeChallenge,
+    jti: randomUUID(),
+    exp: Math.floor(Date.now() / 1000) + 60,
   };
   const encodedHeader = base64url.default.encode(JSON.stringify(headers));
   const encodedPayload = base64url.default.encode(JSON.stringify(claims));

--- a/test/unit/middleware/requires-auth-middleware.test.ts
+++ b/test/unit/middleware/requires-auth-middleware.test.ts
@@ -248,9 +248,7 @@ describe("Requires auth middleware", () => {
     expect(typeof callArgs.request).toBe("string");
 
     const [header] = callArgs.request.split(".");
-    const decodedHeader = JSON.parse(
-      Buffer.from(header, "base64url").toString()
-    );
+    const decodedHeader = JSON.parse(Buffer.from(header, "base64").toString());
     expect(decodedHeader).toMatchObject({
       alg: "RS512",
       typ: "JWT",
@@ -262,7 +260,9 @@ describe("Requires auth middleware", () => {
     );
 
     const claims = callArgs.request.split(".")[1];
-    const decodedClaims = JSON.parse(Buffer.from(claims, "base64url").toString());
+    const decodedClaims = JSON.parse(
+      Buffer.from(claims, "base64url").toString()
+    );
 
     expect(decodedClaims.code_challenge).toBeDefined();
     expect(decodedClaims.code_challenge).toBeTypeOf("string");
@@ -270,13 +270,6 @@ describe("Requires auth middleware", () => {
 
     expect(decodedClaims.code_challenge_method).toBeDefined();
     expect(decodedClaims.code_challenge_method).toEqual("S256");
-
-    expect(decodedClaims.jti).toBeDefined();
-    expect(decodedClaims.jti).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-    );
-    expect(decodedClaims.exp).toBeDefined();
-    expect(decodedClaims.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
 
     delete process.env.ENABLE_PKCE;
     vi.restoreAllMocks();

--- a/test/unit/middleware/requires-auth-middleware.test.ts
+++ b/test/unit/middleware/requires-auth-middleware.test.ts
@@ -248,7 +248,9 @@ describe("Requires auth middleware", () => {
     expect(typeof callArgs.request).toBe("string");
 
     const [header] = callArgs.request.split(".");
-    const decodedHeader = JSON.parse(Buffer.from(header, "base64").toString());
+    const decodedHeader = JSON.parse(
+      Buffer.from(header, "base64url").toString()
+    );
     expect(decodedHeader).toMatchObject({
       alg: "RS512",
       typ: "JWT",
@@ -260,9 +262,7 @@ describe("Requires auth middleware", () => {
     );
 
     const claims = callArgs.request.split(".")[1];
-    const decodedClaims = JSON.parse(
-      Buffer.from(claims, "base64url").toString()
-    );
+    const decodedClaims = JSON.parse(Buffer.from(claims, "base64").toString());
 
     expect(decodedClaims.code_challenge).toBeDefined();
     expect(decodedClaims.code_challenge).toBeTypeOf("string");

--- a/test/unit/middleware/requires-auth-middleware.test.ts
+++ b/test/unit/middleware/requires-auth-middleware.test.ts
@@ -167,7 +167,7 @@ describe("Requires auth middleware", () => {
     expect(callArgs.request).toBeDefined();
     expect(typeof callArgs.request).toBe("string");
 
-    const [header] = callArgs.request.split(".");
+    const [header, payload] = callArgs.request.split(".");
     const decodedHeader = JSON.parse(
       Buffer.from(header, "base64url").toString()
     );
@@ -180,6 +180,16 @@ describe("Requires auth middleware", () => {
     expect(decodedHeader.kid).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
+
+    const decodedPayload = JSON.parse(
+      Buffer.from(payload, "base64url").toString()
+    );
+    expect(decodedPayload.jti).toBeDefined();
+    expect(decodedPayload.jti).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(decodedPayload.exp).toBeDefined();
+    expect(decodedPayload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
 
     vi.restoreAllMocks();
   });
@@ -252,7 +262,7 @@ describe("Requires auth middleware", () => {
     );
 
     const claims = callArgs.request.split(".")[1];
-    const decodedClaims = JSON.parse(Buffer.from(claims, "base64").toString());
+    const decodedClaims = JSON.parse(Buffer.from(claims, "base64url").toString());
 
     expect(decodedClaims.code_challenge).toBeDefined();
     expect(decodedClaims.code_challenge).toBeTypeOf("string");
@@ -260,6 +270,13 @@ describe("Requires auth middleware", () => {
 
     expect(decodedClaims.code_challenge_method).toBeDefined();
     expect(decodedClaims.code_challenge_method).toEqual("S256");
+
+    expect(decodedClaims.jti).toBeDefined();
+    expect(decodedClaims.jti).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(decodedClaims.exp).toBeDefined();
+    expect(decodedClaims.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
 
     delete process.env.ENABLE_PKCE;
     vi.restoreAllMocks();


### PR DESCRIPTION
Updates the JWT sent in the `/authorize` POST request to include `jti` and `exp` claims. `jti` is a random string. `exp` is a unix timestamp of two minutes in the future.