### PR TITLE
OLH-4463: Remove connect-dynamodb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "axios": "^1.18.1",
         "base64url": "3.0.1",
         "body-parser": "^2.3.0",
-        "connect-dynamodb": "^3.0.5",
         "cookie-parser": "^1.4.7",
         "csrf-sync": "^4.2.1",
         "di-account-management-rp-registry": "github:govuk-one-login/di-account-management-rp-registry#main",
@@ -4186,17 +4185,6 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/connect-dynamodb": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/connect-dynamodb/-/connect-dynamodb-3.0.5.tgz",
-      "integrity": "sha512-AQtXLmfpC/YMT7mJlxsgCrpfeXdgKQ2A7cbTBSE/HsRbJXf/d0ZhB3HmKT+JQaObI5DqnK/d0XlUBbFrcqlwTQ==",
-      "engines": {
-        "node": "*"
-      },
-      "optionalDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.218.0"
       }
     },
     "node_modules/content-disposition": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "axios": "^1.18.1",
     "base64url": "3.0.1",
     "body-parser": "^2.3.0",
-    "connect-dynamodb": "^3.0.5",
     "cookie-parser": "^1.4.7",
     "csrf-sync": "^4.2.1",
     "di-account-management-rp-registry": "github:govuk-one-login/di-account-management-rp-registry#main",

--- a/src/app.ts
+++ b/src/app.ts
@@ -153,7 +153,7 @@ async function createApp(): Promise<express.Application> {
   );
   app.use(cookieParser());
 
-  const sessionStore = getSessionStore({ session: session });
+  const sessionStore = getSessionStore();
   app.use(
     session({
       name: "am",
@@ -164,8 +164,7 @@ async function createApp(): Promise<express.Application> {
       unset: "destroy",
       cookie: getSessionCookieOptions(
         isDeployedEnvironment,
-        getSessionExpiry(),
-        getSessionSecret()
+        getSessionExpiry()
       ),
     })
   );

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -1,12 +1,29 @@
+import { CookieOptions } from "express-session";
+
+/**
+ * Builds the express-session cookie options.
+ *
+ * When `maxAge` is omitted (or undefined), the cookie is session-scoped:
+ * no `maxAge`/`expires` attribute is set, so the browser deletes the cookie
+ * when it is closed rather than it persisting for a fixed duration.
+ *
+ * Passing a `maxAge` (in milliseconds) opts back into a persistent cookie
+ * that expires after that duration, as before.
+ *
+ * Server-side session lifetime is controlled separately by the session
+ * store's TTL, regardless of whether the cookie itself is session-scoped.
+ */
 export function getSessionCookieOptions(
   isProdEnv: boolean,
-  expiry: number,
-  secret: string
-): any {
-  return {
-    name: "ams",
-    secret: secret,
-    maxAge: expiry,
+  maxAge?: number
+): CookieOptions {
+  const options: CookieOptions = {
     secure: isProdEnv,
   };
+
+  if (typeof maxAge === "number") {
+    options.maxAge = maxAge;
+  }
+
+  return options;
 }

--- a/src/utils/dynamodb-session-store.ts
+++ b/src/utils/dynamodb-session-store.ts
@@ -1,0 +1,165 @@
+import {
+  AttributeValue,
+  DeleteItemCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { SessionData, Store } from "express-session";
+
+/**
+ * DynamoDB-backed express-session store.
+ *
+ * Wire format is compatible with the now-unmaintained `connect-dynamodb`
+ * package it replaces:
+ *  - item hash key: `${prefix}${sid}` (default prefix "sess:")
+ *  - `sess` (S): JSON-serialised session
+ *  - `expires` (N): epoch seconds at which the item is considered expired
+ *    and used as the DynamoDB TTL attribute
+ */
+
+/** Default session lifetime (seconds) used when a session has no cookie.maxAge. */
+const DEFAULT_TTL_SECONDS = 24 * 60 * 60; // one day
+
+export interface DynamoDBSessionStoreOptions {
+  /** DynamoDB client used to read/write session items. */
+  client: DynamoDBClient;
+  /** Name of the DynamoDB table used to store sessions. */
+  tableName: string;
+  /** Name of the table's hash key attribute. Defaults to "id". */
+  hashKey?: string;
+  /** Prefix applied to session ids before use as the hash key value. Defaults to "sess:". */
+  prefix?: string;
+  /** Fallback TTL (seconds) applied when a session has no cookie.maxAge. Defaults to one day. */
+  defaultTtlSeconds?: number;
+  /**
+   * Optional mapper invoked with the session object being written, returning
+   * extra DynamoDB attributes to store alongside the session (e.g. a GSI
+   * hash key). Returning an empty object omits any extra attributes.
+   */
+  extraAttributes?: (sess: SessionData) => Record<string, AttributeValue>;
+}
+
+export class DynamoDBSessionStore extends Store {
+  private readonly client: DynamoDBClient;
+  private readonly tableName: string;
+  private readonly hashKey: string;
+  private readonly prefix: string;
+  private readonly defaultTtlSeconds: number;
+  private readonly extraAttributes: (
+    sess: SessionData
+  ) => Record<string, AttributeValue>;
+
+  constructor(options: DynamoDBSessionStoreOptions) {
+    super();
+    this.client = options.client;
+    this.tableName = options.tableName;
+    this.hashKey = options.hashKey ?? "id";
+    this.prefix = options.prefix ?? "sess:";
+    this.defaultTtlSeconds = options.defaultTtlSeconds ?? DEFAULT_TTL_SECONDS;
+    this.extraAttributes = options.extraAttributes ?? (() => ({}));
+  }
+
+  private key(sid: string): string {
+    return `${this.prefix}${sid}`;
+  }
+
+  private expiresAt(sess: SessionData): number {
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    return typeof sess.cookie?.maxAge === "number"
+      ? nowInSeconds + Math.floor(sess.cookie.maxAge / 1000)
+      : nowInSeconds + this.defaultTtlSeconds;
+  }
+
+  get = (
+    sid: string,
+    callback: (err: any, session?: SessionData | null) => void
+  ): void => {
+    this.client
+      .send(
+        new GetItemCommand({
+          TableName: this.tableName,
+          Key: { [this.hashKey]: { S: this.key(sid) } },
+          ConsistentRead: true,
+        })
+      )
+      .then((result) => {
+        try {
+          callback(null, this.parseSession(result));
+        } catch (err) {
+          callback(err);
+        }
+      })
+      .catch(callback);
+  };
+
+  private parseSession(result: {
+    Item?: Record<string, AttributeValue>;
+  }): SessionData | null {
+    const item = result.Item;
+    if (!item?.sess?.S) {
+      return null;
+    }
+
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    if (item.expires?.N && nowInSeconds >= Number(item.expires.N)) {
+      return null;
+    }
+
+    return JSON.parse(item.sess.S);
+  }
+
+  set = (
+    sid: string,
+    session: SessionData,
+    callback?: (err?: any) => void
+  ): void => {
+    const item: Record<string, AttributeValue> = {
+      [this.hashKey]: { S: this.key(sid) },
+      expires: { N: String(this.expiresAt(session)) },
+      sess: { S: JSON.stringify(session) },
+      ...this.extraAttributes(session),
+    };
+
+    this.client
+      .send(new PutItemCommand({ TableName: this.tableName, Item: item }))
+      .then(() => callback?.())
+      .catch((err) => callback?.(err));
+  };
+
+  destroy = (sid: string, callback?: (err?: any) => void): void => {
+    this.client
+      .send(
+        new DeleteItemCommand({
+          TableName: this.tableName,
+          Key: { [this.hashKey]: { S: this.key(sid) } },
+        })
+      )
+      .then(() => callback?.())
+      .catch((err) => callback?.(err));
+  };
+
+  touch = (
+    sid: string,
+    session: SessionData,
+    callback?: (err?: any, data?: { expires: string }) => void
+  ): void => {
+    const expires = this.expiresAt(session);
+
+    this.client
+      .send(
+        new UpdateItemCommand({
+          TableName: this.tableName,
+          Key: { [this.hashKey]: { S: this.key(sid) } },
+          UpdateExpression: "set expires = :e",
+          ExpressionAttributeValues: { ":e": { N: String(expires) } },
+          ReturnValues: "UPDATED_NEW",
+        })
+      )
+      .then((result) => {
+        callback?.(null, { expires: result.Attributes?.expires?.N as string });
+      })
+      .catch((err) => callback?.(err));
+  };
+}

--- a/src/utils/session-store.ts
+++ b/src/utils/session-store.ts
@@ -1,44 +1,38 @@
 import { Request } from "express";
-import {
-  DynamoDBClient,
-  QueryCommand,
-  ScalarAttributeType,
-} from "@aws-sdk/client-dynamodb";
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { getSessionStoreTableName } from "../config.js";
+import { getSessionExpiry, getSessionStoreTableName } from "../config.js";
 import { logger } from "./logger.js";
-import connect_dynamodb from "connect-dynamodb";
 import { Store } from "express-session";
 import { ERROR_MESSAGES } from "../app.constants.js";
-import { AwsConfig, getAWSConfig } from "../config/aws.js";
+import { dynamoClient } from "./dynamo.js";
+import { DynamoDBSessionStore } from "./dynamodb-session-store.js";
 
 // the value of the USER_IDENTIFIER_IDX_ATTRIBUTE must match the indexed attribute in SessionsDynamoDB table
 // defined in `../../deploy/template.yaml`.
 const USER_IDENTIFIER_IDX_ATTRIBUTE = "user_id";
-const awsConfig: AwsConfig = getAWSConfig();
-const dynamoDBCientSessionStore = new DynamoDBClient(awsConfig as any);
+const USERS_SESSIONS_INDEX = "users-sessions";
 
 const PREFIX = "sess:";
 
-interface SessionStore {
-  session: any;
-}
-
 let sessionStoreInstance: Store | null = null;
 
-export function getSessionStore({ session }: SessionStore): Store {
+export function getSessionStore(): Store {
   if (!sessionStoreInstance) {
-    const DynamoDBStore = connect_dynamodb(session);
-    const storeOptions = {
-      client: dynamoDBCientSessionStore,
-      table: getSessionStoreTableName(),
-      specialKeys: [
-        { name: USER_IDENTIFIER_IDX_ATTRIBUTE, type: ScalarAttributeType.S },
-      ],
-      skipThrowMissingSpecialKeys: true,
+    sessionStoreInstance = new DynamoDBSessionStore({
+      client: dynamoClient,
+      tableName: getSessionStoreTableName(),
       prefix: PREFIX,
-    };
-    sessionStoreInstance = new DynamoDBStore(storeOptions);
+      defaultTtlSeconds: Math.floor(getSessionExpiry() / 1000),
+      extraAttributes: (sess) =>
+        sess?.[USER_IDENTIFIER_IDX_ATTRIBUTE]
+          ? {
+              [USER_IDENTIFIER_IDX_ATTRIBUTE]: {
+                S: sess[USER_IDENTIFIER_IDX_ATTRIBUTE],
+              },
+            }
+          : {},
+    });
   }
 
   return sessionStoreInstance;
@@ -47,15 +41,13 @@ export function getSessionStore({ session }: SessionStore): Store {
 async function getSessions(subjectId: string): Promise<string[]> {
   const params = {
     TableName: getSessionStoreTableName(),
-    IndexName: "users-sessions",
+    IndexName: USERS_SESSIONS_INDEX,
     KeyConditionExpression: `${USER_IDENTIFIER_IDX_ATTRIBUTE} = :user_identifier`,
     ExpressionAttributeValues: { ":user_identifier": { S: subjectId } },
   };
 
   try {
-    const { Items } = await dynamoDBCientSessionStore.send(
-      new QueryCommand(params)
-    );
+    const { Items } = await dynamoClient.send(new QueryCommand(params));
     return (
       Items?.map((session) => {
         const id = unmarshall(session).id;

--- a/src/utils/test/dynamodb-session-store.test.ts
+++ b/src/utils/test/dynamodb-session-store.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBSessionStore } from "../dynamodb-session-store.js";
+
+describe("DynamoDBSessionStore", () => {
+  let client: DynamoDBClient;
+  let sendStub: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z")); // 1704067200 epoch seconds
+    client = new DynamoDBClient({ region: "eu-west-2" });
+    sendStub = vi.spyOn(client, "send");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("get", () => {
+    it("returns the parsed session when the item exists and is not expired", async () => {
+      const sessionData = { cookie: { maxAge: 3600000 }, user_id: "user-1" };
+      sendStub.mockResolvedValueOnce({
+        Item: {
+          id: { S: "sess:abc123" },
+          sess: { S: JSON.stringify(sessionData) },
+          expires: { N: "1704070800" }, // one hour later, not expired
+        },
+      } as any);
+
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const session = await new Promise((resolve, reject) => {
+        store.get("abc123", (err, sess) => (err ? reject(err) : resolve(sess)));
+      });
+
+      expect(session).toEqual(sessionData);
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input).toEqual({
+        TableName: "sessions",
+        Key: { id: { S: "sess:abc123" } },
+        ConsistentRead: true,
+      });
+    });
+
+    it("returns null when no item is found", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const session = await new Promise((resolve, reject) => {
+        store.get("missing", (err, sess) =>
+          err ? reject(err) : resolve(sess)
+        );
+      });
+
+      expect(session).toBeNull();
+    });
+
+    it("returns null when the item has expired", async () => {
+      sendStub.mockResolvedValueOnce({
+        Item: {
+          id: { S: "sess:expired" },
+          sess: { S: JSON.stringify({ cookie: {} }) },
+          expires: { N: "1704063600" }, // one hour before "now"
+        },
+      } as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const session = await new Promise((resolve, reject) => {
+        store.get("expired", (err, sess) =>
+          err ? reject(err) : resolve(sess)
+        );
+      });
+
+      expect(session).toBeNull();
+    });
+
+    it("returns null when the item has no sess attribute", async () => {
+      sendStub.mockResolvedValueOnce({
+        Item: { id: { S: "sess:broken" } },
+      } as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const session = await new Promise((resolve, reject) => {
+        store.get("broken", (err, sess) => (err ? reject(err) : resolve(sess)));
+      });
+
+      expect(session).toBeNull();
+    });
+
+    it("calls back with an error when the DynamoDB item contains malformed JSON", async () => {
+      sendStub.mockResolvedValueOnce({
+        Item: {
+          id: { S: "sess:malformed" },
+          sess: { S: "{not-json" },
+        },
+      } as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const error = await new Promise((resolve) => {
+        store.get("malformed", (err) => resolve(err));
+      });
+
+      expect(error).toBeInstanceOf(SyntaxError);
+    });
+
+    it("propagates DynamoDB errors via the callback", async () => {
+      const dynamoError = new Error("DynamoDB is unavailable");
+      sendStub.mockRejectedValueOnce(dynamoError);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const error = await new Promise((resolve) => {
+        store.get("abc123", (err) => resolve(err));
+      });
+
+      expect(error).toBe(dynamoError);
+    });
+
+    it("uses a custom hash key and prefix when provided", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({
+        client,
+        tableName: "sessions",
+        hashKey: "pk",
+        prefix: "custom:",
+      });
+
+      await new Promise((resolve) => store.get("abc123", () => resolve(null)));
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Key).toEqual({ pk: { S: "custom:abc123" } });
+    });
+  });
+
+  describe("set", () => {
+    it("writes the session with expires derived from cookie.maxAge", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+      const session = { cookie: { maxAge: 3600000 } }; // 1 hour
+
+      await new Promise((resolve, reject) => {
+        store.set("abc123", session, (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input).toEqual({
+        TableName: "sessions",
+        Item: {
+          id: { S: "sess:abc123" },
+          expires: { N: "1704070800" }, // now + 3600s
+          sess: { S: JSON.stringify(session) },
+        },
+      });
+    });
+
+    it("defaults expires to one day when cookie.maxAge is absent", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+      const session = { cookie: {} };
+
+      await new Promise((resolve, reject) => {
+        store.set("abc123", session, (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Item.expires).toEqual({ N: "1704153600" }); // now + 1 day
+    });
+
+    it("respects a custom defaultTtlSeconds", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({
+        client,
+        tableName: "sessions",
+        defaultTtlSeconds: 60,
+      });
+      const session = { cookie: {} };
+
+      await new Promise((resolve, reject) => {
+        store.set("abc123", session, (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Item.expires).toEqual({ N: "1704067260" }); // now + 60s
+    });
+
+    it("includes extra attributes returned by the extraAttributes mapper", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({
+        client,
+        tableName: "sessions",
+        extraAttributes: (sess) =>
+          sess.user_id ? { user_id: { S: sess.user_id } } : {},
+      });
+      const session = { cookie: { maxAge: 1000 }, user_id: "user-42" };
+
+      await new Promise((resolve, reject) => {
+        store.set("abc123", session, (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Item.user_id).toEqual({ S: "user-42" });
+    });
+
+    it("omits extra attributes when the mapper returns an empty object", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({
+        client,
+        tableName: "sessions",
+        extraAttributes: (sess) =>
+          sess.user_id ? { user_id: { S: sess.user_id } } : {},
+      });
+      const session = { cookie: { maxAge: 1000 } };
+
+      await new Promise((resolve, reject) => {
+        store.set("abc123", session, (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Item.user_id).toBeUndefined();
+    });
+
+    it("propagates DynamoDB errors via the callback", async () => {
+      const dynamoError = new Error("write failed");
+      sendStub.mockRejectedValueOnce(dynamoError);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const error = await new Promise((resolve) => {
+        store.set("abc123", { cookie: {} }, (err) => resolve(err));
+      });
+
+      expect(error).toBe(dynamoError);
+    });
+
+    it("works without an explicit callback", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      expect(() => store.set("abc123", { cookie: {} })).not.toThrow();
+    });
+  });
+
+  describe("destroy", () => {
+    it("deletes the session item by prefixed sid", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      await new Promise((resolve, reject) => {
+        store.destroy("abc123", (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input).toEqual({
+        TableName: "sessions",
+        Key: { id: { S: "sess:abc123" } },
+      });
+    });
+
+    it("propagates DynamoDB errors via the callback", async () => {
+      const dynamoError = new Error("delete failed");
+      sendStub.mockRejectedValueOnce(dynamoError);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const error = await new Promise((resolve) => {
+        store.destroy("abc123", (err) => resolve(err));
+      });
+
+      expect(error).toBe(dynamoError);
+    });
+
+    it("works without an explicit callback", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      expect(() => store.destroy("abc123")).not.toThrow();
+    });
+  });
+
+  describe("touch", () => {
+    it("updates the expires attribute and returns the new value", async () => {
+      sendStub.mockResolvedValueOnce({
+        Attributes: { expires: { N: "1704070800" } },
+      } as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+      const session = { cookie: { maxAge: 3600000 } };
+
+      const result = await new Promise((resolve, reject) => {
+        store.touch("abc123", session, (err, data) =>
+          err ? reject(err) : resolve(data)
+        );
+      });
+
+      expect(result).toEqual({ expires: "1704070800" });
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input).toEqual({
+        TableName: "sessions",
+        Key: { id: { S: "sess:abc123" } },
+        UpdateExpression: "set expires = :e",
+        ExpressionAttributeValues: { ":e": { N: "1704070800" } },
+        ReturnValues: "UPDATED_NEW",
+      });
+    });
+
+    it("propagates DynamoDB errors via the callback", async () => {
+      const dynamoError = new Error("touch failed");
+      sendStub.mockRejectedValueOnce(dynamoError);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      const error = await new Promise((resolve) => {
+        store.touch("abc123", { cookie: {} }, (err) => resolve(err));
+      });
+
+      expect(error).toBe(dynamoError);
+    });
+
+    it("works without an explicit callback", async () => {
+      sendStub.mockResolvedValueOnce({
+        Attributes: { expires: { N: "1704070800" } },
+      } as any);
+      const store = new DynamoDBSessionStore({ client, tableName: "sessions" });
+
+      expect(() => store.touch("abc123", { cookie: {} })).not.toThrow();
+    });
+  });
+});

--- a/src/utils/test/session-store.test.ts
+++ b/src/utils/test/session-store.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Request } from "express";
+import { logger } from "../logger.js";
+import { dynamoClient } from "../dynamo.js";
+import { ERROR_MESSAGES } from "../../app.constants.js";
+import {
+  getSessionStore,
+  deleteExpressSession,
+  destroyUserSessions,
+} from "../session-store.js";
+
+describe("session-store", () => {
+  let sendStub: ReturnType<typeof vi.spyOn>;
+  let loggerErrorSpy: ReturnType<typeof vi.spyOn>;
+  let loggerWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sendStub = vi.spyOn(dynamoClient, "send");
+    loggerErrorSpy = vi.spyOn(logger, "error");
+    loggerWarnSpy = vi.spyOn(logger, "warn");
+    process.env.SESSION_STORE_TABLE_NAME = "sessions-table";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getSessionStore", () => {
+    it("returns a Store-compatible object with get/set/destroy/touch", () => {
+      const store = getSessionStore();
+
+      expect(store).toHaveProperty("get");
+      expect(store).toHaveProperty("set");
+      expect(store).toHaveProperty("destroy");
+      expect(store).toHaveProperty("touch");
+    });
+
+    it("returns the same singleton instance on repeated calls", () => {
+      const first = getSessionStore();
+      const second = getSessionStore();
+
+      expect(first).toBe(second);
+    });
+
+    it("writes user_id as an extra attribute when present on the session", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = getSessionStore();
+
+      await new Promise((resolve, reject) => {
+        store.set(
+          "abc123",
+          { cookie: { maxAge: 1000 }, user_id: "user-42" } as any,
+          (err) => (err ? reject(err) : resolve(undefined))
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Item.user_id).toEqual({ S: "user-42" });
+    });
+
+    it("omits the user_id attribute when not present on the session", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const store = getSessionStore();
+
+      await new Promise((resolve, reject) => {
+        store.set("abc123", { cookie: { maxAge: 1000 } } as any, (err) =>
+          err ? reject(err) : resolve(undefined)
+        );
+      });
+
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input.Item.user_id).toBeUndefined();
+    });
+  });
+
+  describe("deleteExpressSession", () => {
+    it("destroys the express session", async () => {
+      const destroy = vi.fn((cb: (err?: any) => void) => cb());
+      const req = { session: { destroy } } as unknown as Request;
+
+      await deleteExpressSession(req);
+
+      expect(destroy).toHaveBeenCalledTimes(1);
+      expect(loggerErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("logs an error when destroy fails", async () => {
+      const failure = new Error("boom");
+      const destroy = vi.fn((cb: (err?: any) => void) => cb(failure));
+      const req = { session: { destroy } } as unknown as Request;
+
+      await deleteExpressSession(req);
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGES.FAILED_TO_DESTROY_SESSION(failure as any)
+      );
+    });
+
+    it("does nothing when there is no session on the request", async () => {
+      const req = {} as unknown as Request;
+
+      await expect(deleteExpressSession(req)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("destroyUserSessions", () => {
+    function buildRequest() {
+      const destroy = vi.fn((cb: (err?: any) => void) => cb());
+      return { session: { destroy } } as unknown as Request;
+    }
+
+    it("queries sessions for the subject, destroys each on the store, then destroys the express session", async () => {
+      sendStub.mockResolvedValueOnce({
+        Items: [
+          { id: { S: "sess:session-a" } },
+          { id: { S: "sess:session-b" } },
+        ],
+      } as any);
+      const sessionStore = {
+        destroy: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(sendStub).toHaveBeenCalledTimes(1);
+      const [command] = sendStub.mock.calls[0];
+      expect(command.input).toEqual({
+        TableName: "sessions-table",
+        IndexName: "users-sessions",
+        KeyConditionExpression: "user_id = :user_identifier",
+        ExpressionAttributeValues: { ":user_identifier": { S: "subject-1" } },
+      });
+
+      expect(sessionStore.destroy).toHaveBeenCalledTimes(2);
+      expect(sessionStore.destroy).toHaveBeenCalledWith("session-a");
+      expect(sessionStore.destroy).toHaveBeenCalledWith("session-b");
+      expect(req.session.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("strips the sess: prefix from returned session ids", async () => {
+      sendStub.mockResolvedValueOnce({
+        Items: [{ id: { S: "sess:only-one" } }],
+      } as any);
+      const sessionStore = {
+        destroy: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(sessionStore.destroy).toHaveBeenCalledWith("only-one");
+    });
+
+    it("handles session ids without the sess: prefix", async () => {
+      sendStub.mockResolvedValueOnce({
+        Items: [{ id: { S: "no-prefix-id" } }],
+      } as any);
+      const sessionStore = {
+        destroy: vi.fn().mockResolvedValue(undefined),
+      } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(sessionStore.destroy).toHaveBeenCalledWith("no-prefix-id");
+    });
+
+    it("logs a warning when some sessions fail to be destroyed, but still destroys the express session", async () => {
+      sendStub.mockResolvedValueOnce({
+        Items: [
+          { id: { S: "sess:session-a" } },
+          { id: { S: "sess:session-b" } },
+        ],
+      } as any);
+      const sessionStore = {
+        destroy: vi
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error("failed to destroy")),
+      } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+      expect(loggerWarnSpy.mock.calls[0][0]).toContain("1 out of 2 failed");
+      expect(req.session.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs an error and still destroys the express session when the query fails", async () => {
+      const queryError = new Error("query failed");
+      sendStub.mockRejectedValueOnce(queryError);
+      const sessionStore = { destroy: vi.fn() } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Session store: failed to get sessions:")
+      );
+      expect(sessionStore.destroy).not.toHaveBeenCalled();
+      expect(req.session.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns an empty session id list when the query returns no items", async () => {
+      sendStub.mockResolvedValueOnce({} as any);
+      const sessionStore = { destroy: vi.fn() } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(sessionStore.destroy).not.toHaveBeenCalled();
+      expect(req.session.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs an error and still destroys the express session when destroying sessions throws synchronously", async () => {
+      sendStub.mockResolvedValueOnce({
+        Items: [{ id: { S: "sess:session-a" } }],
+      } as any);
+      const synchronousError = new Error("synchronous failure");
+      const sessionStore = {
+        destroy: vi.fn(() => {
+          throw synchronousError;
+        }),
+      } as any;
+      const req = buildRequest();
+
+      await destroyUserSessions(req, "subject-1", sessionStore);
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Session store: failed to delete session(s):")
+      );
+      expect(req.session.destroy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/unit/config/cookie.test.ts
+++ b/test/unit/config/cookie.test.ts
@@ -4,81 +4,52 @@ import { getSessionCookieOptions } from "../../../src/config/cookie.js";
 describe("cookie config", () => {
   describe("getSessionCookieOptions", () => {
     it("should return cookie options with secure true in production environment", () => {
-      const isProdEnv = true;
-      const expiry = 3600000;
-      const secret = "test-secret"; //pragma: allowlist secret
-
-      const result = getSessionCookieOptions(isProdEnv, expiry, secret);
+      const result = getSessionCookieOptions(true);
 
       expect(result).toEqual({
-        name: "ams",
-        secret: "test-secret", //pragma: allowlist secret
-        maxAge: 3600000,
         secure: true,
       });
     });
 
     it("should return cookie options with secure false in non-production environment", () => {
-      const isProdEnv = false;
-      const expiry = 3600000;
-      const secret = "test-secret"; //pragma: allowlist secret
-
-      const result = getSessionCookieOptions(isProdEnv, expiry, secret);
+      const result = getSessionCookieOptions(false);
 
       expect(result).toEqual({
-        name: "ams",
-        secret: "test-secret", //pragma: allowlist secret
-        maxAge: 3600000,
         secure: false,
       });
     });
 
-    it("should handle different expiry values", () => {
-      const isProdEnv = true;
-      const expiry = 7200000;
-      const secret = "test-secret"; //pragma: allowlist secret
+    it("should not set maxAge when no maxAge is provided, so the cookie is session-scoped", () => {
+      const result = getSessionCookieOptions(true);
 
-      const result = getSessionCookieOptions(isProdEnv, expiry, secret);
-
-      expect(result.maxAge).toBe(7200000);
+      expect(result.maxAge).toBeUndefined();
     });
 
-    it("should handle different secret values", () => {
-      const isProdEnv = true;
-      const expiry = 3600000;
-      const secret = "different-secret-value"; //pragma: allowlist secret
+    it("should not set expires when no maxAge is provided, so the cookie is session-scoped", () => {
+      const result = getSessionCookieOptions(false);
 
-      const result = getSessionCookieOptions(isProdEnv, expiry, secret);
-
-      expect(result.secret).toBe("different-secret-value");
+      expect(result.expires).toBeUndefined();
     });
 
-    it("should always set cookie name to ams", () => {
-      const result1 = getSessionCookieOptions(true, 3600000, "secret1");
-      const result2 = getSessionCookieOptions(false, 7200000, "secret2");
+    it("should set maxAge when an explicit maxAge is provided", () => {
+      const result = getSessionCookieOptions(true, 3600000);
 
-      expect(result1.name).toBe("ams");
-      expect(result2.name).toBe("ams");
+      expect(result).toEqual({
+        secure: true,
+        maxAge: 3600000,
+      });
     });
 
-    it("should handle zero expiry", () => {
-      const isProdEnv = true;
-      const expiry = 0;
-      const secret = "test-secret"; //pragma: allowlist secret
-
-      const result = getSessionCookieOptions(isProdEnv, expiry, secret);
+    it("should set maxAge to 0 when an explicit maxAge of 0 is provided", () => {
+      const result = getSessionCookieOptions(true, 0);
 
       expect(result.maxAge).toBe(0);
     });
 
-    it("should handle empty secret string", () => {
-      const isProdEnv = true;
-      const expiry = 3600000;
-      const secret = ""; //pragma: allowlist secret
+    it("should not set maxAge when explicitly passed undefined", () => {
+      const result = getSessionCookieOptions(true, undefined);
 
-      const result = getSessionCookieOptions(isProdEnv, expiry, secret);
-
-      expect(result.secret).toBe("");
+      expect(result.maxAge).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Replace the unmaintained `connect-dynamodb` library with an express-session compatible class which wraps the create, update and delete operations. The items written to DynamoDB are the same format as `connect-dynamodb`, so this can be deployed with zero downtime.

This class adds a new feature over `connect-dynamodb` where we can now not provide a `maxAge` parameter in the cookie options and therefore get a browser-session scoped cookie which will be deleted when users close their browser tab or window. I've not used the feature yet - the cookie expiry is still passed through from the environment variable. We'll make that change in a future PR.

In the future we may want to reuse this code in other frontends. I've intentionally kept the new class with the generic operations separate from the application specific ones (which are still in `session-store.ts`) and passed all the config into the class' constructor. This'll make it easier to pull out later on.

### Why did it change

`connect-dynamodb` is unmaintained and doesn't support setting a cookie with no `maxAge` parameter.

### Related links

The [same implementation in AMC](https://github.com/govuk-one-login/account-components/blob/main/solutions/frontend/src/utils/dynamoDbSessionStore.ts).

## Checklists

<!-- Merging this PR is effectively deploying to production. Be mindful to answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->

I've deployed this to dev, tested it all behaves sensibly and looked at the items in DynamoDB before and after signing in. It'd be worth the reviewer doing the same. 